### PR TITLE
fix: standardize prompt language across commands

### DIFF
--- a/commands/feature-domains.md
+++ b/commands/feature-domains.md
@@ -16,9 +16,9 @@ Read `.feature/<slug>/status.md`.
 Domain analysis is already complete for '<slug>'.
 Domains: .feature/<slug>/domains.md
 
-  Type: continue  to proceed to work planning  ·  or: stop
+  Type **yes**  to proceed to work planning  ·  or: stop
 ```
-If "continue": invoke /feature-plan "<slug>" as a sub-agent immediately.
+If "yes": invoke /feature-plan "<slug>" as a sub-agent immediately.
 If "stop": display `Next: /feature-plan "<slug>"` and stop.
 
 **If Domains stage is `in-progress`:**
@@ -188,11 +188,11 @@ Review the domain analysis above — the Work Planner will build the implementat
 structure from these constraints and ADRs.
 
 ───────────────────────────────────────────────
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ───────────────────────────────────────────────
 ```
 
-If "continue": invoke /feature-plan "<slug>" as a sub-agent immediately.
+If "yes": invoke /feature-plan "<slug>" as a sub-agent immediately.
 If "stop":
 ```
 When you're ready:

--- a/commands/feature-init.md
+++ b/commands/feature-init.md
@@ -114,9 +114,9 @@ If the user leaves it blank or says "none": record `branch_naming: none`.
 
 Display:
 ```
-  Type: continue  to save  ·  or: describe corrections
+  Type **yes**  to save  ·  or: describe corrections
 ```
-If "continue": save. If the user types corrections: apply them and confirm again.
+If "yes": save. If the user types corrections: apply them and confirm again.
 Do not re-ask about fields the user confirmed or did not mention.
 
 ---

--- a/commands/kb.md
+++ b/commands/kb.md
@@ -150,14 +150,14 @@ KB currently contains:
   <n> topics: <list from CLAUDE.md Topic Map>
 
 I can research this now and add it to the KB.
-  Type: continue  to start research  ·  or: stop
+  Type **yes**  to start research  ·  or: stop
 ```
 
 When stale entries were found:
 ```
 Some entries used to answer this question may be outdated.
 I can refresh the research and update the KB.
-  Type: continue  to refresh stale entries  ·  or: skip  to use current data as-is
+  Type **yes**  to refresh stale entries  ·  or: skip  to use current data as-is
 ```
 
 When gaps were identified alongside valid results:
@@ -167,7 +167,7 @@ improve the answer:
   <gap description>
 
 I can research the gaps now and update the KB.
-  Type: continue  to research gaps  ·  or: skip
+  Type **yes**  to research gaps  ·  or: skip
 ```
 
 **If the user chooses to research:**
@@ -259,7 +259,7 @@ Description : <description>
 Path        : .kb/<name>/
 Existing topics: <list or "none yet">
 
-  Type: continue  to create  ·  or: stop
+  Type **yes**  to create  ·  or: stop
 ```
 
 **Step 3 — Create**

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -101,11 +101,11 @@ Options:
   1. Continue as /quick — I'll keep it tight and flag scope creep if I find it
   2. Switch to /feature — run /feature "<description>" for the full pipeline
 
-  Type: continue  to stay as /quick  ·  or: feature
+  Type **yes**  to stay as /quick  ·  or: feature
 ───────────────────────────────────────────────
 ```
 
-If "continue": continue as /quick, note the signals in status.md and proceed with
+If "yes": continue as /quick, note the signals in status.md and proceed with
 heightened scope vigilance (see Step 3).
 
 **4+ signals:** Hard redirect. The description is clearly feature-scale:
@@ -279,7 +279,7 @@ Display:
 Tests I'll write:
   1. test_<n> — <scenario>
   2. test_<n> — <scenario>
-  Type: continue  ·  or: describe changes
+  Type **yes**  ·  or: describe changes
 ```
 Write on "continue" or immediately if the user provides changes.
 
@@ -293,10 +293,10 @@ Display:
 <n> tests written and verified failing.
 
 ───────────────────────────────────────────────
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ───────────────────────────────────────────────
 ```
-If "continue": proceed to Step 5.
+If "yes": proceed to Step 5.
 
 ---
 
@@ -318,10 +318,10 @@ Display:
 All tests passing.
 
 ───────────────────────────────────────────────
-  Type: continue  ·  or: stop
+  Type **yes**  ·  or: stop
 ───────────────────────────────────────────────
 ```
-If "continue": proceed to Step 6.
+If "yes": proceed to Step 6.
 
 ---
 
@@ -370,4 +370,4 @@ Note: this touched <area> which may be worth a full /feature pass later.
 ```
 
 If the user types pr: invoke /feature-pr "<quick-slug>" as a sub-agent immediately.
-If Enter or stop: stop.
+If "stop": stop.

--- a/commands/research.md
+++ b/commands/research.md
@@ -65,10 +65,10 @@ After the user responds: echo confirmed values, then proceed.
 Existing topics: <list from .kb/CLAUDE.md Topic Map>
 
 To add it: /kb topic "<topic>" "<one-line description>"
-  Type: continue  to create the topic now  ·  or: manual
+  Type **yes**  to create the topic now  ·  or: manual
 ```
 
-   If "continue": invoke `/kb topic "<topic>" "<description>"` as a sub-agent,
+   If "yes": invoke `/kb topic "<topic>" "<description>"` as a sub-agent,
    wait for it to complete, then proceed with the research session.
    If "manual": stop and let the user run it manually.
 
@@ -107,7 +107,7 @@ Report to user:
 
 If category already has content, display:
 ```
-  Type: continue  to proceed anyway  ·  or: stop
+  Type **yes**  to proceed anyway  ·  or: stop
 ```
 
 ---

--- a/commands/upgrade-vallorcine.md
+++ b/commands/upgrade-vallorcine.md
@@ -110,7 +110,7 @@ Preserved (never touched):
   .kb/CLAUDE.md        if you have added topics
   .decisions/CLAUDE.md if you have added decisions
 
-  Type: continue  to apply upgrade  ·  or: stop
+  Type **yes**  to apply upgrade  ·  or: stop
 ```
 
 Wait. If "stop": exit cleanly with "Upgrade cancelled. No changes made."


### PR DESCRIPTION
## Summary
- Replaces inconsistent `Type: continue` prompts with `Type **yes**` across 6 command files
- Aligns with the convention already used in feature.md, feature-plan.md, and feature-test.md

## Test plan
- [ ] Verify prompts display correctly when running affected commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)