### PR TITLE
feat: architecture hardening — principle 1, security review, ADR validation

### DIFF
--- a/.claude/commands/ideate.md
+++ b/.claude/commands/ideate.md
@@ -26,7 +26,7 @@ Read these files in order:
    have crashed or been interrupted. If present and non-empty, this takes
    priority: the session goal should incorporate finishing or continuing this work
    unless the user's goal explicitly overrides it.
-2. **DESIGN.md** — system architecture and the 9 core principles
+2. **DESIGN.md** — system architecture and the 10 core principles
 3. **CONTEXT.md** — focus on: Current focus, Recent decisions, Open questions.
    CONTEXT.md is the active working state only. Settled design history lives in
    SETTLED.md and competitive landscape in COMPETITIVE.md — do not read those

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@ Initial release. Two subsystems: TDD Pipeline and KB/Decisions.
 - `/feature-plan` — work planner with token-based work unit split analysis
 - `/feature-test` — test writer agent, TDD cycle management
 - `/feature-implement` — code writer agent
-- `/feature-refactor` — refactor agent with 6-category checklist
+- `/feature-refactor` — refactor agent with 8-category checklist (2a-2h)
 - `/feature-pr` — PR draft generator
 - `/feature-complete` — archive and cleanup
 - `/feature-resume` — crash recovery from status.md checkpoint

--- a/COMPETITIVE.md
+++ b/COMPETITIVE.md
@@ -54,11 +54,7 @@ blunt context loading, no ADR concept. Passive and unstructured.
 
 ## Confirmed gaps vs ecosystem
 
-- Hooks integration
-- LSP awareness
-- /decisions list/filter command
-- Coverage gating
-- Live docs in domain analysis
+- LSP awareness (recommended as companion, not bundled — principle 1)
 
 ---
 
@@ -68,4 +64,20 @@ blunt context loading, no ADR concept. Passive and unstructured.
 cost. Our KB approach is more persistent.
 
 **Autonomous looping** — Ralph Wiggum pattern, explicitly against design
-principle 8.
+principle 9.
+
+**Hooks-based TDD enforcement** — TDD Guard and Superpowers use Claude Code hooks
+to block file modifications. Requires platform-specific hooks infrastructure —
+violates principle 1. Rules-based enforcement is reliable enough in practice.
+
+**Coverage gating** — requires language-specific coverage tools. Violates
+principle 1. Step 2e (missing test heuristic) is the language-agnostic proxy.
+
+**Context7 / live docs** — requires MCP server. Violates principle 1.
+
+## Closed gaps (previously listed)
+
+- ~~/decisions list/filter~~ — shipped v0.2.4
+- ~~Hooks integration~~ — dropped, violates principle 1
+- ~~Coverage gating~~ — dropped, violates principle 1
+- ~~Live docs in domain analysis~~ — dropped, violates principle 1

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,17 @@ Active testing on jlsm project. WIP.md cleared.
   verifies project documentation stays current when features change modules, APIs,
   or patterns. Added after 2f (integration tests).
 
+- **Principle 1: bash and markdown only** (2026-03-16) — hard constraint, not
+  preference. No MCP servers, no hooks infrastructure, no package managers, no
+  external runtimes. First filter for new features. Dropped hooks-for-non-TDD and
+  Context7/live-docs from backlog as violations.
+
+- **Refactor step 2h: security review** (2026-03-16) — holistic security audit
+  after all other refactoring. Distinct from 2c (inline fixes): 2h assesses auth,
+  data handling, trust boundaries, dependencies, and threat surface delta. Findings
+  use HIGH/MEDIUM/LOW severity. Always pauses on findings. Flows into PR via
+  cycle-log.
+
 - **Draft ADRs warn but don't block** (2026-03-16) — Domain Scout classifies
   draft ADRs as `pending-decision` with a warning. User can proceed or formalize
   via `/decisions review`.
@@ -74,21 +85,55 @@ Active testing on jlsm project. WIP.md cleared.
 
 ## Open questions
 
-*Live list — resolve into SETTLED.md or drop when addressed*
+*Live list — resolve into SETTLED.md or drop when addressed.*
+*Prioritised: do next → do soon → do when needed → do when scale demands it.*
 
-- **KB coding agent** — third KB role that reads entries and implements against
-  them. Would close the loop between research and implementation.
+### Do next (low effort, real risk mitigation)
+
+- ~~Command name collision audit~~ — **done** (2026-03-16). Zero collisions found
+  across 22 commands vs 45 Claude Code built-ins. `feature-` prefix strategy works.
+
+- ~~ADR contradiction check~~ — **done** (2026-03-16). `scripts/adr-validate.sh`
+  scans for duplicate accepted slugs. Added to pre-flight checks. Regression test
+  at `tests/scenario-adr-contradiction.sh` (10 cases).
+
+### Do soon (medium effort, clear designs)
+
+- ~~`/decisions backfill`~~ — **updated** (2026-03-16). Added Step 0 size check:
+  projects over `backfill_file_threshold` (default 50, in project-config.md)
+  require explicit path. Spec in decisions.md and DEFERRED.md.
 
 - **Work unit split thresholds** — 15K crossover and 3.5K per-construct are
-  reasoned estimates, not measured. Token estimate vs actual tracking now in
-  status.md — real data will inform adjustments.
+  reasoned estimates, not measured. Token tracking is collecting actuals — needs
+  data review once enough features have run with tracking enabled.
 
-- **install.sh --run-tests flag** — validation flag for fresh installs and
-  upgrades. Would run scenario scripts against a temp repo to verify the
-  installation works before using it on a real project.
+### Do when needed (useful but workarounds exist)
 
-- **setup-vallorcine merge into feature-init** — both are one-time setup.
-  Could be a single command. Low priority, no user has complained.
+- **/feature-split** — split in-progress feature when scope expands. Workaround:
+  finish current feature, start a new one.
+
+- **HANDOFF.md convention** — `/save-work` mostly covers this. May just need
+  documentation rather than new code.
+
+- **KB coding agent** — third KB role that reads entries and implements against
+  them. Current workflow (read KB manually) works.
+
+### Do when scale demands it (team/scale features)
+
+- **KB `depends-on` field** — frontmatter field for structural staleness. P2/P3
+  tension with fan-out reads on dependency chains. Date-based staleness sufficient
+  for current scale.
+
+- **Team KB commands** — `/kb sync`, `/kb consolidate`, `/kb status`. Useful for
+  teams but vallorcine is primarily single-developer today.
+
+- **LSP integration** — README documentation of companion plugins. Nice-to-have.
+
+- **Pipeline observability** — velocity metrics, KB utilization tracking.
+  Premature until more projects use vallorcine.
+
+- **KB cross-referencing** — reverse mapping (decisions → KB). One-way exists.
+  Low urgency until KB is large enough to need it.
 
 ---
 

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -13,31 +13,13 @@ CONTEXT.md when you're ready to act on them, or drop them if no longer relevant.
 
 ## Active deferrals
 
-- **Hooks for non-TDD tooling** — linting on write, security scanning, formatting.
-  Future: `hooks/` directory with opt-in configs via project-config.md.
-
 - **LSP integration** — document in README which LSP plugins pair well with
-  vallorcine's Code Writer stage as a recommended companion.
-
-- **Context7 / live docs in Domain Scout** — pull current framework docs via
-  Context7 MCP. Opt-in via project-config.md flag.
-
-- ~~/decisions list~~ — **done** (v0.2.4). Browse and filter by status/keyword.
-
-- ~~Project-level CONTEXT.md~~ — **done** (v0.2.4). `PROJECT-CONTEXT.md` with `/project-context` command.
-  90-day expiry, scoped entries, size cap, agent integration at scoping/domains/planning.
-
-- ~~Diff-based install~~ — **done** (v0.2.4). `install.sh --diff` shows changes without writing.
-
-- **Coverage gating in refactor** — flag coverage drops below configured minimum.
+  vallorcine's Code Writer stage as a recommended companion. No bundled dependency.
 
 - **/feature-split** — split in-progress feature into two when scope expands.
 
 - **KB coding agent** — third KB role that reads entries and implements against
   them. Would close the loop between research and implementation.
-
-- ~~Auto-capture of accidental decisions~~ — **done** (v0.2.4). PostSessionEnd hook +
-  `/decisions candidates` review command. Surfaces at `/feature-domains` and `/feature-resume`.
 
 - **KB staleness: `depends-on` field** — frontmatter `depends-on` field in
   subject files for cross-entry dependency tracking. Staleness detection by
@@ -51,33 +33,54 @@ CONTEXT.md when you're ready to act on them, or drop them if no longer relevant.
   for concurrent index writes is already built — these commands would extend
   the team support further.
 
-- ~~Feature retrospectives~~ — **done** (v0.2.4). `/feature-retro` reviews scope, assumptions, domains, tokens, TDD efficiency.
-
-- ~~Dependency-aware work splitting~~ — **done** (v0.2.4). Topology view with dependency layers in `/feature-resume`.
-
-- ~~/decisions explain~~ — **done** (v0.2.4). Plain-language ADR summary with KB context.
-
-- ~~/feature-cleanup~~ — **done** (v0.2.4). Interactive walkthrough of stale feature dirs.
-
 - **HANDOFF.md for cross-developer session handoff** — `/save-work` writes a
   structured summary of decisions made, approaches tried, and open questions.
   Useful for team handoffs and solo resume after long gaps. Documentation/convention
   for now — can't be enforced by tooling.
 
-- **ADR contradiction CI check** — scan `.decisions/CLAUDE.md` for duplicate
-  question slugs with `accepted` status. Requires CI integration (GitHub Actions
-  or pre-push hook). See "Known team issues" in DESIGN.md for details.
+- **ADR contradiction check** — scan `.decisions/CLAUDE.md` for duplicate
+  question slugs with `accepted` status. Originally spec'd as CI/GitHub Actions.
+  Redesigned (2026-03-16): bash script (`scripts/adr-validate.sh`) to stay within
+  principle 1. Can run as pre-flight check alongside version-check.sh.
 
-- **`/decisions backfill` — retroactive decision extraction.** Scans archived
-  features and source structure to surface implicit architectural decisions that
-  were never documented as ADRs. Designed 2026-03-16. Full spec below.
+- **Pipeline observability** — velocity metrics (time/tokens per stage across
+  features), KB utilization (which entries get read), pipeline trends. Token
+  tracking exists but is narrow. Premature until more projects use vallorcine.
+
+- **KB cross-referencing** — reverse mapping from decisions to KB entries. One-way
+  (KB → decisions) exists in `/kb query`. Low urgency until KB is large enough.
+
+- **`/decisions backfill` — retroactive decision extraction.** Scans source
+  structure to surface implicit architectural decisions that were never documented
+  as ADRs. Designed 2026-03-16, revised 2026-03-16. Full spec below.
 
   **Command:** `/decisions backfill [<path>] [--limit N]`
-  - No args: scan archived features + source structure, top 5 by signal strength
-  - With path: scope to module/package, top 5
+  - With path: scan specified module/package, top 5 by signal strength
+  - No path: allowed only if project is under `backfill_file_threshold` (default
+    50 source files, configurable in project-config.md). Over threshold: require
+    explicit path — display available top-level modules with file counts.
   - `--limit N`: adjust batch size (default 5)
-  - Re-runnable: dismissed items recorded, don't resurface. Shows deferred items
-    after new candidates (deferred may now be answerable).
+  - Re-runnable: dismissed items recorded in `.decisions/.backfill-dismissed`,
+    don't resurface.
+
+  **Step 0 — Size check (zero token cost):**
+  Read `project-config.md` for source directory and language. Run bash `find`
+  to count source files by extension. Compare against `backfill_file_threshold`.
+
+  If over threshold and no path provided:
+  ```
+  This project has ~320 source files. To keep scan costs predictable,
+  specify a path to scope the backfill:
+
+    /decisions backfill src/core
+    /decisions backfill src/api
+
+  Available top-level modules:
+    src/core/      (42 files)
+    src/api/       (38 files)
+    src/auth/      (15 files)
+    ...
+  ```
 
   **Signal sources (ranked):**
   1. Archived feature domains marked `resolved` with no ADR (highest signal)
@@ -106,4 +109,28 @@ CONTEXT.md when you're ready to act on them, or drop them if no longer relevant.
   - Conventions are out of scope — linters own that. Only ADR-weight items.
   - Draft ADRs visible to Domain Scout as warnings, not blockers.
   - Deferred ADRs are local `.decisions/` stubs, not GitHub issues.
-  - Incremental by design — 5 at a time, not an exhaustive dump.
+  - Path-scoped, not incremental — user controls scope per invocation.
+  - File count threshold in project-config.md (default 50) gates full-project scan.
+
+---
+
+## Dropped
+
+- ~~Hooks for non-TDD tooling~~ — **dropped** (2026-03-16). Requires Claude Code
+  hooks infrastructure — violates principle 1 (bash and markdown only).
+- ~~Context7 / live docs in Domain Scout~~ — **dropped** (2026-03-16). Requires
+  MCP server — violates principle 1 (bash and markdown only).
+- ~~Coverage gating in refactor~~ — **dropped** (2026-03-16). Requires
+  language-specific coverage tools — violates principle 1. Step 2e (missing test
+  detection) is the language-agnostic proxy.
+
+## Done
+
+- ~~/decisions list~~ — **done** (v0.2.4)
+- ~~Project-level CONTEXT.md~~ — **done** (v0.2.4)
+- ~~Diff-based install~~ — **done** (v0.2.4)
+- ~~Auto-capture of accidental decisions~~ — **done** (v0.2.4)
+- ~~Feature retrospectives~~ — **done** (v0.2.4)
+- ~~Dependency-aware work splitting~~ — **done** (v0.2.4)
+- ~~/decisions explain~~ — **done** (v0.2.4)
+- ~~/feature-cleanup~~ — **done** (v0.2.4)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -42,7 +42,38 @@ the 5th feature on a project faster than the 1st.
 
 ## Core design principles
 
-### 1. Pull model throughout
+Ordered by priority. When principles conflict, higher-numbered principles yield
+to lower-numbered ones. Each principle notes what breaks if it is violated.
+
+### 1. Bash and markdown only — no external dependencies
+
+The entire kit runs on two things every developer already has: a shell that can
+run bash, and text files. No package managers, no runtimes, no compiled tools,
+no MCP servers, no platform-specific hooks infrastructure, no database, no
+network services.
+
+This is a hard constraint, not a preference:
+- `install.sh` is a bash script that copies markdown files
+- Commands are markdown prompt files read by Claude Code
+- Agents are markdown identity definitions
+- Rules are markdown files loaded by convention
+- Scripts are bash — `token-usage.sh`, `version-check.sh`, etc.
+- State is markdown files — `status.md`, `cycle-log.md`, `CLAUDE.md` indexes
+
+The constraint eliminates an entire class of adoption friction: no `npm install`,
+no Python virtualenv, no Docker container, no CI pipeline dependency. A developer
+with Claude Code and a terminal can run vallorcine on any project in any language
+immediately.
+
+When evaluating new features, this is the first filter: if it requires anything
+beyond bash and markdown, it does not belong in the kit. Features that would
+benefit from external tooling (coverage gating, LSP integration, live docs) are
+documented as recommended companions, not bundled dependencies.
+
+**If violated:** the kit gains an installation prerequisite that gates adoption.
+Every external dependency is a reason for a developer to not use vallorcine.
+
+### 2. Pull model throughout
 
 Nothing loads automatically except the rules in `.claude/rules/` and the root
 `CLAUDE.md`. The KB, decision records, feature work files, and agent command
@@ -59,7 +90,32 @@ The pull model is enforced by three mechanisms:
 - Subdirectory `CLAUDE.md` files serve as lazy-loaded indexes rather than
   auto-loaded content
 
-### 2. File-based state, not in-memory state
+**If violated:** token cost grows with content volume. A project with rich KB
+and decision history becomes slower and more expensive to use with every entry
+added — the opposite of the intended compounding effect.
+
+### 3. Context is expensive — size every file accordingly
+
+Token cost shapes every structural decision in this kit:
+
+- Always-loaded files (`CLAUDE.md`, rules) are capped and pointer-only
+- Index files (`.kb/CLAUDE.md`, `.decisions/CLAUDE.md`) have 80-line hard caps
+  with archival rules that enforce them
+- Subject files (`.kb/<topic>/<category>/<subject>.md`) are capped at 200 lines
+  with overflow extracted to `<subject>-detail.md` via `@import`
+- The Work Planner loads only ADR sections and KB key-parameters, not full files
+- The Code Writer loads only stub files and test files relevant to the current
+  work unit, not the entire feature
+
+The token estimation in the Work Planner's work unit analysis (Step 2b) is a
+direct expression of this principle: split only when the savings justify the
+overhead. The crossover is ~15K for a single Code Writer session.
+
+**If violated:** individual operations become token-expensive even when the pull
+model is respected. A single oversized file can blow the context budget for a
+Code Writer session, causing truncation or degraded output quality.
+
+### 4. File-based state, not in-memory state
 
 Claude has no memory between sessions. Everything that needs to survive a session
 boundary — current stage, substage, cycle count, work unit status, in-progress
@@ -76,7 +132,11 @@ This separation — mutable checkpoint + immutable history — is the same patte
 used in write-ahead logs and event sourcing. It gives idempotency for free:
 read the checkpoint, if work is already done, stop.
 
-### 3. Idempotency at every stage
+**If violated:** work is lost on session end, context overflow, or crash. The
+pipeline cannot be resumed — every interruption requires starting over from
+scratch, wasting tokens and developer time.
+
+### 5. Idempotency at every stage
 
 Every command starts by reading `status.md` and checking whether its stage is
 already complete. If it is, it reports and stops. No command re-does completed
@@ -94,7 +154,26 @@ The idempotency pattern is:
 4. If stage not-started → proceed normally
 ```
 
-### 4. Write authority is strictly partitioned
+**If violated:** duplicate work on re-run — tests written twice, implementations
+overwritten, cycle counts inflated. Crash recovery becomes unreliable, and users
+lose confidence that interruptions are safe.
+
+### 6. Tests are the specification
+
+Test files are written before implementation and may never be modified by the
+Code Writer. If the implementation can't satisfy a test, that is a signal that
+the contract is wrong — handled by escalation to the Test Writer, not by
+changing the test to fit the implementation.
+
+This enforces genuine TDD rather than test-after development. The Test Writer
+writes tests against work-plan contracts. The Code Writer implements against
+those tests. The test files are the ground truth.
+
+**If violated:** TDD degrades into test-after development. The Code Writer shapes
+tests to fit implementation rather than implementing to satisfy contracts. Test
+coverage becomes a formality rather than a specification.
+
+### 7. Write authority is strictly partitioned
 
 Each agent writes only to its designated files. No agent writes to another
 agent's output files. This is enforced by explicit rules in each command file
@@ -121,35 +200,11 @@ belongs to another's domain:
 - Refactor Agent finds missing tests → escalates to Test Writer (does not write tests)
 - Test Writer needs a contract change → escalates to Work Planner (does not modify stubs)
 
-### 5. Tests are the specification
+**If violated:** agents silently overwrite each other's work. Escalation paths
+break down — problems get papered over instead of surfaced. The pipeline loses
+its separation of concerns and becomes a single monolithic agent with extra steps.
 
-Test files are written before implementation and may never be modified by the
-Code Writer. If the implementation can't satisfy a test, that is a signal that
-the contract is wrong — handled by escalation to the Test Writer, not by
-changing the test to fit the implementation.
-
-This enforces genuine TDD rather than test-after development. The Test Writer
-writes tests against work-plan contracts. The Code Writer implements against
-those tests. The test files are the ground truth.
-
-### 6. Context is expensive — size every file accordingly
-
-Token cost shapes every structural decision in this kit:
-
-- Always-loaded files (`CLAUDE.md`, rules) are capped and pointer-only
-- Index files (`.kb/CLAUDE.md`, `.decisions/CLAUDE.md`) have 80-line hard caps
-  with archival rules that enforce them
-- Subject files (`.kb/<topic>/<category>/<subject>.md`) are capped at 200 lines
-  with overflow extracted to `<subject>-detail.md` via `@import`
-- The Work Planner loads only ADR sections and KB key-parameters, not full files
-- The Code Writer loads only stub files and test files relevant to the current
-  work unit, not the entire feature
-
-The token estimation in the Work Planner's work unit analysis (Step 2b) is a
-direct expression of this principle: split only when the savings justify the
-overhead. The crossover is ~15K for a single Code Writer session.
-
-### 7. Human confirmation before irreversible writes
+### 8. Human confirmation before irreversible writes
 
 Two agents never write their primary output without explicit user confirmation:
 
@@ -165,7 +220,11 @@ All other agents write their outputs as part of their normal execution, but
 the handoff prompts between stages ("Continue? yes / no") give the user a
 review checkpoint before each stage begins.
 
-### 8. Agents are routers, not autonomy machines
+**If violated:** incorrect scope or flawed architectural decisions propagate
+through the entire pipeline before being caught. The cost of correction
+multiplies with each downstream stage that builds on the mistake.
+
+### 9. Agents are routers, not autonomy machines
 
 The pipeline is explicitly staged and human-paced. Agents do not chain
 automatically — they present their output, ask for confirmation, and either
@@ -179,7 +238,11 @@ unit's test writing. The user stays in the loop at every inter-stage boundary.
 question, and hands the user a pre-filled command. It never does pipeline work
 itself. It is a router, not an agent.
 
-### 9. Agents own the files — users don't edit them directly
+**If violated:** the pipeline runs ahead of the user's understanding. Errors
+compound silently across stages. The user loses the ability to course-correct
+at natural checkpoints, turning a collaborative tool into an unpredictable one.
+
+### 10. Agents own the files — users don't edit them directly
 
 Every file written by the kit — `.kb/CLAUDE.md`, `.decisions/CLAUDE.md`,
 `status.md`, `brief.md`, ADRs, subject files, index files — carries a managed-by
@@ -195,6 +258,10 @@ The rule: if you want something to change in a kit-managed file, there is a
 slash command for it. If there isn't, that is a gap in the kit — add a command
 rather than editing the file directly.
 
+**If violated:** kit-managed files drift into inconsistent states. Index files
+disagree with directory contents, status checkpoints lie about pipeline position,
+cap enforcement stops working. Recoverable, but requires manual investigation.
+
 ---
 
 ## Diagrams
@@ -204,7 +271,7 @@ rather than editing the file directly.
 ```mermaid
 graph TD
     TW["Test Writer<br>writes tests against contracts"] --> CW["Code Writer<br>implements to green"]
-    CW --> RA["Refactor Agent<br>quality review (2a-2f)"]
+    CW --> RA["Refactor Agent<br>quality review (2a-2h)"]
     RA -->|"all clear"| NEXT{"next unit?"}
     NEXT -->|"yes"| TW
     NEXT -->|"no"| PR["PR Draft"]
@@ -341,7 +408,7 @@ Last successful checkpoint: <human-readable description>
 ```
 
 The substage field enables intra-stage crash recovery — the Refactor Agent
-stores which checklist item it was on (2a through 2f) so it can resume exactly
+stores which checklist item it was on (2a through 2h) so it can resume exactly
 where it stopped.
 
 ### Work units
@@ -486,13 +553,11 @@ current branch's KB or decisions indexes are behind main. Advisory only.
 **Version skew** — `version-check.sh` warns when vallorcine version on the
 current branch differs from main.
 
-### Known but not yet mitigated
+**ADR contradiction** — `adr-validate.sh` warns at pipeline start when two
+accepted ADRs share the same slug. Catches the case where two developers
+independently accept conflicting decisions that the merge driver lands cleanly.
 
-**ADR contradiction** — two developers can independently accept conflicting ADRs
-for the same question. The merge driver ensures both rows land cleanly in the
-index, but does not detect the semantic conflict (two `accepted` answers to the
-same question). Fix requires a CI check or validation script that scans for
-duplicate accepted slugs. See DEFERRED.md.
+### Known but not yet mitigated
 
 **Same feature slug on different branches** — `.feature/<slug>/` is gitignored,
 so two developers using the same slug have silently divergent local state with
@@ -537,7 +602,7 @@ vallorcine/
 │   ├── feature-coordinate.md        ← /feature-coordinate — parallel batch coordinator
 │   ├── feature-test.md              ← /feature-test [--unit] — write failing tests
 │   ├── feature-implement.md         ← /feature-implement [--unit] — implement to green
-│   ├── feature-refactor.md          ← /feature-refactor [--unit] — quality review (2a-2g)
+│   ├── feature-refactor.md          ← /feature-refactor [--unit] — quality review (2a-2h)
 │   ├── feature-pr.md                ← /feature-pr — PR draft + gh pr create
 │   ├── feature-retro.md             ← /feature-retro — post-feature retrospective
 │   ├── feature-complete.md          ← /feature-complete — post-merge archival
@@ -572,7 +637,8 @@ vallorcine/
 │   ├── version-check.sh             ← warns if branch vallorcine version is behind main
 │   ├── kb-freshness-check.sh        ← warns if KB/decisions indexes are behind main
 │   ├── merge-driver-index.sh        ← git merge driver for CLAUDE.md index files
-│   └── ensure-merge-driver.sh       ← registers merge driver on first pipeline run
+│   ├── ensure-merge-driver.sh       ← registers merge driver on first pipeline run
+│   └── adr-validate.sh             ← warns if contradictory accepted ADRs exist
 │
 ├── tests/                           ← test scripts (not installed)
 │   ├── test-install.sh              ← install + upgrade smoke tests
@@ -581,7 +647,8 @@ vallorcine/
 │   ├── scenario-version-skew-warning.sh
 │   ├── scenario-index-merge-driver.sh
 │   ├── scenario-ensure-merge-driver.sh
-│   └── scenario-stale-kb.sh
+│   ├── scenario-stale-kb.sh
+│   └── scenario-adr-contradiction.sh
 │
 ├── kb/                              ← seed KB structure
 │   ├── CLAUDE.md                    ← KB root index template

--- a/MANIFEST
+++ b/MANIFEST
@@ -46,4 +46,5 @@
 .claude/scripts/merge-driver-index.sh
 .claude/scripts/ensure-merge-driver.sh
 .claude/scripts/kb-freshness-check.sh
+.claude/scripts/adr-validate.sh
 .claude/upgrade.sh

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ every feature completed.
 | `/feature-coordinate "<slug>"` | Parallel batch coordinator |
 | `/feature-test "<slug>"` | Write failing tests from contracts |
 | `/feature-implement "<slug>"` | Implement until tests pass |
-| `/feature-refactor "<slug>"` | Quality review (7-item checklist) |
+| `/feature-refactor "<slug>"` | Quality review (8-item checklist, 2a-2h) |
 | `/feature-pr "<slug>"` | Draft PR title, description, checklist |
 | `/feature-retro "<slug>"` | Post-feature retrospective |
 | `/feature-complete "<slug>"` | Archive after PR merges |
@@ -239,7 +239,7 @@ reviewing past decisions, crash recovery, and more.
 ## Architecture
 
 See [DESIGN.md](DESIGN.md) for the full design reference: the four concerns
-model, 9 core principles, token budget, agent write authority table, crash
+model, 10 core principles, token budget, agent write authority table, crash
 recovery model, KB/decisions hierarchy, work unit splitting, and extension points.
 
 ## Development

--- a/SETTLED.md
+++ b/SETTLED.md
@@ -85,7 +85,7 @@ pre-filled command. Never does pipeline work itself.
 /kb topic command; .kb/CLAUDE.md Topic Map is authoritative live list.
 research.md reads it first, offers to run /kb topic as sub-agent if missing.
 
-## Agents own the files (principle 9)
+## Agents own the files (principle 10)
 
 All kit-managed files carry managed-by notices. Manual edits bypass safety checks.
 
@@ -244,3 +244,12 @@ files. Escape hatch: `bash .claude/upgrade.sh --version vX.Y.Z` pins to any
 released version. Noted in upgrade.sh summary output.
 Rejected: snapshot before upgrade (storage overhead, point-in-time problem);
 git-based restore (not all projects version .claude/).
+
+## setup-vallorcine and feature-init remain separate (2026-03-16)
+
+Originally considered merging both into a single command (both are one-time setup).
+Rejected after the four-concern architecture model made the boundary clear:
+/setup-vallorcine creates Knowledge + Decisions infrastructure (.kb/, .decisions/).
+/feature-init creates Features infrastructure (.feature/, project-config.md).
+A project may use KB/Decisions without the feature pipeline, or vice versa.
+Merging would force users of one concern to configure the other.

--- a/agents/refactor-agent.md
+++ b/agents/refactor-agent.md
@@ -3,7 +3,8 @@
 ## Role
 You are a Refactor Agent. You improve code quality without changing behaviour.
 After the Code Writer makes tests pass, you review: coding standards, duplication,
-security, performance, and missing test coverage.
+security (inline fixes), performance, missing test coverage, documentation, and
+security posture (holistic audit of threat surface changes).
 
 You track cycle count and warn/checkpoint the user before the loop becomes
 counterproductive.

--- a/commands/decisions.md
+++ b/commands/decisions.md
@@ -14,7 +14,7 @@ Single entry point for all architecture decision operations.
 | `/decisions list [--status <filter>] [--search <term>]` | Browse and filter all decisions |
 | `/decisions explain "<slug>"` | Plain-language summary of a decision with KB context |
 | `/decisions candidates` | Review undocumented decision candidates from recent sessions |
-| `/decisions backfill [<path>] [--limit N]` | Surface implicit decisions from archived features and source code |
+| `/decisions backfill [<path>] [--limit N]` | Surface implicit decisions from source code. Path required for large projects (over backfill_file_threshold) |
 
 **Default (no subcommand):** if the first argument looks like a question rather
 than a subcommand name, treat it as `/decisions "<question>"`.
@@ -703,7 +703,9 @@ file.
 
 Scans archived features and source structure to surface implicit architectural
 decisions that were never documented as ADRs. Presents candidates one at a time
-for the user to decide, draft, defer, or dismiss.
+for the user to decide, draft, defer, or dismiss. On projects with more than
+`backfill_file_threshold` source files (default 50, set in project-config.md),
+a `<path>` argument is required to scope the scan.
 
 Display opening header:
 ```
@@ -712,12 +714,51 @@ Display opening header:
 ───────────────────────────────────────────────
 ```
 
-### Step 0 — Parse arguments
+### Step 0 — Parse arguments and size check
 
 - `<path>` (optional): scope the source scan to this module/package path.
   Archived feature scan still runs (results are filtered to domains that
   relate to constructs in the scoped path).
 - `--limit N` (optional, default 5): max candidates to present this session.
+
+**Size check (before any scanning):**
+
+Read `.feature/project-config.md` for the source directory, language, and
+`Backfill file threshold` (default 50). Count source files using bash:
+
+```bash
+find <source-dir> -type f \( -name "*.<ext>" \) | wc -l
+```
+
+Use language from project-config to determine extensions:
+- Java: `*.java`
+- TypeScript/JavaScript: `*.ts *.tsx *.js *.jsx`
+- Python: `*.py`
+- Go: `*.go`
+- Rust: `*.rs`
+- Multiple languages: union of applicable extensions
+
+**If `<path>` was provided:** skip the size check, proceed to Step 1.
+
+**If no `<path>` and file count is under threshold:** proceed to Step 1.
+
+**If no `<path>` and file count is at or over threshold:** require a path.
+List available top-level directories under the source root with file counts:
+
+```
+This project has ~<n> source files. To keep scan costs predictable,
+specify a module or package path:
+
+  /decisions backfill <source-dir>/<module-1>
+  /decisions backfill <source-dir>/<module-2>
+
+Available:
+  <source-dir>/<module-1>/    (<n> files)
+  <source-dir>/<module-2>/    (<n> files)
+  <source-dir>/<module-3>/    (<n> files)
+  ...
+```
+Stop. Do not proceed without a path.
 
 ### Step 1 — Load dismissed list
 

--- a/commands/feature-init.md
+++ b/commands/feature-init.md
@@ -172,6 +172,9 @@ last_updated: "<YYYY-MM-DD>"
 
 ## Knowledge Base
 **KB staleness threshold (days):** `90`
+
+## Decisions
+**Backfill file threshold:** `50`
 ```
 
 ---

--- a/commands/feature-refactor.md
+++ b/commands/feature-refactor.md
@@ -75,7 +75,8 @@ Stop.
 - Say: "Refactor was in progress at: <substage>. Resuming from there."
 - Jump to the appropriate checklist item in this order:
   2a coding-standards → 2b duplication → 2c security → 2d performance →
-  2e missing-tests → 2f integration-tests → 2g documentation → Step 4 final-lint
+  2e missing-tests → 2f integration-tests → 2g documentation →
+  2h security-review → Step 4 final-lint
 
 **If Refactor is `not-started`:**
 - Verify cycle-log.md has an `implemented` entry for this cycle.
@@ -289,6 +290,87 @@ Display findings:
 Run tests after changes (documentation changes should not break tests, but
 verify anyway).
 
+### 2h — Security review
+`status.md substage → "refactor: security-review"`
+`Display: ── Security review ──────────────────────────`
+
+This is a holistic audit of the feature's security posture — distinct from 2c
+which fixes implementation-level vulnerabilities inline. 2h steps back and
+assesses what this feature changes about the project's threat surface.
+
+Scope to only the constructs and files changed by this feature (read work-plan.md
+for the list). Do not audit the entire codebase.
+
+**Authentication & Authorization:**
+- Do new endpoints/APIs enforce authentication?
+- Do access control checks match the feature's intended audience?
+- Are there privilege escalation paths (user action → admin effect)?
+
+**Data handling:**
+- Is sensitive data (PII, credentials, tokens) encrypted at rest and in transit?
+- Are there new logging statements that might log sensitive data?
+- Is data sanitized before display (XSS) and before storage (injection)?
+- Are temporary files / caches cleaned up?
+
+**Trust boundaries:**
+- Does this feature introduce new trust boundaries (user input, external API,
+  file upload, deserialization)?
+- Are all inputs from untrusted sources validated at the boundary?
+- Are error responses safe (no stack traces, internal paths, or version info)?
+
+**Dependency & configuration:**
+- Do new dependencies have known vulnerabilities? (advisory check, not a scanner)
+- Are there new configuration options with insecure defaults?
+- Are feature flags / admin toggles protected?
+
+**Threat surface delta:**
+- What attack surface does this feature add that didn't exist before?
+- One sentence summary of the security posture change
+
+**If no findings:**
+```
+  Security review: no issues found ✓
+  Threat surface delta: <one sentence>
+```
+Continue to Step 4.
+
+**If findings exist — always pause:**
+```
+── Security review — findings ─────────────────
+<n> issue(s) found:
+
+  1. [HIGH] <description> — <file:line>
+  2. [MEDIUM] <description> — <file:line>
+  3. [LOW/INFO] <description>
+
+  Fix now?  Type **yes**  ·  or: stop  to review first
+```
+
+Severity levels:
+- **HIGH** — exploitable vulnerability, must fix before PR (injection, auth
+  bypass, secret exposure)
+- **MEDIUM** — defense-in-depth gap, should fix (missing rate limiting, overly
+  broad permissions)
+- **LOW/INFO** — observation worth noting in PR (new attack surface, recommended
+  future hardening)
+
+If "yes": fix HIGH and MEDIUM inline, note LOW/INFO in the cycle-log. Re-run
+tests after fixes.
+
+If "stop": write all findings to cycle-log, do not fix anything.
+
+Append to cycle-log.md:
+```markdown
+## <YYYY-MM-DD> — security-review
+**Agent:** ✨ Refactor Agent
+**Cycle:** <n>
+**Findings:** <n total — n HIGH, n MEDIUM, n LOW>
+**Fixed:** <list of fixed issues, or "none">
+**Noted:** <list of LOW/INFO items for PR review, or "none">
+**Threat surface delta:** <one sentence>
+---
+```
+
 ---
 
 ## Step 3 — Missing tests escalation
@@ -379,7 +461,9 @@ Append `refactor-complete` to cycle-log.md:
 **Agent:** ✨ Refactor Agent
 **Cycle:** <n>
 **Changes:** <bullet list>
-**Security findings:** <none | list>
+**Security findings (2c):** <none | list>
+**Security review (2h):** <n findings — n HIGH, n MEDIUM, n LOW | clean>
+**Threat surface delta:** <one sentence>
 **Performance findings:** <none | list>
 **Missing tests found:** <n>
 **Unit tests:** <n> passing, 0 failing

--- a/rules/tdd-protocol.md
+++ b/rules/tdd-protocol.md
@@ -26,6 +26,7 @@ Before starting any pipeline command, run these scripts and display any output:
 - `bash .claude/scripts/version-check.sh` — warns if branch is behind main
 - `bash .claude/scripts/ensure-merge-driver.sh` — registers index merge driver if missing
 - `bash .claude/scripts/kb-freshness-check.sh` — warns if KB/decisions are behind main
+- `bash .claude/scripts/adr-validate.sh` — warns if contradictory accepted ADRs exist
 All are advisory — never block on their output.
 
 ## Idempotency rule (CRITICAL)

--- a/scripts/adr-validate.sh
+++ b/scripts/adr-validate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# vallorcine ADR contradiction check
+# Scans .decisions/CLAUDE.md for duplicate question slugs with "accepted" status.
+# Two accepted ADRs for the same slug means contradictory decisions landed
+# (e.g., from parallel branches). See "Known team issues" in DESIGN.md.
+#
+# Usage: bash .claude/scripts/adr-validate.sh
+#   Exit 0 always — advisory, never blocks.
+
+DECISIONS_INDEX=""
+
+# Find the decisions index
+if [[ -f ".decisions/CLAUDE.md" ]]; then
+    DECISIONS_INDEX=".decisions/CLAUDE.md"
+else
+    # Try relative to script location (installed path)
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    if [[ -f "$PROJECT_ROOT/.decisions/CLAUDE.md" ]]; then
+        DECISIONS_INDEX="$PROJECT_ROOT/.decisions/CLAUDE.md"
+    fi
+fi
+
+[[ -z "$DECISIONS_INDEX" ]] && exit 0
+
+# Extract slugs from table rows with "accepted" status (case-insensitive).
+# Table format: | Problem | Slug | Date | Status | Recommendation |
+# We look for rows where the Status column contains "accepted".
+# Slugs appear in column 2 of pipe-delimited tables.
+accepted_slugs="$(grep -i '| *accepted *|' "$DECISIONS_INDEX" 2>/dev/null \
+    | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $3); print $3}' \
+    | sort)"
+
+[[ -z "$accepted_slugs" ]] && exit 0
+
+# Find duplicates
+duplicates="$(echo "$accepted_slugs" | uniq -d)"
+
+[[ -z "$duplicates" ]] && exit 0
+
+# Report
+dup_count="$(echo "$duplicates" | wc -l | tr -d ' ')"
+echo "⚠  ADR contradiction: $dup_count slug(s) have multiple accepted decisions:"
+while IFS= read -r slug; do
+    count="$(echo "$accepted_slugs" | grep -c "^${slug}$")"
+    echo "   - $slug ($count accepted entries)"
+done <<< "$duplicates"
+echo "   Review with: /decisions review <slug>"
+
+exit 0

--- a/tests/scenario-adr-contradiction.sh
+++ b/tests/scenario-adr-contradiction.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Scenario: ADR contradiction detection
+#
+# Validates that adr-validate.sh detects duplicate accepted slugs in
+# .decisions/CLAUDE.md and stays silent when no contradictions exist.
+#
+# Run from repo root: bash tests/scenario-adr-contradiction.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-adr-contradiction"
+
+# ── Test helpers ─────────────────────────────────────────────────────────────
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ""
+echo "scenario: ADR contradiction detection"
+echo "────────────────────────────────────────────────"
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+cleanup
+mkdir -p "$TEST_BASE"
+
+PROJECT="$TEST_BASE/project"
+mkdir -p "$PROJECT/.decisions"
+
+# Copy the script to the installed location
+mkdir -p "$PROJECT/.claude/scripts"
+cp "$REPO_ROOT/scripts/adr-validate.sh" "$PROJECT/.claude/scripts/adr-validate.sh"
+
+# ── Test 1: no decisions index — silent ──────────────────────────────────────
+
+echo ""
+echo "── Test 1: no decisions index"
+
+rm -f "$PROJECT/.decisions/CLAUDE.md"
+output="$(cd "$PROJECT" && bash .claude/scripts/adr-validate.sh 2>&1)"
+if [[ -z "$output" ]]; then
+    pass "silent when no .decisions/CLAUDE.md"
+else
+    fail "should be silent without index" "got: $output"
+fi
+
+# ── Test 2: empty index — silent ─────────────────────────────────────────────
+
+echo ""
+echo "── Test 2: empty index"
+
+cat > "$PROJECT/.decisions/CLAUDE.md" << 'EOF'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+
+## Recently Accepted (last 5)
+
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+EOF
+
+output="$(cd "$PROJECT" && bash .claude/scripts/adr-validate.sh 2>&1)"
+if [[ -z "$output" ]]; then
+    pass "silent with empty index"
+else
+    fail "should be silent with empty index" "got: $output"
+fi
+
+# ── Test 3: one accepted — silent ────────────────────────────────────────────
+
+echo ""
+echo "── Test 3: single accepted ADR"
+
+cat > "$PROJECT/.decisions/CLAUDE.md" << 'EOF'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+
+## Recently Accepted (last 5)
+
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+| Storage format | storage-format | 2026-03-01 | accepted | Use LSM-Tree |
+EOF
+
+output="$(cd "$PROJECT" && bash .claude/scripts/adr-validate.sh 2>&1)"
+if [[ -z "$output" ]]; then
+    pass "silent with one accepted ADR"
+else
+    fail "should be silent with single accepted" "got: $output"
+fi
+
+# ── Test 4: two different accepted — silent ──────────────────────────────────
+
+echo ""
+echo "── Test 4: two different accepted ADRs"
+
+cat > "$PROJECT/.decisions/CLAUDE.md" << 'EOF'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+| Auth approach | auth-approach | 2026-03-10 | accepted | Use JWT |
+
+## Recently Accepted (last 5)
+
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+| Storage format | storage-format | 2026-03-01 | accepted | Use LSM-Tree |
+EOF
+
+output="$(cd "$PROJECT" && bash .claude/scripts/adr-validate.sh 2>&1)"
+if [[ -z "$output" ]]; then
+    pass "silent with two different accepted ADRs"
+else
+    fail "should be silent with different slugs" "got: $output"
+fi
+
+# ── Test 5: duplicate accepted slug — warns ──────────────────────────────────
+
+echo ""
+echo "── Test 5: duplicate accepted slug (contradiction)"
+
+cat > "$PROJECT/.decisions/CLAUDE.md" << 'EOF'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+| Storage format v2 | storage-format | 2026-03-15 | accepted | Use B-Tree |
+
+## Recently Accepted (last 5)
+
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+| Storage format | storage-format | 2026-03-01 | accepted | Use LSM-Tree |
+EOF
+
+output="$(cd "$PROJECT" && bash .claude/scripts/adr-validate.sh 2>&1)"
+if [[ -n "$output" ]]; then
+    pass "warns on duplicate accepted slug"
+else
+    fail "should warn on contradiction" "got no output"
+fi
+
+if echo "$output" | grep -q "storage-format"; then
+    pass "warning mentions the contradicting slug"
+else
+    fail "warning should mention slug" "got: $output"
+fi
+
+# ── Test 6: non-accepted duplicates — silent ─────────────────────────────────
+
+echo ""
+echo "── Test 6: duplicate slug but different statuses"
+
+cat > "$PROJECT/.decisions/CLAUDE.md" << 'EOF'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+| Storage format v2 | storage-format | 2026-03-15 | proposed | Consider B-Tree |
+
+## Recently Accepted (last 5)
+
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+| Storage format | storage-format | 2026-03-01 | accepted | Use LSM-Tree |
+EOF
+
+output="$(cd "$PROJECT" && bash .claude/scripts/adr-validate.sh 2>&1)"
+if [[ -z "$output" ]]; then
+    pass "silent when duplicate slug has different status"
+else
+    fail "should be silent — only one is accepted" "got: $output"
+fi
+
+# ── Test 7: multiple contradictions — reports all ────────────────────────────
+
+echo ""
+echo "── Test 7: multiple contradictions"
+
+cat > "$PROJECT/.decisions/CLAUDE.md" << 'EOF'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+| Storage format v2 | storage-format | 2026-03-15 | accepted | Use B-Tree |
+| Auth v2 | auth-approach | 2026-03-15 | accepted | Use OAuth |
+
+## Recently Accepted (last 5)
+
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+| Storage format | storage-format | 2026-03-01 | accepted | Use LSM-Tree |
+| Auth approach | auth-approach | 2026-03-05 | accepted | Use JWT |
+EOF
+
+output="$(cd "$PROJECT" && bash .claude/scripts/adr-validate.sh 2>&1)"
+if echo "$output" | grep -q "storage-format"; then
+    pass "reports storage-format contradiction"
+else
+    fail "should report storage-format" "got: $output"
+fi
+
+if echo "$output" | grep -q "auth-approach"; then
+    pass "reports auth-approach contradiction"
+else
+    fail "should report auth-approach" "got: $output"
+fi
+
+if echo "$output" | grep -q "2 slug"; then
+    pass "reports correct count of contradictions"
+else
+    fail "should report 2 contradictions" "got: $output"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+echo ""
+
+exit $failed


### PR DESCRIPTION
## Summary

- **Principle 1: bash and markdown only** — new top-priority design principle. Hard constraint that gates all new features. Dropped hooks-for-non-TDD, Context7/live-docs, and coverage gating from backlog as violations.
- **Principles renumbered 1-10 by priority** with violation consequences documented. Structural constraints (1-3) outrank correctness guarantees (4-7) which outrank workflow discipline (8-10).
- **Refactor step 2h: security review** — holistic audit after all other refactoring. Checks auth, data handling, trust boundaries, dependencies, and threat surface delta. HIGH/MEDIUM/LOW severity. Always pauses on findings.
- **ADR contradiction check** — new pre-flight script (`scripts/adr-validate.sh`) warns when duplicate accepted slugs exist in `.decisions/CLAUDE.md`. Regression test with 10 cases.
- **`/decisions backfill` size check** — requires explicit path on projects over `backfill_file_threshold` (default 50 source files, configurable in project-config.md).
- **Backlog cleanup** — DEFERRED.md reorganized into active/dropped/done. COMPETITIVE.md gaps updated. CONTEXT.md open questions prioritized into four tiers. Command collision audit completed (zero collisions). Several stale items dropped or settled.

## Changed files (16)

| File | Change |
|------|--------|
| DESIGN.md | Principles renumbered 1-10, violation consequences, principle 1 added, mermaid diagram + manifest updated |
| CONTEXT.md | Open questions reorganized into priority tiers, new decisions added |
| COMPETITIVE.md | Gaps updated with principle 1 rationale, closed gaps section |
| DEFERRED.md | Reorganized: active/dropped/done sections, backfill spec updated |
| SETTLED.md | setup-vallorcine/feature-init separation settled |
| README.md | Principle count 9→10, checklist count 7→8 |
| CHANGELOG.md | Checklist count 6→8 |
| commands/feature-refactor.md | Step 2h security review added, resume sequence updated |
| commands/decisions.md | Backfill Step 0 size check added |
| commands/feature-init.md | Backfill file threshold in project-config template |
| agents/refactor-agent.md | Role description updated for dual security passes |
| rules/tdd-protocol.md | adr-validate.sh added to pre-flight checks |
| MANIFEST | adr-validate.sh added |
| .claude/commands/ideate.md | 9→10 principles |
| scripts/adr-validate.sh | New: ADR contradiction detection |
| tests/scenario-adr-contradiction.sh | New: 10-case regression test |

## Test plan

- [x] `bash tests/scenario-adr-contradiction.sh` — 10/10 passing
- [ ] Verify `install.sh` installs `adr-validate.sh` to `.claude/scripts/`
- [ ] Run `/decisions backfill` on a project with >50 files — confirm path required
- [ ] Run `/feature-refactor` — confirm 2h security review step appears after 2g
- [ ] Verify pre-flight checks include adr-validate.sh output

🤖 Generated with [Claude Code](https://claude.com/claude-code)