### PR TITLE
feat: effort tuning + PreCompact crash recovery

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -110,6 +110,7 @@
 .claude/scripts/subagent-hook.py
 .claude/scripts/subagent-hook.js
 .claude/scripts/subagent-hook-wrapper.sh
+.claude/scripts/precompact-hook.sh
 .claude/scripts/uninstall.sh
 .claude/scripts/spec-lib.sh
 .claude/scripts/spec-validate.sh

--- a/agents/research-agent.md
+++ b/agents/research-agent.md
@@ -22,7 +22,7 @@ Claude Code's native lazy-loading memory system.
 - Always update CLAUDE.md indexes bottom-up after writing:
   category CLAUDE.md → topic CLAUDE.md → .kb/CLAUDE.md
 - Never overwrite an existing subject file — append ## Updates YYYY-MM-DD instead.
-- Keep subject files under 200 lines; extract overflow to <subject>-detail.md with @import.
+- Aim for subject files under 200 lines. Up to 300 is fine if the content is dense and useful. Above 300, extract to <subject>-detail.md with @import.
 - Record every source URL with an accessed date in the file's sources frontmatter.
 - Cross-link all new articles to each other and update existing related entries.
 

--- a/install.sh
+++ b/install.sh
@@ -288,6 +288,7 @@ install_file "$SCRIPT_DIR/scripts/subagent-hook.sh" "$TARGET/.claude/scripts/sub
 install_file "$SCRIPT_DIR/scripts/subagent-hook.py" "$TARGET/.claude/scripts/subagent-hook.py"
 install_file "$SCRIPT_DIR/scripts/subagent-hook.js" "$TARGET/.claude/scripts/subagent-hook.js"
 install_file "$SCRIPT_DIR/scripts/subagent-hook-wrapper.sh" "$TARGET/.claude/scripts/subagent-hook-wrapper.sh"
+install_file "$SCRIPT_DIR/scripts/precompact-hook.sh" "$TARGET/.claude/scripts/precompact-hook.sh"
 install_file "$SCRIPT_DIR/scripts/uninstall.sh" "$TARGET/.claude/scripts/uninstall.sh"
 install_file "$SCRIPT_DIR/scripts/spec-lib.sh" "$TARGET/.claude/scripts/spec-lib.sh"
 install_file "$SCRIPT_DIR/scripts/spec-validate.sh" "$TARGET/.claude/scripts/spec-validate.sh"
@@ -452,6 +453,22 @@ HOOKJSON
         echo -e "  ${GREEN}merge${NC} SubagentStart/SubagentStop hooks added to settings.json"
     elif [[ -f "$SETTINGS_FILE" ]]; then
         echo -e "  ${YELLOW}skip${NC}  settings.json exists but jq not available — add subagent hooks manually"
+    fi
+
+    # ── PreCompact hook for crash recovery ───────────────────────────
+    PRECOMPACT_MARKER="precompact-hook"
+    if [[ -f "$SETTINGS_FILE" ]] && grep -qF "$PRECOMPACT_MARKER" "$SETTINGS_FILE" 2>/dev/null; then
+        echo -e "  ${YELLOW}skip${NC}  PreCompact hook already registered"
+    elif [[ -f "$SETTINGS_FILE" ]] && command -v jq &>/dev/null; then
+        jq '.hooks.PreCompact = ((.hooks.PreCompact // []) + [{
+            "hooks": [{
+                "type": "command",
+                "command": "bash .claude/scripts/precompact-hook.sh"
+            }]
+        }])' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
+        echo -e "  ${GREEN}merge${NC} PreCompact hook added to settings.json"
+    elif [[ -f "$SETTINGS_FILE" ]]; then
+        echo -e "  ${YELLOW}skip${NC}  settings.json exists but jq not available — add PreCompact hook manually"
     fi
 
     # ── Migrate old direct script references to wrappers ─────────────

--- a/scripts/precompact-hook.sh
+++ b/scripts/precompact-hook.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# vallorcine PreCompact hook — checkpoint feature state before context compaction
+# Performance: <5ms (2 stat() calls + 1 file copy)
+#
+# Fires before Claude Code compacts the conversation context. Copies the
+# active feature's status.md to .status-checkpoint.md so /feature-resume
+# can recover after overflow.
+
+cat > /dev/null  # consume stdin (required by hooks)
+
+# Find active feature directory (skip archived)
+ACTIVE=""
+for d in .feature/*/; do
+    [[ -f "$d/status.md" ]] || continue
+    stage=$(grep -m1 '^stage:' "$d/status.md" 2>/dev/null | sed 's/stage: *//')
+    [[ "$stage" == "archived" ]] && continue
+    ACTIVE="$d"
+    break
+done
+
+[[ -z "$ACTIVE" ]] && exit 0
+
+# Checkpoint: atomic write via tmp + rename
+cp "$ACTIVE/status.md" "$ACTIVE/.status-checkpoint.md.tmp" 2>/dev/null \
+    && mv "$ACTIVE/.status-checkpoint.md.tmp" "$ACTIVE/.status-checkpoint.md" 2>/dev/null
+
+exit 0

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: "Run adversarial audit pipeline against shipped code"
 argument-hint: "<entry-point>"
+effort: high
 ---
 
 # /audit "<entry-point>"

--- a/skills/feature-harden/SKILL.md
+++ b/skills/feature-harden/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: "Adversarial test hardening — domain-lens behavioral attacks on contracts before implementation"
 argument-hint: "<feature-slug> [--unit <WU-N>] [--lite]"
+effort: high
 ---
 
 # /feature-harden "<feature-slug>" [--unit <WU-N>] [--lite]

--- a/skills/spec-author/SKILL.md
+++ b/skills/spec-author/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: "Author a hardened spec through two-pass adversarial review"
 argument-hint: "<feature-id> <title>"
+effort: high
 ---
 
 # /spec-author <feature-id> <title>

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 description: "Verify a spec against its implementation"
 argument-hint: "<feature-id>"
+effort: high
 ---
 
 # /spec-verify <feature-id>


### PR DESCRIPTION
## Summary

- **Effort tuning** — `effort: high` on 4 adversarial skills (audit, feature-harden, spec-author, spec-verify) where deeper reasoning directly improves bug-finding quality. All other skills remain at session default.
- **PreCompact hook** — checkpoints active feature's status.md before context compaction so `/feature-resume` can recover after overflow. <5ms, pure bash.
- **KB article line limit relaxed** — soft target 200, hard limit 300 (was hard 200). Prevents unnecessary article splits on dense research output.

## Test plan

- [x] `bash tests/test-install.sh` — 0 failures
- [x] Only 4 skills have `effort: high` (grep verified)
- [x] PreCompact hook tested manually — creates `.status-checkpoint.md` from active feature
- [x] MANIFEST entry resolves to actual file

🤖 Generated with [Claude Code](https://claude.com/claude-code)