### PR TITLE
fix: crash-safe history archive — write before remove

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -589,9 +589,12 @@ If stop: display the manual command and stop.
 2. Create or update `.decisions/<problem-slug>/CLAUDE.md` using the **Problem Index Template**
 3. Update `.decisions/CLAUDE.md` master index:
    - Add the problem to the Active Decisions table
-   - Check "Recently Accepted": if it exceeds 5 rows, move the oldest row to `history.md`
-   - Check total line count: if over 80 lines, continue moving oldest accepted rows to `history.md`
-   - If `history.md` does not exist, create it from the **History File Template** first
+   - Check "Recently Accepted": if it exceeds 5 rows, archive the oldest row.
+     Check total line count: if over 80 lines, continue archiving oldest accepted rows.
+     **Archive order (crash-safe):**
+     1. If `history.md` does not exist, create it from the **History File Template** first
+     2. Append the row to `history.md` (write-first — survives crash)
+     3. Remove the row from `CLAUDE.md`
    - Ensure `Archived: [history.md](history.md)` pointer line is present
 
 ---

--- a/skills/decisions/SKILL.md
+++ b/skills/decisions/SKILL.md
@@ -415,8 +415,9 @@ Deferred remaining: <n>
 If the Deferred section is now empty, add a `<!-- Last cleared: YYYY-MM-DD -->`
 comment to that section in `.decisions/CLAUDE.md`.
 
-Check total line count: if over 80 lines, move oldest Recently Accepted rows
-to `history.md` (same rule as `/architect` Step 7).
+Check total line count: if over 80 lines, archive oldest Recently Accepted rows
+to `history.md` (same crash-safe order as `/architect` Step 7: create history.md
+if needed → append row to history.md → remove row from CLAUDE.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- Archive operation for decisions CLAUDE.md → history.md now explicitly ordered: write to history.md first, then remove from CLAUDE.md
- Previously the order was unspecified — a crash between operations could lose the row entirely
- Fixed in both `/architect` Step 7 and `/decisions` review

## Found via

JLSM stress test — Recently Accepted hit 6 entries (max 5), triggering the archive path.

## Test plan

- [ ] Run `/architect` on a problem that pushes Recently Accepted past 5 rows — verify history.md is written before CLAUDE.md row removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)