### PR TITLE
feat: parallel work unit execution with batch coordinator

### DIFF
--- a/commands/feature-complete.md
+++ b/commands/feature-complete.md
@@ -39,7 +39,7 @@ This is fine if:
   - The PR has already merged
   - You intentionally skipped stages (e.g. no refactor needed for small changes)
 
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ```
 Wait for explicit confirmation before continuing.
 
@@ -75,7 +75,7 @@ If any are untracked or have uncommitted changes:
 
 Archive them anyway? Their content will be lost from git history if you proceed
 without committing.
-  Type: continue  to archive anyway  ·  or: stop
+  Type **yes**  to archive anyway  ·  or: stop
 ```
 Wait for response.
 
@@ -125,6 +125,8 @@ ADRs and KB entries are permanent and remain in place.
 ## Step 5 — Archive the working directory
 
 Move `.feature/<slug>/` to `.feature/_archive/<slug>/`.
+(If `units/` subdirectory exists inside the slug directory, it moves with it
+automatically — no special handling needed.)
 
 `.feature/_archive/` is gitignored — the archive stays on the local machine
 as a short-term reference but does not go into the repository.

--- a/commands/feature-coordinate.md
+++ b/commands/feature-coordinate.md
@@ -1,0 +1,196 @@
+# /feature-coordinate "<feature-slug>"
+
+Parallel batch coordinator. Launches independent work units as parallel subagents,
+waits for completion, then launches the next batch. Only used when `execution_strategy`
+is `balanced` or `speed`.
+
+---
+
+## Step 0 — Pre-flight
+
+Read `.feature/<slug>/status.md`.
+
+- Verify `execution_strategy` is `balanced` or `speed`. If it is `cost` or `not-set`:
+  ```
+  🔀 COORDINATOR · <slug>
+  ───────────────────────────────────────────────
+  Execution strategy is '<strategy>' — parallel coordination not applicable.
+  Use /feature-test "<slug>" to start sequential execution.
+  ```
+  Stop.
+
+- Read `automation_mode` from status.md.
+
+Display opening header:
+```
+───────────────────────────────────────────────
+🔀 COORDINATOR · <slug>
+───────────────────────────────────────────────
+```
+
+---
+
+## Step 1 — Compute batch
+
+Read the Work Units table from status.md.
+
+Find all units where:
+- Status is `not-started` AND all `Depends On` units are `complete`
+
+**If none ready but some in-progress:**
+```
+🔀 COORDINATOR · <slug>
+───────────────────────────────────────────────
+Units are in progress — waiting for completion.
+Re-run /feature-coordinate "<slug>" when current batch finishes.
+```
+Stop.
+
+**If all units are `complete`:** skip to Step 4 (merge + finalize).
+
+Group ready units as the current batch. Update `<!-- current_batch: -->` in
+status.md.
+
+Display batch plan:
+```
+── Batch <n> ──────────────────────────────────
+Previously completed:
+  ✓ WU-<n>: <name>
+
+Launching now (parallel):
+  → WU-<n>: <name>
+  → WU-<n>: <name>
+
+Remaining:
+  ○ WU-<n>: <name> (blocked on <deps>)
+```
+
+---
+
+## Step 2 — Launch parallel subagents
+
+For each unit in the batch: invoke `/feature-test "<slug>" --unit WU-<n>` as a
+sub-agent.
+
+**All invocations in a single response** — Claude Code runs them in parallel.
+
+Each subagent runs the full test → implement → refactor cycle for its unit.
+Subagents always chain internally (autonomous within a unit — even in manual mode,
+the manual checkpoint is at the batch boundary, not within units).
+
+Wait for all subagents to return.
+
+---
+
+## Step 3 — Batch completion
+
+Read each unit's `units/WU-N/status.md` to check results.
+
+For each unit:
+- If refactor complete → mark `complete` in feature-level Work Units table in status.md
+
+If any unit hit an escalation:
+```
+── Batch <n> escalation ───────────────────────
+  WU-<n>: <escalation details from unit status>
+
+How would you like to proceed?
+  retry  — re-run the failed unit
+  skip   — mark as failed, continue with dependent units blocked
+  stop   — pause for manual intervention
+```
+Wait for user input.
+
+If all succeeded:
+```
+── Batch <n> complete ─────────────────────────
+  ✓ WU-<n>: <name> — <n> tests, <n> constructs
+  ✓ WU-<n>: <name> — <n> tests, <n> constructs
+```
+
+- If `automation_mode: autonomous`: loop back to Step 1 for next batch.
+- If `automation_mode: manual`:
+  ```
+  Next batch ready.
+    Type **yes**  ·  or: stop
+  ```
+  If "yes": loop back to Step 1.
+  If "stop": display `Next: /feature-coordinate "<slug>"` and stop.
+
+---
+
+## Step 4 — Merge and finalize
+
+All work units are complete.
+
+### 4a — Merge cycle logs
+
+Read each `units/WU-N/cycle-log.md`. Merge into feature-level `cycle-log.md`:
+- Interleave entries by timestamp
+- Prefix each entry header with `[WU-N]`
+- Example: `## <YYYY-MM-DD> — [WU-2] tests-written`
+
+### 4b — Run integration tests
+
+Run integration tests (equivalent to refactor Step 2f). In parallel mode,
+integration tests are deferred from individual refactor stages to here.
+
+Read project-config.md for the `Run integration tests` command.
+
+**If an integration test command is configured:**
+
+Run it. Three possible outcomes:
+
+1. **All pass** — note the result and continue.
+   ```
+   Integration tests: <n> passing ✓
+   ```
+
+2. **Some fail** — determine whether the failure is related to this feature:
+   - If YES: treat as a bug. Fix, re-run unit tests, re-run integration tests.
+     Append `integration-test-failure` to cycle-log.md.
+   - If NO: note as pre-existing. Append `integration-test-warning` to cycle-log.md.
+     Continue.
+
+3. **Cannot run** — note and continue.
+
+**If no integration test command is configured:** check for integration test
+directories. If found, note for manual check. If not found, skip silently.
+
+### 4c — Update feature-level status
+
+Update feature-level status.md:
+- All units marked `complete` in Work Units table
+- Stage → `refactor`, substage → `refactor complete`
+
+### 4d — Hand off
+
+Display:
+```
+───────────────────────────────────────────────
+🔀 COORDINATOR complete · <slug>
+───────────────────────────────────────────────
+All <n> work units complete.
+Integration tests: <result>
+Merged cycle log: .feature/<slug>/cycle-log.md
+```
+
+- If `automation_mode: autonomous`: invoke `/feature-pr "<slug>"` immediately.
+- If `automation_mode: manual`:
+  ```
+  Feature is ready for PR.
+    Type **yes**  ·  or: stop
+  ```
+  If "yes": invoke `/feature-pr "<slug>"`.
+  If "stop": display `Next: /feature-pr "<slug>"` and stop.
+
+---
+
+## Write authority
+
+The coordinator writes to:
+- `.feature/<slug>/status.md` — Work Units table (unit status), batch tracking comments
+- `.feature/<slug>/cycle-log.md` — merged log from per-unit logs
+
+The coordinator does NOT write to per-unit files (`units/WU-N/`). Those are owned
+by the TDD subagents.

--- a/commands/feature-implement.md
+++ b/commands/feature-implement.md
@@ -22,6 +22,23 @@ If work units are defined:
 
 Update the active unit status → `in-progress` in the Work Units table.
 
+### Per-unit path resolution (parallel mode)
+
+If `execution_strategy` is `balanced` or `speed` in feature-level status.md:
+```
+unit_status = .feature/<slug>/units/WU-<n>/status.md
+unit_log = .feature/<slug>/units/WU-<n>/cycle-log.md
+```
+Else:
+```
+unit_status = .feature/<slug>/status.md
+unit_log = .feature/<slug>/cycle-log.md
+```
+
+All status.md reads/writes for stage, substage, cycle tracker → use `unit_status`.
+All cycle-log.md appends → use `unit_log`.
+Feature-level status.md Work Units table → still update unit status there too.
+
 Display opening header:
 ```
 ───────────────────────────────────────────────
@@ -41,15 +58,29 @@ The Test Writer has resolved a contract conflict. Resume implementation.
 - Jump to Step 2 (implement in order, skipping constructs whose tests already pass)
 
 **If Implementation for this cycle is `complete`:**
+
+Read `automation_mode` from status.md.
+
+**If `automation_mode: autonomous`:**
+```
+⚙️  CODE WRITER · <slug> · Cycle <n>
+───────────────────────────────────────────────
+Implementation is already complete for cycle <n>.
+Starting refactor  ·  type stop to pause
+───────────────────────────────────────────────
+```
+Invoke /feature-refactor "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
+
+**If `automation_mode: manual` (or not set):**
 ```
 ⚙️  CODE WRITER · <slug> · Cycle <n>
 ───────────────────────────────────────────────
 Implementation is already complete for cycle <n>.
 All tests were passing as of: <date from status.md>
 
-  Type: continue  to proceed to refactor  ·  or: stop
+  Type **yes**  to proceed to refactor  ·  or: stop
 ```
-If "continue": invoke /feature-refactor "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
+If "yes": invoke /feature-refactor "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
 If "stop": display `Next: /feature-refactor "<slug>"` and stop.
 
 **If Implementation is `in-progress`:**
@@ -223,6 +254,10 @@ If work units are defined:
 - Mark the active unit as `complete` in the Work Units table in status.md
 - Check if any blocked units are now unblocked (all their deps are complete)
   → update those units from `blocked` → `not-started`
+- **Parallel mode (`execution_strategy` is `balanced` or `speed`):** mark unit
+  complete in feature-level Work Units table and unblock dependent units, but do
+  NOT invoke the next unit — the coordinator handles unit sequencing. Chain to
+  `/feature-refactor` for the current unit as normal.
 
 Update `.feature/CLAUDE.md`.
 
@@ -273,11 +308,11 @@ Work unit progress:
   ○ WU-3: <n> — blocked (waiting on WU-2)
 
 ───────────────────────────────────────────────
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ───────────────────────────────────────────────
 ```
 
-If "continue": invoke `/feature-refactor "<slug>"<  --unit WU-<n>>` as a sub-agent.
+If "yes": invoke `/feature-refactor "<slug>"<  --unit WU-<n>>` as a sub-agent.
 If "stop":
 ```
 When you're ready:

--- a/commands/feature-plan.md
+++ b/commands/feature-plan.md
@@ -24,9 +24,9 @@ Otherwise:
 Work planning is already complete for '<slug>'.
 Work plan: .feature/<slug>/work-plan.md
 
-  Type: continue  to proceed to test writing  ·  or: stop
+  Type **yes**  to proceed to test writing  ·  or: stop
 ```
-If "continue": invoke /feature-test "<slug>" as a sub-agent immediately.
+If "yes": invoke /feature-test "<slug>" as a sub-agent immediately.
 If "stop": display `Next: /feature-test "<slug>"` and stop.
 
 **If Planning stage is `in-progress`:**
@@ -87,7 +87,7 @@ New constructs to CREATE:
 
 Display:
 ```
-  Type: continue  ·  or: describe corrections
+  Type **yes**  ·  or: describe corrections
 ```
 Wait for the user to type "continue" or describe corrections. Update status.md substage → `confirmed-design`
 after confirmation.
@@ -172,12 +172,89 @@ Estimated savings: ~<N>K per session vs ~<N>K single unit
 
   WU-3: <name>  (depends on WU-1 + WU-2)  [if applicable]
         ...
-
-  Type: split  ·  or: single
 ```
 
-If "single": record `work_units: none` in status.md, proceed to Step 3.
-If "split" (or no split was proposed): proceed with unit structure.
+### Execution strategy prompt
+
+After the work unit analysis display, determine the execution strategy.
+
+**If feature doesn't qualify for splitting** (1–3 constructs, no boundaries):
+set `execution_strategy: cost` implicitly in status.md, skip the prompt.
+
+**If feature qualifies for splitting**, show the analysis then ask:
+
+```
+── Execution strategy ─────────────────────────────
+  cost      — sequential execution. Splits only when a single session
+              exceeds ~15K tokens.
+
+  balanced  — split at clean boundaries, independent units run in parallel.
+              Moderate token overhead.
+
+  speed     — split at every clean boundary, maximum parallelism.
+              Fastest completion, highest token cost.
+
+Type: cost, balanced, or speed
+```
+
+Record `execution_strategy: <choice>` in status.md and in the
+`<!-- execution_strategy: -->` comment under `## Work Units`.
+
+**Strategy behaviour:**
+
+- `cost`: use current split thresholds (>15K). If under threshold, `work_units: none`.
+  If over, split but units run sequentially. No per-unit dirs.
+- `balanced`: lower threshold to >8K OR 2+ independent groups. Split and create
+  per-unit dirs (see below).
+- `speed`: split at every clean boundary (still never split 1–3 total constructs).
+  Create per-unit dirs.
+
+**If "cost" and under threshold:** record `work_units: none` in status.md, proceed to Step 3.
+**If "cost" and over threshold:** proceed with unit structure (sequential execution).
+**If "balanced" or "speed":** proceed with unit structure and parallel setup.
+
+### Dependency graph (balanced/speed only)
+
+After the Work Units table is confirmed, display:
+```
+── Dependency graph ───────────────────────────
+  Batch 1: WU-1, WU-2  (parallel — no mutual deps)
+  Batch 2: WU-3         (depends on WU-1)
+
+  Critical path: <n> sequential batches
+  Estimated time: ~<n> sessions (vs ~<n> sequential)
+```
+
+### Per-unit directory creation (balanced/speed only)
+
+Create `.feature/<slug>/units/WU-N/` for each unit with:
+
+Per-unit `status.md`:
+```markdown
+---
+feature: "<slug>"
+unit: "WU-<n>"
+unit_name: "<name>"
+---
+
+## Current Position
+**Stage:** not-started
+**Substage:** —
+**Last successful checkpoint:** unit directory created
+**Cycle:** 0
+
+## TDD Cycle Tracker
+| Cycle | Tests written | Tests passing | Refactor done | Missing tests |
+```
+
+Per-unit `cycle-log.md`:
+```markdown
+# Cycle Log — <slug> / WU-<n>
+<!-- Append-only. Each agent appends entries. -->
+---
+```
+
+### Write Work Units table
 
 After confirmation, write the Work Units table to status.md:
 ```markdown
@@ -281,6 +358,21 @@ and changing them later requires re-running tests.
 Ask the user how they want to run the TDD loop. This choice is recorded now and
 persists for the lifetime of this feature — it will not be asked again.
 
+**When `execution_strategy` is `balanced` or `speed`:**
+
+Display:
+```
+── How would you like to run the TDD loop? ─────
+  autonomous  — independent units run their full test → implement → refactor
+               cycles in parallel. Checkpoints happen at batch boundaries.
+
+  manual      — I'll pause between batches and wait for your go-ahead.
+
+Type: autonomous  or  manual
+```
+
+**When `execution_strategy` is `cost` (or not set):**
+
 Display:
 ```
 ── How would you like to run the TDD loop? ─────
@@ -308,7 +400,19 @@ Manual mode. I'll prompt you at each stage boundary.
 ──────────────────────────────────────────────────
 ```
 
-### Step 5b — Start test writing
+### Step 5b — Start test writing or coordinator
+
+**If `execution_strategy` is `balanced` or `speed`:**
+
+```
+───────────────────────────────────────────────
+Launching parallel coordinator.
+Run /feature-resume "<slug>" at any point to see batch status.
+───────────────────────────────────────────────
+```
+Invoke `/feature-coordinate "<slug>"` as a sub-agent immediately.
+
+**If `execution_strategy` is `cost` (or not set):**
 
 If work units are defined:
 ```

--- a/commands/feature-pr.md
+++ b/commands/feature-pr.md
@@ -27,10 +27,10 @@ If a previous PR draft exists in `.feature/<slug>/pr-draft.md`:
 A PR draft already exists for '<slug>'.
 Draft: .feature/<slug>/pr-draft.md
 
-  Type: continue  to proceed to PR creation  ·  or: regenerate
+  Type **yes**  to proceed to PR creation  ·  or: regenerate
 ```
 If "regenerate": proceed to regenerate the draft.
-If "continue": skip to Step 5 — PR creation (attempt to create the PR from the existing draft).
+If "yes": skip to Step 5 — PR creation (attempt to create the PR from the existing draft).
 
 ---
 
@@ -55,6 +55,8 @@ Read in order:
    OR the Description field from status.md (quick task)
 3. `.feature/<slug>/work-plan.md` if it exists
 4. `.feature/<slug>/cycle-log.md` — full history
+   (If `units/` directory exists, the coordinator has already merged per-unit
+   logs into the feature-level cycle-log.md — read that merged log.)
 5. `.feature/<slug>/domains.md` if it exists — for ADR links
 
 Do NOT read implementation or test files — the PR description should describe
@@ -84,6 +86,13 @@ who has not seen the feature work. No implementation details.>
 ## Changes
 <Bullet list of the meaningful changes — constructs added, behaviour changed,
 files modified. One line each. Sourced from work-plan.md and cycle-log.md.>
+
+<If units/ directory exists (parallel feature), group changes by work unit:>
+### WU-1: <name>
+- <changes from WU-1 cycle-log entries>
+
+### WU-2: <name>
+- <changes from WU-2 cycle-log entries>
 
 ## Tests
 <How the change is tested. Number of tests written, what they cover at a high

--- a/commands/feature-refactor.md
+++ b/commands/feature-refactor.md
@@ -24,6 +24,23 @@ If work units are defined:
   refactored (all other units are `complete`). Skip 2f for intermediate units
   and note: "Integration tests deferred — not the final work unit."
 
+### Per-unit path resolution (parallel mode)
+
+If `execution_strategy` is `balanced` or `speed` in feature-level status.md:
+```
+unit_status = .feature/<slug>/units/WU-<n>/status.md
+unit_log = .feature/<slug>/units/WU-<n>/cycle-log.md
+```
+Else:
+```
+unit_status = .feature/<slug>/status.md
+unit_log = .feature/<slug>/cycle-log.md
+```
+
+All status.md reads/writes for stage, substage, cycle tracker → use `unit_status`.
+All cycle-log.md appends → use `unit_log`.
+Feature-level status.md Work Units table → still update unit status there too.
+
 Display opening header with unit if applicable:
 ```
 ───────────────────────────────────────────────
@@ -146,9 +163,9 @@ This issue may affect other units or require interface changes:
 
   <description of issue and why it can't be self-contained>
 
-  Type: continue  ·  or: stop  to review before continuing
+  Type **yes**  ·  or: stop  to review before continuing
 ```
-Wait for input. If "continue": continue the refactor and resume chaining if autonomous.
+Wait for input. If "yes": continue the refactor and resume chaining if autonomous.
 If "stop": complete the current checklist item, write the log entry, then stop.
 
 ### 2e — Missing tests
@@ -167,6 +184,9 @@ If missing tests are found → see Step 3 (escalate, do not continue).
 ### 2f — Integration tests
 `status.md substage → "refactor: integration-tests"`
 `Display: ── Integration tests ───────────────────────`
+
+**Parallel mode (`execution_strategy` is `balanced` or `speed`):** skip 2f entirely.
+Display: "Integration tests deferred to coordinator." Continue to Step 4.
 
 Only run this step if all unit tests are passing and no missing-test escalation
 was triggered in 2e.
@@ -330,7 +350,22 @@ Read `automation_mode` from status.md.
 **Token tracking:** run `bash -c 'source .claude/scripts/token-usage.sh && token_summary ".feature/<slug>" "refactor"'`
 and capture the output as TOKEN_USAGE.
 
-**If more work units remain (not the final unit):**
+**If `execution_strategy` is `balanced` or `speed` (parallel mode):**
+
+Mark unit complete in per-unit `unit_status`.
+Mark unit complete in feature-level Work Units table.
+Do NOT chain to next unit or PR — the coordinator handles that.
+
+```
+───────────────────────────────────────────────
+✨ REFACTOR AGENT complete · <slug> · WU-<n>
+  Tokens : <TOKEN_USAGE>
+───────────────────────────────────────────────
+Unit complete. Returning to coordinator.
+```
+STOP. (Coordinator launched this as subagent; returning is sufficient.)
+
+**If more work units remain (not the final unit) — sequential/cost mode only:**
 
 — Autonomous:
 ```
@@ -350,12 +385,12 @@ Invoke `/feature-test "<slug>" --unit WU-<next>` immediately.
 ───────────────────────────────────────────────
 ✨ REFACTOR AGENT complete · <slug> · Cycle <n> · WU-<n>
 ───────────────────────────────────────────────
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ```
-If "continue": invoke `/feature-test "<slug>" --unit WU-<next>`.
+If "yes": invoke `/feature-test "<slug>" --unit WU-<next>`.
 If "stop": display the manual command and stop.
 
-**If this is the final (or only) unit and refactor is clean:**
+**If this is the final (or only) unit and refactor is clean — sequential/cost mode only:**
 
 — Autonomous:
 ```
@@ -376,9 +411,9 @@ Invoke `/feature-pr "<slug>"` immediately.
 Refactor cycle <n> complete. <n> tests passing.
 Feature is ready for review.
 
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ```
-If "continue": invoke `/feature-pr "<slug>"`.
+If "yes": invoke `/feature-pr "<slug>"`.
 If "stop": display manual commands and stop.
 
 **If missing tests escalation triggered (either mode):**
@@ -390,8 +425,8 @@ If "stop": display manual commands and stop.
 Missing tests found — handing to Test Writer.
 <If autonomous:> Pausing — missing tests require your review.
 
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ```
 Wait for input regardless of automation_mode — missing tests are always a
-human checkpoint. If Enter: invoke `/feature-test "<slug>" --add-missing`.
+human checkpoint. If "yes": invoke `/feature-test "<slug>" --add-missing`.
 If "stop": display the manual sequence and stop.

--- a/commands/feature-resume.md
+++ b/commands/feature-resume.md
@@ -74,6 +74,8 @@ Substage:   <substage>
 Last checkpoint: <last successful checkpoint>
 Last updated:    <timestamp>
 Automation: <autonomous | manual | not-set (will ask on next /feature-implement)>
+<If execution_strategy is balanced or speed:>
+EXECUTION: parallel (<balanced|speed>)
 
 STAGE PROGRESS
   ✓ Scoping        complete    <date>
@@ -112,7 +114,23 @@ If work units are defined, determine the precise next command:
 3. If all units are `complete` → feature is ready for `/feature-pr`
 4. If a unit is `blocked` → its dependencies need to complete first
 
-Display the work unit table as part of the resume output:
+**If `execution_strategy` is `balanced` or `speed`:** read per-unit
+`units/WU-N/status.md` for each unit's current stage/substage and display
+with batch grouping:
+
+```
+Work units:
+  Batch 1 (complete):
+    ✓ WU-1: <name>
+  Batch 2 (in-progress):
+    ↻ WU-2: <name> — implementing (cycle 1)
+    ↻ WU-3: <name> — testing (cycle 1)
+  Batch 3 (waiting):
+    ○ WU-4: <name> — blocked (waiting on WU-2, WU-3)
+```
+
+**Otherwise (sequential/cost mode):** display the work unit table as part of the
+resume output:
 ```
 Work units:
   ✓ WU-1: <n> — complete
@@ -120,9 +138,11 @@ Work units:
   ○ WU-3: <n> — blocked (waiting on WU-2)
 ```
 
-The "Next command" line must include the `--unit` flag:
+The "Next command" line must include the `--unit` flag (sequential mode) or
+use the coordinator (parallel mode):
 ```
-Next: /feature-implement "<slug>" --unit WU-2
+<sequential:> Next: /feature-implement "<slug>" --unit WU-2
+<parallel:>   Next: /feature-coordinate "<slug>"
 ```
 
 ## Step 3 — Determine and display what to run next
@@ -168,6 +188,10 @@ NEXT STEP
 - If the next step resolves to `/feature-plan` (stage is `domains/complete` or
   `planning/in-progress`): invoke `/feature-plan "<slug>"` as a sub-agent
   immediately. Planning requires no external action to proceed.
+
+- If `automation_mode: autonomous` AND `execution_strategy` is `balanced` or
+  `speed` AND work units remain incomplete: invoke `/feature-coordinate "<slug>"`
+  as a sub-agent immediately.
 
 - If `automation_mode: autonomous` AND the next step resolves to
   `/feature-implement` or `/feature-refactor` (stages `testing/complete`,

--- a/commands/feature-test.md
+++ b/commands/feature-test.md
@@ -36,6 +36,23 @@ If work units are defined:
 
 Update the Work Units table in status.md: active unit → `in-progress`.
 
+### Per-unit path resolution (parallel mode)
+
+If `execution_strategy` is `balanced` or `speed` in feature-level status.md:
+```
+unit_status = .feature/<slug>/units/WU-<n>/status.md
+unit_log = .feature/<slug>/units/WU-<n>/cycle-log.md
+```
+Else:
+```
+unit_status = .feature/<slug>/status.md
+unit_log = .feature/<slug>/cycle-log.md
+```
+
+All status.md reads/writes for stage, substage, cycle tracker → use `unit_status`.
+All cycle-log.md appends → use `unit_log`.
+Feature-level status.md Work Units table → still update unit status there too.
+
 Display opening header with unit if applicable:
 ```
 ───────────────────────────────────────────────
@@ -84,6 +101,20 @@ Re-run implementation:
 Stop.
 
 If Testing status for the current cycle is `complete` (for this unit if --unit provided):
+
+Read `automation_mode` from status.md.
+
+**If `automation_mode: autonomous`:**
+```
+🧪 TEST WRITER · <slug>
+───────────────────────────────────────────────
+Tests are already written for cycle <n><  · WU-<n>>.
+Starting implementation  ·  type stop to pause
+───────────────────────────────────────────────
+```
+Invoke /feature-implement "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
+
+**If `automation_mode: manual` (or not set):**
 ```
 🧪 TEST WRITER · <slug>
 ───────────────────────────────────────────────
@@ -91,9 +122,9 @@ Tests are already written for cycle <n><  · WU-<n>>.
 Test plan: .feature/<slug>/test-plan.md
 All tests verified failing.
 
-  Type: continue  to proceed to implementation  ·  or: stop
+  Type **yes**  to proceed to implementation  ·  or: stop
 ```
-If "continue": invoke /feature-implement "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
+If "yes": invoke /feature-implement "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
 If "stop": display `Next: /feature-implement "<slug>"` and stop.
 
 If Testing is `in-progress`:
@@ -361,8 +392,29 @@ Update `.feature/CLAUDE.md`.
 
 ## Step 6 — Hand off
 
+Read `automation_mode` from status.md.
+
 **Token tracking:** run `bash -c 'source .claude/scripts/token-usage.sh && token_summary ".feature/<slug>" "testing"'`
 and capture the output as TOKEN_USAGE.
+
+**If `automation_mode: autonomous`:**
+
+Display the summary then chain immediately without prompting:
+```
+───────────────────────────────────────────────
+🧪 TEST WRITER complete · <slug> · Cycle <n><  · WU-<n>>
+  Tokens : <TOKEN_USAGE>
+───────────────────────────────────────────────
+Tests written and verified failing. Cycle <n><  · WU-<n>>.
+
+Starting implementation  ·  type stop to pause
+───────────────────────────────────────────────
+```
+
+Then invoke `/feature-implement "<slug>"<  --unit WU-<n>>` as a sub-agent
+immediately. Do not wait for user input.
+
+**If `automation_mode: manual` (or not set):**
 
 Display:
 ```
@@ -373,11 +425,11 @@ Display:
 Tests written and verified failing. Cycle <n><  · WU-<n>>.
 
 ───────────────────────────────────────────────
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ───────────────────────────────────────────────
 ```
 
-If "continue": invoke /feature-implement "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
+If "yes": invoke /feature-implement "<slug>"<  --unit WU-<n>> as a sub-agent immediately.
 If "stop":
 ```
 When you're ready:

--- a/commands/feature.md
+++ b/commands/feature.md
@@ -17,9 +17,9 @@ brief.md, and initialises status.md as the restart checkpoint.
      Scoping is already complete for '<slug>'.
      Brief: .feature/<slug>/brief.md
 
-       Type: continue  to proceed to domain analysis  ·  or: stop
+       Type **yes**  to proceed to domain analysis  ·  or: stop
      ```
-     If "continue": invoke /feature-domains "<slug>" as a sub-agent immediately.
+     If "yes": invoke /feature-domains "<slug>" as a sub-agent immediately.
      If "stop": display `Next: /feature-domains "<slug>"` and stop.
      Stop if the user says "redo" or "update brief" — proceed with re-scoping.
    - If stage is `scoping` and substage is `in-progress`:
@@ -246,11 +246,11 @@ If "skip": continue without creating a branch.
 
 ```
 ───────────────────────────────────────────────
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ───────────────────────────────────────────────
 ```
 
-If "continue": invoke /feature-domains "<slug>" as a sub-agent immediately.
+If "yes": invoke /feature-domains "<slug>" as a sub-agent immediately.
 If "stop":
 ```
 When you're ready:
@@ -277,6 +277,7 @@ last_updated: "<YYYY-MM-DD HH:MM>"
 **Substage:** interviewing
 **Last successful checkpoint:** feature directory created
 **Automation mode:** not-set
+**Execution strategy:** not-set
 
 ## Stage Completion
 
@@ -298,6 +299,8 @@ last_updated: "<YYYY-MM-DD HH:MM>"
 ## Work Units
 <!-- Populated by /feature-plan if feature is split into units -->
 <!-- work_units: none  ← set this if no split was done -->
+<!-- execution_strategy: not-set -->
+<!-- current_batch: 0 -->
 
 | Unit | Name | Constructs | Depends On | Status | Cycle |
 |------|------|------------|------------|--------|-------|

--- a/rules/tdd-protocol.md
+++ b/rules/tdd-protocol.md
@@ -7,9 +7,14 @@ its designated files. No agent may skip a stage or act outside its write authori
   /quick "<description>"   — small changes: test → implement → refactor, minimal setup
   /feature "<description>" — full pipeline for new functionality with design decisions
 
-## Full pipeline order
+## Full pipeline order (sequential / cost mode)
   /feature → /feature-domains → /feature-plan → /feature-test →
   /feature-implement → /feature-refactor → /feature-pr → /feature-complete
+
+## Parallel pipeline (balanced/speed mode)
+  /feature → /feature-domains → /feature-plan → /feature-coordinate
+  (coordinator launches batches of: /feature-test → /feature-implement → /feature-refactor)
+  → /feature-pr → /feature-complete
 
 ## Utility commands (any time)
   /feature-resume "<slug>"  — where am I, what do I run next
@@ -34,9 +39,15 @@ No command re-does completed work without explicit user confirmation.
   Scoping Agent      → .feature/<slug>/brief.md
   Domain Scout       → .feature/<slug>/domains.md
   Work Planner       → .feature/<slug>/work-plan.md + stub files in src/
+  Coordinator        → .feature/<slug>/status.md (batch tracking, unit status)
+                       .feature/<slug>/cycle-log.md (merged log)
+  All TDD agents     → .feature/<slug>/units/WU-N/status.md (parallel mode)
   Test Writer        → test files + .feature/<slug>/cycle-log.md (test entries)
+                       .feature/<slug>/units/WU-N/cycle-log.md (parallel: test entries)
   Code Writer        → implementation files + .feature/<slug>/cycle-log.md (code entries)
+                       .feature/<slug>/units/WU-N/cycle-log.md (parallel: code entries)
   Refactor Agent     → implementation files + .feature/<slug>/cycle-log.md (refactor entries)
+                       .feature/<slug>/units/WU-N/cycle-log.md (parallel: refactor entries)
   PR command         → .feature/<slug>/pr-draft.md
 
 ## Shared read


### PR DESCRIPTION
## Summary
- Adds a 3-way execution strategy prompt (cost/balanced/speed) to `/feature-plan` so users can choose between token efficiency, moderate parallelism, or maximum speed
- Introduces per-unit file isolation (`units/WU-N/status.md` and `cycle-log.md`) to eliminate shared mutable state between parallel subagents
- New `/feature-coordinate` command that groups independent units into batches, launches them as parallel subagents, and manages batch-to-batch progression

## Changes
- **feature.md**: `execution_strategy` and batch metadata added to status template
- **feature-plan.md**: Strategy prompt replaces split confirmation; dependency graph display; per-unit directory creation for balanced/speed modes
- **feature-coordinate.md**: New batch coordinator — computes batches from dependency graph, launches parallel subagents, merges cycle logs, runs deferred integration tests
- **feature-test/implement/refactor.md**: Per-unit path resolution so TDD agents read/write unit-scoped files in parallel mode
- **feature-refactor.md**: Skips integration tests in parallel mode (deferred to coordinator); returns to coordinator instead of chaining to next unit
- **feature-resume.md**: Parallel-aware display with batch grouping; auto-invokes coordinator in autonomous mode
- **feature-pr.md**: Groups changes by work unit in PR description
- **feature-complete.md**: Notes that `units/` moves with slug dir during archive
- **tdd-protocol.md**: Parallel pipeline order and expanded write authority for coordinator + per-unit files

## Test plan
- [ ] Run `/feature` on a project with 6+ constructs, choose `balanced`, confirm per-unit dirs created and coordinator launches parallel subagents
- [ ] Verify `cost` mode is identical to current behavior (no per-unit dirs, sequential execution)
- [ ] Verify `feature-resume` correctly reads per-unit statuses and suggests `/feature-coordinate`
- [ ] Verify coordinator merges cycle logs and runs integration tests after all units complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)