### PR TITLE
docs: update DESIGN.md manifest for skills + dashboard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "vallorcine",
   "metadata": {
-    "description": "TDD pipeline and KB/Decisions workflow system for Claude Code",
+    "description": "A reliable engineering partner for Claude Code — persistent knowledge, structured decisions, and TDD guardrails that compound across sessions",
     "url": "https://github.com/telefrek/vallorcine"
   },
   "owner": {
@@ -11,7 +11,7 @@
     {
       "name": "vallorcine",
       "source": "./",
-      "description": "Full TDD pipeline (scoping → domains → planning → test → implement → refactor → PR) with crash recovery and token-aware work unit splitting. Pull-model knowledge base and architecture decision store. Sequential scoping interview, enter-to-proceed prompts throughout.",
+      "description": "Turns Claude Code into a reliable engineering partner. Crash-recoverable TDD pipeline, pull-model knowledge base, architecture decision store, and live tmux dashboard. Your project learns across sessions — each feature makes the next one faster.",
       "version": "0.3.4",
       "keywords": ["tdd", "workflow", "knowledge-base", "decisions", "pipeline"]
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "vallorcine",
   "version": "0.3.4",
-  "description": "TDD pipeline and KB/Decisions workflow system for Claude Code. Crash-recoverable feature pipeline with scoping, domain analysis, work planning, and TDD cycles. Pull-model knowledge base and architecture decision store.",
+  "description": "A reliable engineering partner for Claude Code. Persistent knowledge base, structured architecture decisions, crash-recoverable TDD pipeline, and live tmux dashboard. Sessions compound — each feature makes the next one faster.",
   "author": {
     "name": "vallorcine"
   },
   "license": "MIT",
   "keywords": ["tdd", "workflow", "knowledge-base", "decisions", "pipeline", "agents"],
   "components": {
-    "commands": ["commands/"],
+    "skills": ["skills/"],
     "agents": ["agents/"],
     "rules": ["rules/"]
   }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,9 +8,12 @@ debugging unexpected agent behaviour, or evaluating whether to adopt it.
 
 ## What this is
 
-A set of Claude Code slash commands, agent definitions, and rules that turn a
-project into a self-documenting, crash-recoverable, TDD-first development
-environment. Organised around four concerns:
+A reliable engineering partner for Claude Code — persistent knowledge,
+structured decisions, TDD guardrails, and a conversational flow that enforces
+the process you want without the friction you don't. Each feature shipped makes
+the next one faster because the project's context compounds across sessions.
+
+Organised around four concerns:
 
 **Knowledge** — a pull-model knowledge base (`.kb/`) maintained by the Research
 Agent. Research findings accumulate across features and are queried on demand.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 # vallorcine
 
-A Claude Code workflow package built around four concerns:
+**A reliable engineering partner for Claude Code that's easy to work with.**
 
-**Knowledge** — pull-model knowledge base. Research findings accumulate in `.kb/`
-and are queried on demand.
+vallorcine enforces the process you want without the friction you don't —
+persistent knowledge, structured decisions, TDD guardrails, and a conversational
+flow that just tells you what's next. Each feature you ship makes the next one
+faster because your project's context compounds, not its token cost.
 
-**Decisions** — architecture decision store. The Architect Agent deliberates
-tradeoffs and writes ADRs to `.decisions/`. Decisions compound across features.
+No dependencies. `bash install.sh` and go.
 
-**Features** — TDD pipeline. Scoping → domain analysis → work planning → test →
-implement → refactor → PR → retrospective. Crash-recoverable, token-aware,
-with parallel work unit execution.
+### Four concerns
 
-**System** — setup, upgrade, project context, and help. One-time configuration
-and ongoing maintenance.
+**Knowledge** — research findings accumulate in `.kb/` and are queried on demand.
+Your project learns once and remembers forever.
+
+**Decisions** — the Architect Agent deliberates tradeoffs and writes ADRs to
+`.decisions/`. Decisions compound across features — you don't re-debate settled
+questions.
+
+**Features** — TDD pipeline from scoping through PR, with crash recovery and
+parallel work unit execution. Claude follows the discipline so you can focus on
+directing the work, not policing it.
+
+**System** — setup, upgrade, live dashboard, and help. `/vallorcine-help` routes
+you to the right command. The tmux dashboard shows exactly what's happening so
+you stay in control.
 
 ---
 
@@ -64,10 +75,9 @@ graph LR
     style DECQ fill:#f59e0b,color:#fff
 ```
 
-The knowledge and decisions layers are independent — they accumulate across
-features and get richer over time. Features read from them during domain analysis
-and write back via retrospectives. The project layer gets more valuable with
-every feature completed.
+Knowledge and decisions accumulate across features and get richer over time.
+Features read from them during domain analysis and write back via retrospectives.
+This feedback loop is what makes the 5th feature on a project faster than the 1st.
 
 ---
 
@@ -127,6 +137,8 @@ every feature completed.
 | `/project-context add "<entry>"` | Add team-shared codebase knowledge |
 | `/project-context cleanup` | Review expired context entries |
 | `/project-context` | Display all active context entries |
+| `/dashboard` | Launch tmux dashboard (pipeline progress + stage detail) |
+| `/dashboard off` | Suppress dashboard hint |
 
 ---
 


### PR DESCRIPTION
## Summary

- Update DESIGN.md file manifest to reflect skills/ migration (commands/ → skills/<name>/SKILL.md)
- Add dashboard watchers and scripts to manifest
- Update extension points to reference skills instead of commands

This was part of the dashboard + skills session but landed after PR #11 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)