### PR TITLE
feat: research signal recognition + ADR pressure/gravity/hub curation

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -50,67 +50,13 @@ CONTEXT.md when you're ready to act on them, or drop them if no longer relevant.
 - **KB cross-referencing** — reverse mapping from decisions to KB entries. One-way
   (KB → decisions) exists in `/kb query`. Low urgency until KB is large enough.
 
-- **`/decisions backfill` — retroactive decision extraction.** Scans source
-  structure to surface implicit architectural decisions that were never documented
-  as ADRs. Designed 2026-03-16, revised 2026-03-16. Full spec below.
-
-  **Command:** `/decisions backfill [<path>] [--limit N]`
-  - With path: scan specified module/package, top 5 by signal strength
-  - No path: allowed only if project is under `backfill_file_threshold` (default
-    50 source files, configurable in project-config.md). Over threshold: require
-    explicit path — display available top-level modules with file counts.
-  - `--limit N`: adjust batch size (default 5)
-  - Re-runnable: dismissed items recorded in `.decisions/.backfill-dismissed`,
-    don't resurface.
-
-  **Step 0 — Size check (zero token cost):**
-  Read `project-config.md` for source directory and language. Run bash `find`
-  to count source files by extension. Compare against `backfill_file_threshold`.
-
-  If over threshold and no path provided:
-  ```
-  This project has ~320 source files. To keep scan costs predictable,
-  specify a path to scope the backfill:
-
-    /decisions backfill src/core
-    /decisions backfill src/api
-
-  Available top-level modules:
-    src/core/      (42 files)
-    src/api/       (38 files)
-    src/auth/      (15 files)
-    ...
-  ```
-
-  **Signal sources (ranked):**
-  1. Archived feature domains marked `resolved` with no ADR (highest signal)
-  2. Module/package boundaries — why does this exist as a separate unit?
-  3. Interface hierarchies — sealed types, strategy patterns, extension points
-  4. Encoding/serialization/storage choices — high cost to change
-  5. Dependency graph edges — why A depends on B but not C
-
-  **Filtered out (not surfaced):**
-  - Framework/library choices (tooling, not architecture)
-  - Naming, test structure, formatting (linter territory)
-  - Anything with an existing ADR in `.decisions/`
-
-  **Per-candidate actions:**
-  - **decide** → invoke `/architect` inline for full deliberation
-  - **draft** → user provides rationale in a few sentences, written as partial
-    ADR marked `status: draft`. Domain Scout warns on draft ADRs but does not
-    block — user's choice to proceed without formalizing.
-  - **defer** → prompt for who should answer + optional context. Written as stub
-    ADR marked `status: deferred`. Stays in `.decisions/`, local only (no
-    external system integration yet).
-  - **dismiss** → recorded in `.decisions/.backfill-dismissed` so it doesn't
-    resurface on re-scan.
-
-  **Key design decisions:**
-  - Conventions are out of scope — linters own that. Only ADR-weight items.
-  - Draft ADRs visible to Domain Scout as warnings, not blockers.
-  - Deferred ADRs are local `.decisions/` stubs, not GitHub issues.
-  - Path-scoped, not incremental — user controls scope per invocation.
-  - File count threshold in project-config.md (default 50) gates full-project scan.
+- ~~`/decisions backfill`~~ — **subsumed by `/curate`** (2026-03-18). Curation's
+  analysis 8 (backfill candidates) + analysis 3b-3d (ADR pressure/gravity/hubs)
+  cover all five signal sources. Archived feature domains (source 1) are scanned
+  directly. Module boundaries, interface hierarchies, encoding choices, and
+  dependency edges (sources 2-5) are detected via ADR gravity — files that
+  co-change with ADR-constrained files but aren't in the ADR's scope. High
+  gravity signals isolation problems that route to `/architect`.
 
 ---
 

--- a/agents/scoping-agent.md
+++ b/agents/scoping-agent.md
@@ -18,6 +18,18 @@ for clarification. You make the fuzzy precise.
 - Depth on one question is better than breadth across all — follow up when needed
 - When all unknowns are resolved, move to brief confirmation without announcement
 
+## Recognising research signals
+When the user expresses uncertainty about a topic that could influence the
+design — "I'm not sure," "I don't know," "might be worth investigating,"
+"my feeling is," or similar hedging — that is a research signal, not an
+out-of-scope item. Capture it in the brief's Research Commissions section
+with a topic, key questions, and how findings would influence the design.
+
+The scoping agent does not do research. It recognises the signal so the
+Domain Scout can act on it. Do not bury research signals in "Explicit Out
+of Scope" or "Open Assumptions" — those are dead ends that the downstream
+pipeline may never surface.
+
 ## Non-negotiable rules
 - Before doing anything, read .feature/<slug>/status.md if it exists — check
   whether scoping is already complete and report rather than redoing work

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -213,6 +213,138 @@ if [[ -d ".feature/_archive" ]]; then
     done < "$TMPDIR_SCAN/changed-files.txt"
 fi
 
+# ── Analysis 3b: ADR Pressure ────────────────────────────────────────────────
+# Aggregate ADR artifact hits by slug to detect decisions under concentrated
+# change. When multiple files constrained by the same ADR change, the decision
+# may need re-evaluation.
+#
+# DESIGN NOTE: File references are found via grep of ADR body text + files:
+# frontmatter, not just the structured files: field. This is intentionally
+# broad — a file mentioned in rationale or constraints is a signal even if not
+# formally constrained. If this proves too noisy in practice, restrict to
+# files: frontmatter only. Track user feedback on false positive rate.
+
+TEST_PATTERN='(test[_/]|_test\.|\.test\.|Test\.|tests/|spec[_/]|_spec\.|\.spec\.)'
+
+> "$TMPDIR_SCAN/adr-pressure.txt"
+> "$TMPDIR_SCAN/adr-gravity.txt"
+> "$TMPDIR_SCAN/hub-files.txt"
+
+if [[ -d ".decisions" ]] && [[ -s "$TMPDIR_SCAN/artifact-hits.txt" ]]; then
+
+    # Extract slug|changed_file pairs from ADR artifact hits
+    grep '^ADR|' "$TMPDIR_SCAN/artifact-hits.txt" 2>/dev/null \
+        | awk -F'|' '{
+            split($2, parts, "/")
+            slug = parts[2]
+            print slug "|" $3
+        }' | sort -u > "$TMPDIR_SCAN/adr-slug-files.txt" 2>/dev/null || true
+
+    # --- Pressure: count unique changed files per ADR slug ---
+    cut -d'|' -f1 "$TMPDIR_SCAN/adr-slug-files.txt" \
+        | sort | uniq -c | sort -rn \
+        | awk '$1 >= 2 {print $2 "|" $1}' > "$TMPDIR_SCAN/adr-pressure-counts.txt" 2>/dev/null || true
+
+    while IFS='|' read -r slug changed; do
+        # Count total file references in this ADR (all references, not just changed)
+        total=0
+        for adr_f in .decisions/"$slug"/adr.md .decisions/"$slug"/constraints.md; do
+            [[ -f "$adr_f" ]] || continue
+            t=$(grep -oE '[a-zA-Z0-9_./+-]+/[a-zA-Z0-9_.+-]+\.[a-zA-Z0-9]+' "$adr_f" 2>/dev/null \
+                | sort -u | wc -l)
+            total=$((total + t))
+        done
+        # Floor: total can't be less than changed
+        [[ "$total" -ge "$changed" ]] || total="$changed"
+        pct=$(( (changed * 100) / total ))
+        echo "PRESSURE|$slug|$changed|$total|$pct" >> "$TMPDIR_SCAN/adr-pressure.txt"
+    done < "$TMPDIR_SCAN/adr-pressure-counts.txt"
+
+    sort -t'|' -k5 -rn "$TMPDIR_SCAN/adr-pressure.txt" -o "$TMPDIR_SCAN/adr-pressure.txt" 2>/dev/null || true
+
+    # ── Analysis 3c: ADR Gravity ─────────────────────────────────────────────
+    # Cross-reference co-change pairs with ADR constrained files. If one file
+    # in a pair is ADR-constrained and the other isn't, the unconstrained file
+    # is gravitationally linked — it may belong in the ADR's scope.
+    # Test files are excluded on the unconstrained side (they co-change with
+    # everything and inflate every relationship).
+
+    > "$TMPDIR_SCAN/adr-gravity-raw.txt"
+
+    if [[ -s "$TMPDIR_SCAN/co-change.txt" ]] && [[ -s "$TMPDIR_SCAN/adr-slug-files.txt" ]]; then
+        # Build set of ADR-constrained changed files
+        cut -d'|' -f2 "$TMPDIR_SCAN/adr-slug-files.txt" | sort -u > "$TMPDIR_SCAN/adr-constrained-set.txt"
+
+        while IFS= read -r line; do
+            count="$(echo "$line" | awk '{print $1}')"
+            pair="$(echo "$line" | awk '{$1=""; print $0}' | sed 's/^ //')"
+            file_a="$(echo "$pair" | cut -d'|' -f1)"
+            file_b="$(echo "$pair" | cut -d'|' -f2)"
+
+            a_constrained=0
+            grep -qxF "$file_a" "$TMPDIR_SCAN/adr-constrained-set.txt" 2>/dev/null && a_constrained=1
+            b_constrained=0
+            grep -qxF "$file_b" "$TMPDIR_SCAN/adr-constrained-set.txt" 2>/dev/null && b_constrained=1
+
+            # Case: A constrained, B not — B is the gravity signal
+            if [[ "$a_constrained" -gt 0 && "$b_constrained" -eq 0 ]]; then
+                if ! echo "$file_b" | grep -qE "$TEST_PATTERN"; then
+                    awk -F'|' -v f="$file_a" '$2 == f {print $1}' "$TMPDIR_SCAN/adr-slug-files.txt" \
+                        | while IFS= read -r slug; do
+                            echo "$slug|$file_b|$file_a|$count"
+                        done >> "$TMPDIR_SCAN/adr-gravity-raw.txt"
+                fi
+            fi
+
+            # Case: B constrained, A not — A is the gravity signal
+            if [[ "$b_constrained" -gt 0 && "$a_constrained" -eq 0 ]]; then
+                if ! echo "$file_a" | grep -qE "$TEST_PATTERN"; then
+                    awk -F'|' -v f="$file_b" '$2 == f {print $1}' "$TMPDIR_SCAN/adr-slug-files.txt" \
+                        | while IFS= read -r slug; do
+                            echo "$slug|$file_a|$file_b|$count"
+                        done >> "$TMPDIR_SCAN/adr-gravity-raw.txt"
+                fi
+            fi
+        done < "$TMPDIR_SCAN/co-change.txt"
+    fi
+
+    # ── Analysis 3d: Classify gravity → signals vs hub files ─────────────────
+    # Hub files (3+ ADRs) are fragility/test-coverage concerns, not attributed
+    # to any single ADR. High gravity on a single ADR (5+ unconstrained files)
+    # suggests a boundary/isolation problem worth architect review.
+
+    if [[ -s "$TMPDIR_SCAN/adr-gravity-raw.txt" ]]; then
+        # Count distinct ADR slugs per unconstrained file
+        awk -F'|' '{print $1 "|" $2}' "$TMPDIR_SCAN/adr-gravity-raw.txt" \
+            | sort -u \
+            | cut -d'|' -f2 | sort | uniq -c | sort -rn \
+            > "$TMPDIR_SCAN/gravity-adr-counts.txt"
+
+        # Hub files: unconstrained files co-changing with 3+ ADRs
+        awk '$1 >= 3' "$TMPDIR_SCAN/gravity-adr-counts.txt" \
+            | while read -r adr_count uncon_file; do
+                slugs=$(awk -F'|' -v f="$uncon_file" '$2 == f {print $1}' "$TMPDIR_SCAN/adr-gravity-raw.txt" \
+                    | sort -u | tr '\n' ',' | sed 's/,$//')
+                echo "HUB|$uncon_file|$adr_count|$slugs" >> "$TMPDIR_SCAN/hub-files.txt"
+            done
+
+        # Build set of hub files for filtering
+        awk '$1 >= 3 {$1=""; print $0}' "$TMPDIR_SCAN/gravity-adr-counts.txt" \
+            | sed 's/^ //' > "$TMPDIR_SCAN/hub-set.txt" 2>/dev/null || true
+
+        # Gravity signals: non-hub unconstrained files
+        while IFS='|' read -r slug uncon_file constrained co_count; do
+            if ! grep -qxF "$uncon_file" "$TMPDIR_SCAN/hub-set.txt" 2>/dev/null; then
+                echo "GRAVITY|$slug|$uncon_file|$constrained|$co_count"
+            fi
+        done < "$TMPDIR_SCAN/adr-gravity-raw.txt" \
+            | sort -u >> "$TMPDIR_SCAN/adr-gravity.txt"
+
+        sort -t'|' -k5 -rn "$TMPDIR_SCAN/adr-gravity.txt" -o "$TMPDIR_SCAN/adr-gravity.txt" 2>/dev/null || true
+        sort -t'|' -k3 -rn "$TMPDIR_SCAN/hub-files.txt" -o "$TMPDIR_SCAN/hub-files.txt" 2>/dev/null || true
+    fi
+fi
+
 # ── Analysis 4: Identify orphaned files (high churn, no artifact coverage) ───
 
 > "$TMPDIR_SCAN/orphaned.txt"
@@ -411,6 +543,45 @@ if [[ -s "$TMPDIR_SCAN/artifact-hits.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# ADR Pressure
+if [[ -s "$TMPDIR_SCAN/adr-pressure.txt" ]]; then
+    echo "## ADR Pressure" >> "$SUMMARY_FILE"
+    echo "Decisions with concentrated file changes (2+ constrained files changed):" >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| ADR | Changed | Total | Pressure |" >> "$SUMMARY_FILE"
+    echo "|-----|---------|-------|----------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ slug changed total pct; do
+        echo "| $slug | $changed | $total | ${pct}% |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/adr-pressure.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+# ADR Gravity
+if [[ -s "$TMPDIR_SCAN/adr-gravity.txt" ]]; then
+    echo "## ADR Gravity" >> "$SUMMARY_FILE"
+    echo "Files co-changing with ADR-constrained files but not in the ADR's scope:" >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| ADR | Unconstrained File | Co-changes With | Count |" >> "$SUMMARY_FILE"
+    echo "|-----|-------------------|-----------------|-------|" >> "$SUMMARY_FILE"
+    head -20 "$TMPDIR_SCAN/adr-gravity.txt" | while IFS='|' read -r _ slug uncon constrained co_count; do
+        echo "| $slug | $uncon | $constrained | $co_count |" >> "$SUMMARY_FILE"
+    done
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+# Hub Files
+if [[ -s "$TMPDIR_SCAN/hub-files.txt" ]]; then
+    echo "## Hub Files" >> "$SUMMARY_FILE"
+    echo "Files co-changing with 3+ ADRs' constrained files (fragility/test-coverage concern):" >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| File | ADR Count | ADRs |" >> "$SUMMARY_FILE"
+    echo "|------|-----------|------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ file adr_count slugs; do
+        echo "| $file | $adr_count | $slugs |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/hub-files.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # Orphaned high-churn files
 if [[ -s "$TMPDIR_SCAN/orphaned.txt" ]]; then
     echo "## Orphaned Areas (no KB/ADR/feature coverage)" >> "$SUMMARY_FILE"
@@ -485,6 +656,9 @@ echo "Summary written to: $SUMMARY_FILE"
 echo "  Churn hotspots: $(wc -l < "$TMPDIR_SCAN/churn.txt" 2>/dev/null || echo 0)"
 echo "  Co-change clusters: $(wc -l < "$TMPDIR_SCAN/co-change.txt" 2>/dev/null || echo 0)"
 echo "  Artifact correlations: $(wc -l < "$TMPDIR_SCAN/artifact-hits.txt" 2>/dev/null || echo 0)"
+echo "  ADR pressure: $(wc -l < "$TMPDIR_SCAN/adr-pressure.txt" 2>/dev/null || echo 0)"
+echo "  ADR gravity signals: $(wc -l < "$TMPDIR_SCAN/adr-gravity.txt" 2>/dev/null || echo 0)"
+echo "  Hub files: $(wc -l < "$TMPDIR_SCAN/hub-files.txt" 2>/dev/null || echo 0)"
 echo "  Orphaned areas: $(wc -l < "$TMPDIR_SCAN/orphaned.txt" 2>/dev/null || echo 0)"
 echo "  Stale KB entries: $(wc -l < "$TMPDIR_SCAN/stale-kb.txt" 2>/dev/null || echo 0)"
 echo "  ADRs to revisit: $(wc -l < "$TMPDIR_SCAN/adr-revisit.txt" 2>/dev/null || echo 0)"

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -10,10 +10,13 @@ to find things that individual features, decisions, and research sessions
 couldn't see because they each had a narrower scope.
 
 **What it finds:**
-1. ADR drift — code diverging from architectural decisions
-2. Stale KB — research that may have better approaches now given what's been built
-3. Implicit dependencies — gaps between independently-designed features
-4. Orphaned areas — high-churn files with no structured knowledge behind them
+1. ADR pressure — decisions under concentrated change (scope being actively modified)
+2. ADR gravity — files implicitly related to decisions but not in their scope
+3. Hub files — shared dependencies across 3+ decisions (fragility/test concerns)
+4. ADR drift — code diverging from architectural decisions
+5. Stale KB — research that may have better approaches now given what's been built
+6. Implicit dependencies — gaps between independently-designed features
+7. Orphaned areas — high-churn files with no structured knowledge behind them
 
 **Flags:**
 - `--init` — first-time scan (ignores last-scanned SHA, good for new installs)
@@ -85,11 +88,32 @@ Also read (if they exist):
 
 ### 2a — ADR drift detection
 
-For each entry in "Artifact Correlations" where Type is ADR:
-1. Read the referenced ADR file
-2. Compare the ADR's stated approach against the changed files
+**ADR Pressure** (from "ADR Pressure" in scan summary):
+1. ADRs with 2+ constrained files changed in the scan window
+2. Higher pressure % = more of the decision's scope is actively changing
+3. Read the ADR and assess: is the code evolving within the decision, or away from it?
+4. High pressure (>60%) → strong signal for re-evaluation
+
+**ADR Gravity** (from "ADR Gravity" in scan summary):
+1. Files that co-change with ADR-constrained files but aren't in the ADR's scope
+2. These are implicit relationships — the decision's influence is wider than documented
+3. Assess: should these files be added to the ADR's `files:` field, or is the
+   co-change coincidental?
+4. High gravity (5+ unconstrained files for one ADR) → potential **isolation problem**.
+   The decision may have drawn the boundary in the wrong place. Flag for `/architect`
+   review with framing: "This decision's actual dependency footprint is larger than
+   its documented scope — worth re-evaluating the boundary."
+
+**Hub Files** (from "Hub Files" in scan summary):
+1. Files co-changing with 3+ ADRs' constrained areas
+2. These are fragility points — changes here ripple across multiple decisions
+3. Flag as test coverage concerns: "This file is a shared dependency across
+   <N> architectural decisions. Worth ensuring test coverage is solid."
+
+**Flat artifact correlations** (from "Artifact Correlations" where Type is ADR):
+1. Individual ADR file references not captured by pressure (single-file changes)
+2. Read the referenced ADR, compare stated approach against changed files
 3. Check if "Conditions for Revision" have been met by recent changes
-4. Flag if code appears to be diverging from the decision
 
 ### 2b — KB + hindsight review
 
@@ -181,16 +205,26 @@ I scanned <N> commits since last review and found <N> items:
   1. <Index/integrity issue> — <what's broken and impact>
      → I'll fix this now (no confirmation needed, it's bookkeeping)
 
-  2. <ADR slug> — <what changed and why the decision may not fit>
+  2. <ADR slug> — <N>% pressure (<M> of <T> constrained files changed)
+     → I'll compare the current code against this decision
+
+  3. <ADR slug> — <N> unconstrained files co-changing with its scope
+     → This decision's boundary may not match the actual dependencies.
+       I'll review the isolation.
+
+  4. <Hub file> — shared across <N> decisions (<slugs>)
+     → I'll check test coverage for this shared dependency
+
+  5. <ADR slug> — <what changed and why the decision may not fit>
      → I'll re-evaluate this decision against the current codebase
 
-  3. <KB entry> — last researched <date>, <what's changed since>
+  6. <KB entry> — last researched <date>, <what's changed since>
      → I'll refresh this research with current implementation context
 
-  4. <Shared files> — touched by <feature A> and <feature B>, no cross-coverage
+  7. <Shared files> — touched by <feature A> and <feature B>, no cross-coverage
      → I'll explore the interaction and flag anything missed
 
-  5. <Orphaned files> — <N> commits, no KB or decision coverage
+  8. <Orphaned files> — <N> commits, no KB or decision coverage
      → I'll research this area so future work has context
 
 Pick a number to start, or:
@@ -248,6 +282,28 @@ Execute the action for that item:
 
 **Index/integrity fixes:** Fix directly — rebuild indexes, clean up stale
 entries. These are bookkeeping and don't need architectural judgment.
+
+**ADR pressure:** Read the ADR file, then compare the decision's stated approach
+against the changed constrained files. Present a summary: "This decision
+constrains <N> files and <M> have changed. Here's what shifted: <brief
+description>." Offer: "Want me to run a full re-evaluation via /architect?"
+
+**ADR gravity (low, <5 files):** Read the ADR and the unconstrained files.
+Assess whether the relationship is meaningful or coincidental. If meaningful:
+"These files appear to be implicitly part of this decision's scope. Want me
+to add them to the ADR's files: field?" If coincidental: note and move on.
+
+**ADR gravity (high, 5+ files) — isolation concern:** This is a boundary
+problem, not just missing file tags. Invoke `/architect "<ADR-slug> boundary
+review"`. Provide context: "This decision's actual dependency footprint is
+significantly wider than documented — <N> unconstrained files co-change with
+its scope. The boundary may need redrawing."
+
+**Hub files:** Read the hub file and the ADRs it's connected to. Assess test
+coverage: does the file have tests that cover its interaction with each
+decision's constrained area? Flag gaps. This is not an `/architect` issue —
+it's a test coverage concern. Present: "This file is shared across <N>
+decisions. Current test coverage: <assessment>."
 
 **ADR drift:** Invoke `/architect "<problem>"` as a review session.
 Provide context: "This was originally decided on <date> because <reason>. The

--- a/skills/feature-domains/SKILL.md
+++ b/skills/feature-domains/SKILL.md
@@ -134,18 +134,34 @@ Read `brief.md` in full. Identify distinct technical domains — areas where an
 architectural or research decision is needed. Not every concept, only ones that
 require a choice or have research depth worth capturing.
 
+### Research commissions from scoping
+
+Check the `## Research Commissions` section of `brief.md`. If it contains
+entries, each one becomes a domain pre-classified as `pending-research`. These
+represent uncertainty the user expressed during scoping that was captured as a
+research signal rather than deferred.
+
+Add research commission domains to the domain list alongside domains you
+identify from the brief's technical content. Do not duplicate — if a research
+commission overlaps with a domain you would have extracted anyway, merge them
+(the commission's key questions and purpose enrich the domain).
+
 Display:
 ```
 ── Identifying domains ─────────────────────────
 Domains identified:
   1. <Domain> — <one sentence: what decision or research is needed>
   2. <Domain> — ...
+  📋 <n> research commission(s) from scoping included.
 Checking KB and decisions store for each.
 ```
 
+If no research commissions: omit the commission line.
+
 Initialise the Domain Resolution Tracker in status.md with all identified
-domains set to `pending`. Write this before doing any lookups so a crash
-here doesn't lose the domain list.
+domains set to `pending`. Research commission domains start as `pending-research`
+rather than `pending`. Write this before doing any lookups so a crash here
+doesn't lose the domain list.
 
 ---
 

--- a/skills/feature/SKILL.md
+++ b/skills/feature/SKILL.md
@@ -155,6 +155,27 @@ before moving to Q3. Depth on one question is better than breadth across all.
 Record any discussion points that affect the brief as you go — don't rely
 on reconstructing them at brief-writing time.
 
+### Recognising research signals in user answers
+
+When the user responds with uncertainty about a topic that could influence the
+design — phrases like "I'm not sure," "I don't know," "might be worth
+investigating," "my feeling is," or similar hedging — treat this as a
+**research signal**, not a deferral.
+
+**Do not** put research signals in "Explicit Out of Scope" or "Open Assumptions."
+Those sections are dead ends — the Domain Scout may never surface them as domains.
+
+**Instead**, capture each research signal in the brief's `## Research Commissions`
+section with:
+- **Topic** — what needs investigating
+- **Key questions** — the specific unknowns the user expressed
+- **Purpose** — how findings would influence the design of this feature
+
+The scoping agent does not do research — it captures the signal so the Domain
+Scout can commission it during domain analysis. When in doubt about whether
+something is a deferral or a research signal, ask the user: "Would it help to
+research this before we design, or is it safe to defer?"
+
 ---
 
 ## Step 3 — Present the brief for confirmation
@@ -172,7 +193,7 @@ SUMMARY
 
 ACTORS / INPUTS / OUTPUTS & SIDE EFFECTS / BUSINESS RULES /
 ERROR CASES / EXPLICIT OUT OF SCOPE / ACCEPTANCE CRITERIA /
-OPEN ASSUMPTIONS / PERFORMANCE EXPECTATIONS
+OPEN ASSUMPTIONS / RESEARCH COMMISSIONS / PERFORMANCE EXPECTATIONS
 ───────────────────────────────────────────────
 Does this capture it correctly? Confirm or tell me what to change.
 ```
@@ -360,6 +381,11 @@ status: "scoped"
 ## Explicit Out of Scope
 ## Acceptance Criteria
 ## Open Assumptions
+## Research Commissions
+<!-- Topics where user expressed uncertainty that could influence the design.
+     Each entry: Topic, Key questions, Purpose (how findings affect this feature).
+     Domain Scout will commission /research for each during domain analysis.
+     If none: "None — no research signals identified during scoping." -->
 ## Performance Expectations
 
 ## Project Context

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -128,6 +128,20 @@ For each subject:
 4. Fetch full content from top 3–5 authoritative sources
 5. Record every URL with title and access date — these go in the sources frontmatter
 
+### Fetch discipline
+
+Fetches can hang indefinitely on slow or unresponsive sources. Rules:
+- **Never block on a single fetch.** If a fetch hasn't returned within ~30
+  seconds, move on. The research can proceed with the sources that did respond.
+- **Prefer smaller pages.** Arxiv HTML versions, GitHub wiki pages, and
+  documentation sites are usually fast. Avoid fetching large PDFs, full
+  repository archives, or pages that require JavaScript rendering.
+- **3 sources is enough.** Don't fetch 5 sources if 3 gave you what you need.
+  Each additional fetch is a timeout risk for diminishing return.
+- **If a fetch fails or times out:** note the URL in the subject file's sources
+  as `(not fetched — timeout/error)` so future research knows to try again or
+  use a different source. Do not retry in the same session.
+
 ---
 
 ## Step 3 — Write subject files

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -14,6 +14,12 @@
 # - Handles incremental scanning (picks up new commits)
 # - Respects --window flag
 # - Handles non-git directories gracefully
+# - Detects ADR pressure (2+ constrained files changed)
+# - Detects ADR gravity (unconstrained files co-changing with ADR scope)
+# - Excludes test files from gravity signals
+# - Detects hub files (co-changing with 3+ ADRs)
+# - Separates hub files from gravity signals
+# - Calculates pressure percentage
 #
 # Run from repo root: bash tests/scenario-curate-scan.sh
 
@@ -404,10 +410,180 @@ else
     fail "scan should complete with large commit filter" "got: $output"
 fi
 
-# ── Test 15: .curate directory auto-created ──────────────────────────────────
+# ── Test 15: ADR Pressure ────────────────────────────────────────────────────
 
 echo ""
-echo "── Test 15: .curate directory auto-created"
+echo "── Test 15: ADR Pressure"
+
+# session-storage ADR constrains session.ts and middleware.ts — both changed
+cd "$PROJECT" && bash .claude/scripts/curate-scan.sh --init >/dev/null 2>&1
+
+if grep -q "ADR Pressure" "$PROJECT/.curate/scan-summary.md"; then
+    pass "ADR Pressure section present"
+else
+    fail "ADR Pressure section should appear (session-storage has 2+ changed files)"
+fi
+
+if grep -q "session-storage" "$PROJECT/.curate/scan-summary.md" | head -1 && \
+   sed -n '/## ADR Pressure/,/^## /p' "$PROJECT/.curate/scan-summary.md" | grep -q "session-storage"; then
+    pass "session-storage ADR appears in pressure table"
+else
+    fail "session-storage should be under pressure (both constrained files changed)"
+fi
+
+# ── Test 16: ADR Gravity ────────────────────────────────────────────────────
+
+echo ""
+echo "── Test 16: ADR Gravity"
+
+# lib/db.ts co-changes with src/auth/session.ts (4 commits together)
+# session.ts is constrained by session-storage ADR, db.ts is not
+# → db.ts should be a gravity signal for session-storage
+
+gravity_section="$(sed -n '/## ADR Gravity/,/^## /p' "$PROJECT/.curate/scan-summary.md")"
+if [[ -n "$gravity_section" ]]; then
+    pass "ADR Gravity section present"
+else
+    fail "ADR Gravity section should appear (db.ts co-changes with ADR-constrained session.ts)"
+fi
+
+if echo "$gravity_section" | grep -q "db.ts"; then
+    pass "db.ts identified as gravity signal for session-storage"
+else
+    fail "db.ts should be gravitationally linked to session-storage ADR"
+fi
+
+# ── Test 17: Test files excluded from gravity ───────────────────────────────
+
+echo ""
+echo "── Test 17: Test files excluded from gravity"
+
+# Create a test file that co-changes with auth files
+mkdir -p "$PROJECT/tests"
+for i in $(seq 1 4); do
+    echo "// test change $i" >> "$PROJECT/tests/session.test.ts"
+    echo "// paired $i" >> "$PROJECT/src/auth/session.ts"
+    git -C "$PROJECT" add -A
+    git -C "$PROJECT" commit -m "test + session $i" >/dev/null 2>&1
+done
+
+cd "$PROJECT" && bash .claude/scripts/curate-scan.sh --init >/dev/null 2>&1
+
+gravity_section="$(sed -n '/## ADR Gravity/,/^## /p' "$PROJECT/.curate/scan-summary.md")"
+if echo "$gravity_section" | grep -q "session.test.ts"; then
+    fail "test files should be excluded from gravity (unconstrained side)"
+else
+    pass "test files correctly excluded from gravity signals"
+fi
+
+# ── Test 18: Hub file detection ─────────────────────────────────────────────
+
+echo ""
+echo "── Test 18: Hub file detection"
+
+# Create two more ADRs constraining different files
+mkdir -p "$PROJECT/.decisions/billing-model"
+cat > "$PROJECT/.decisions/billing-model/adr.md" << 'EOF'
+---
+problem: "billing-model"
+date: "2026-03-01"
+status: "confirmed"
+---
+
+# ADR — Billing Model
+
+## Files Constrained by This Decision
+- src/billing/stripe.ts
+
+## Decision
+Use Stripe for payments.
+EOF
+
+mkdir -p "$PROJECT/.decisions/db-connection"
+cat > "$PROJECT/.decisions/db-connection/adr.md" << 'EOF'
+---
+problem: "db-connection"
+date: "2026-03-01"
+status: "confirmed"
+---
+
+# ADR — DB Connection
+
+## Files Constrained by This Decision
+- lib/db.ts
+
+## Decision
+Use connection pooling.
+EOF
+
+git -C "$PROJECT" add -A
+git -C "$PROJECT" commit -m "add billing and db ADRs" >/dev/null 2>&1
+
+# Create a shared config file that co-changes with files from all 3 ADRs
+echo "config = {}" > "$PROJECT/src/config.ts"
+git -C "$PROJECT" add -A
+git -C "$PROJECT" commit -m "add config" >/dev/null 2>&1
+
+for i in $(seq 1 4); do
+    echo "// config $i" >> "$PROJECT/src/config.ts"
+    echo "// auth cfg $i" >> "$PROJECT/src/auth/session.ts"
+    git -C "$PROJECT" add -A
+    git -C "$PROJECT" commit -m "config + auth $i" >/dev/null 2>&1
+done
+
+for i in $(seq 1 4); do
+    echo "// config billing $i" >> "$PROJECT/src/config.ts"
+    echo "// billing cfg $i" >> "$PROJECT/src/billing/stripe.ts"
+    git -C "$PROJECT" add -A
+    git -C "$PROJECT" commit -m "config + billing $i" >/dev/null 2>&1
+done
+
+for i in $(seq 1 4); do
+    echo "// config db $i" >> "$PROJECT/src/config.ts"
+    echo "// db cfg $i" >> "$PROJECT/lib/db.ts"
+    git -C "$PROJECT" add -A
+    git -C "$PROJECT" commit -m "config + db $i" >/dev/null 2>&1
+done
+
+cd "$PROJECT" && bash .claude/scripts/curate-scan.sh --init >/dev/null 2>&1
+
+if grep -q "Hub Files" "$PROJECT/.curate/scan-summary.md"; then
+    pass "Hub Files section present"
+else
+    fail "Hub Files section should appear (config.ts co-changes with 3 ADRs' files)"
+fi
+
+hub_section="$(sed -n '/## Hub Files/,/^## /p' "$PROJECT/.curate/scan-summary.md")"
+if echo "$hub_section" | grep -q "config.ts"; then
+    pass "config.ts identified as hub file"
+else
+    fail "config.ts should be a hub file (co-changes with 3+ ADRs' constrained files)"
+fi
+
+# Hub file should NOT appear in gravity section
+gravity_section="$(sed -n '/## ADR Gravity/,/^## /p' "$PROJECT/.curate/scan-summary.md")"
+if echo "$gravity_section" | grep -q "config.ts"; then
+    fail "hub files should not appear in gravity (they're separated)"
+else
+    pass "hub file correctly excluded from gravity signals"
+fi
+
+# ── Test 19: Pressure percentage ────────────────────────────────────────────
+
+echo ""
+echo "── Test 19: Pressure percentage calculation"
+
+pressure_section="$(sed -n '/## ADR Pressure/,/^## /p' "$PROJECT/.curate/scan-summary.md")"
+if echo "$pressure_section" | grep -q "%"; then
+    pass "pressure percentage is calculated"
+else
+    fail "pressure table should include percentage"
+fi
+
+# ── Test 20: .curate directory auto-created ──────────────────────────────────
+
+echo ""
+echo "── Test 20: .curate directory auto-created"
 
 FRESH="$TEST_BASE/fresh"
 git init --initial-branch=main "$FRESH" >/dev/null 2>&1


### PR DESCRIPTION
## Summary

- **Research signal recognition in scoping** — uncertainty patterns ("I don't know", "not sure") now captured as Research Commissions in the brief instead of buried in out-of-scope. Domain scout auto-commissions `/research` for each.
- **ADR Pressure** — curation detects decisions with 2+ constrained files actively changing, surfaces with pressure percentage for re-evaluation.
- **ADR Gravity** — unconstrained files co-changing with ADR-constrained files reveal implicit relationships. High gravity (5+ files) flags isolation problems for `/architect` boundary review.
- **Hub Files** — files co-changing with 3+ ADRs' constrained areas flagged as fragility/test-coverage concerns. Test files excluded from gravity signals.
- **Research fetch discipline** — agent moves on after ~30s, 3 sources sufficient, no retries in same session.
- **`/decisions backfill` subsumed** — fully covered by `/curate` analyses 3b-3d + analysis 8.
- **Bug fix** — `grep -cxF` under `set -e` produced dual output (grep's 0 + echo 0), breaking gravity detection.

## Test plan

- [x] 33 curate scan tests passing (9 new: pressure, gravity, test exclusion, hub detection, hub/gravity separation, pressure percentage)
- [ ] Dogfood on JLSM — run `/curate --init` to validate pressure/gravity signals on a real project
- [ ] Verify research commission flow end-to-end on next `/feature` session

🤖 Generated with [Claude Code](https://claude.com/claude-code)