### PR TITLE
feat: explicit WD lifecycle phases

### DIFF
--- a/scripts/work-resolve.sh
+++ b/scripts/work-resolve.sh
@@ -4,8 +4,9 @@
 # Output: markdown readiness report on stdout | diagnostics on stderr
 #
 # Walks all WDs in a work group, cross-references their artifact_deps against
-# actual artifact states, and reports which are READY, BLOCKED, IN_PROGRESS,
-# or COMPLETE.
+# actual artifact states, and reports which are READY, BLOCKED, SPECIFYING,
+# SPECIFIED, IMPLEMENTING, or COMPLETE.
+# Legacy: IN_PROGRESS is treated as IMPLEMENTING for backwards compatibility.
 #
 # Readiness is computed each invocation — never cached.
 
@@ -47,7 +48,9 @@ declare -A WD_DEP_COUNT # id -> number of artifact deps
 
 READY_COUNT=0
 BLOCKED_COUNT=0
-IN_PROGRESS_COUNT=0
+SPECIFYING_COUNT=0
+SPECIFIED_COUNT=0
+IMPLEMENTING_COUNT=0
 COMPLETE_COUNT=0
 TOTAL_COUNT=0
 
@@ -69,20 +72,32 @@ while IFS= read -r wd_file; do
   WD_BLOCKERS["$wd_id"]=""
   ((TOTAL_COUNT++)) || true
 
-  # If already COMPLETE or IN_PROGRESS, respect the declared status
+  # Respect declared phase statuses — no recomputation needed
   if [[ "$wd_status" == "COMPLETE" ]]; then
     WD_STATUS["$wd_id"]="COMPLETE"
     ((COMPLETE_COUNT++)) || true
     continue
   fi
 
-  if [[ "$wd_status" == "IN_PROGRESS" ]]; then
-    WD_STATUS["$wd_id"]="IN_PROGRESS"
-    ((IN_PROGRESS_COUNT++)) || true
+  if [[ "$wd_status" == "IMPLEMENTING" || "$wd_status" == "IN_PROGRESS" ]]; then
+    WD_STATUS["$wd_id"]="IMPLEMENTING"
+    ((IMPLEMENTING_COUNT++)) || true
     continue
   fi
 
-  # For DRAFT, SPECIFIED, READY, or BLOCKED: compute readiness from deps
+  if [[ "$wd_status" == "SPECIFYING" ]]; then
+    WD_STATUS["$wd_id"]="SPECIFYING"
+    ((SPECIFYING_COUNT++)) || true
+    continue
+  fi
+
+  if [[ "$wd_status" == "SPECIFIED" ]]; then
+    WD_STATUS["$wd_id"]="SPECIFIED"
+    ((SPECIFIED_COUNT++)) || true
+    continue
+  fi
+
+  # For DRAFT: compute readiness from deps
   blockers=""
   dep_count=0
 
@@ -124,7 +139,7 @@ while IFS= read -r wd_file; do
 
 done < <(work_list_wds "$GROUP_DIR")
 
-echo "[resolve] Group: $GROUP_SLUG — $TOTAL_COUNT WDs ($READY_COUNT ready, $BLOCKED_COUNT blocked, $IN_PROGRESS_COUNT in progress, $COMPLETE_COUNT complete)" >&2
+echo "[resolve] Group: $GROUP_SLUG — $TOTAL_COUNT WDs ($READY_COUNT ready, $BLOCKED_COUNT blocked, $SPECIFYING_COUNT specifying, $SPECIFIED_COUNT specified, $IMPLEMENTING_COUNT implementing, $COMPLETE_COUNT complete)" >&2
 
 # ── Build dependency graph ───────────────────────────────────────────────────
 # For each WD, check if its produces match another WD's artifact_deps.
@@ -159,7 +174,7 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 cat <<EOF
 # Work Group Readiness: $GROUP_SLUG
 Generated: $TIMESTAMP
-Total: $TOTAL_COUNT | Ready: $READY_COUNT | Blocked: $BLOCKED_COUNT | In Progress: $IN_PROGRESS_COUNT | Complete: $COMPLETE_COUNT
+Total: $TOTAL_COUNT | Ready: $READY_COUNT | Blocked: $BLOCKED_COUNT | Specifying: $SPECIFYING_COUNT | Specified: $SPECIFIED_COUNT | Implementing: $IMPLEMENTING_COUNT | Complete: $COMPLETE_COUNT
 
 ## Status
 
@@ -167,8 +182,8 @@ Total: $TOTAL_COUNT | Ready: $READY_COUNT | Blocked: $BLOCKED_COUNT | In Progres
 |----|-------|--------|------|----------|
 EOF
 
-# Sort by status priority: READY first, then BLOCKED, IN_PROGRESS, COMPLETE
-for status_phase in READY BLOCKED IN_PROGRESS COMPLETE; do
+# Sort by status priority: actionable first
+for status_phase in READY BLOCKED SPECIFYING SPECIFIED IMPLEMENTING COMPLETE; do
   for wd_id in $(echo "${!WD_STATUS[@]}" | tr ' ' '\n' | sort); do
     [[ "${WD_STATUS[$wd_id]}" != "$status_phase" ]] && continue
     unblocks="${WD_UNBLOCKS[$wd_id]:-none}"

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -78,18 +78,25 @@ Use AskUserQuestion with options:
 If "Pick a different WD": show READY WDs and let user choose.
 If "Start anyway": proceed to Step 4 with a warning logged.
 
-If IN_PROGRESS: check if a feature directory already exists for this WD:
+If SPECIFYING: check if a feature directory already exists for this WD:
 ```
-WD-<nn> is already IN_PROGRESS.
+WD-<nn> is already being specified.
 Feature directory: .feature/<group>--<wd-slug>/
 
 Resume with: /feature-resume "<group>--<wd-slug>"
 ```
 Stop.
 
-If COMPLETE:
+If SPECIFIED:
 ```
-WD-<nn> is already COMPLETE. Nothing to do.
+WD-<nn> is already specified. Ready for implementation:
+  /work-start "<group-slug>" WD-<nn>
+```
+Stop.
+
+If IMPLEMENTING or COMPLETE:
+```
+WD-<nn> is already past the specification phase. Nothing to do.
 ```
 Stop.
 
@@ -194,7 +201,7 @@ Stage Completion table — specification mode only:
 
 ### 4c — Update WD status
 
-Edit `.work/<group-slug>/WD-<nn>.md` — set `status: IN_PROGRESS`.
+Edit `.work/<group-slug>/WD-<nn>.md` — set `status: SPECIFYING`.
 Update `.work/<group-slug>/manifest.md` — update the WD's status in the table.
 
 ---
@@ -217,9 +224,10 @@ WHAT the system must do as a result. Without specs, the adversarial
 hardening and audit pipeline have nothing to falsify. Do not skip or
 bypass spec authoring for any WD type.
 
-**After spec authoring completes, stop.** Do not proceed to
-`/feature-retro` or `/feature-complete` — those run after implementation.
-Display:
+**After spec authoring completes, stop.** Update the WD status to
+`SPECIFIED` in `.work/<group-slug>/WD-<nn>.md` and the manifest. Do not
+proceed to `/feature-retro` or `/feature-complete` — those run after
+implementation. Display:
 ```
 ───────────────────────────────────────────────
 📝 WORK PLAN complete · <group-slug> / WD-<nn>

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -53,31 +53,26 @@ Display opening header:
 
 ### If specific WD (e.g., WD-01):
 
-Check if the specified WD is READY in the resolver output.
+Check the WD's status in the resolver output.
 
-If READY: proceed to Step 4.
+If SPECIFIED: proceed to Step 4.
 
-If BLOCKED: display the blockers from the resolver output:
+If READY or BLOCKED or SPECIFYING: the WD has not been through `/work-plan` yet.
 ```
-WD-<nn> (<title>) is BLOCKED:
-  - <blocker 1>
-  - <blocker 2>
-
-Unblock by resolving these dependencies first.
+WD-<nn> (<title>) needs specification before implementation.
+Run /work-plan "<group-slug>" WD-<nn> first.
 ```
 Use AskUserQuestion with options:
-  - "Pick a different WD"
   - "Run /work-plan first" (description: "Specify this WD to produce its required artifacts")
-  - "Start anyway (skip readiness check)"
+  - "Start anyway (skip specification)" (description: "Proceed without specs — not recommended")
   - "Stop"
 
-If "Pick a different WD": show READY WDs and let user choose.
 If "Run /work-plan first": invoke `/work-plan "<group-slug>" WD-<nn>`.
 If "Start anyway": proceed to Step 4 with a warning logged.
 
-If IN_PROGRESS: check if a feature directory already exists for this WD:
+If IMPLEMENTING: check if a feature directory already exists for this WD:
 ```
-WD-<nn> is already IN_PROGRESS.
+WD-<nn> is already being implemented.
 Feature directory: .feature/<group>--<wd-slug>/
 
 Resume with: /feature-resume "<group>--<wd-slug>"
@@ -92,24 +87,24 @@ Stop.
 
 ### If "next" (or no WD specified):
 
-From the READY WDs, select the one with the most downstream dependents
+From the SPECIFIED WDs, select the one with the most downstream dependents
 (i.e., the WD whose completion would unblock the most other WDs). This
 maximizes unblocking value.
 
 If multiple WDs tie on unblocking value, prefer the one with fewer
 artifact dependencies (simpler work first).
 
-If no WDs are READY:
+If no WDs are SPECIFIED:
 ```
-No work definitions are READY in '<group-slug>'.
+No work definitions are SPECIFIED in '<group-slug>'.
 
 Status:
-  <blocked>  blocked
-  <in_progress> in progress
+  <ready>  ready (needs /work-plan first)
+  <specifying> specifying
+  <implementing> implementing
   <complete> complete
 
-Unblock by resolving the artifact dependencies shown in:
-  /work-status "<group-slug>"
+Run /work-plan "<group-slug>" to specify a ready WD first.
 ```
 Stop.
 
@@ -203,7 +198,7 @@ Stage Completion table — implementation stages only:
 
 ### 4d — Update WD status
 
-Edit `.work/<group-slug>/WD-<nn>.md` — set `status: IN_PROGRESS`.
+Edit `.work/<group-slug>/WD-<nn>.md` — set `status: IMPLEMENTING`.
 Update `.work/<group-slug>/manifest.md` — update the WD's status in the table.
 
 ---

--- a/skills/work-status/SKILL.md
+++ b/skills/work-status/SKILL.md
@@ -7,7 +7,7 @@ argument-hint: "<group-slug> [--all]"
 
 Shows the readiness state of a work group. Reports which work definitions are
 READY (all artifact dependencies satisfied), BLOCKED (with specific missing
-artifacts), IN_PROGRESS, or COMPLETE.
+artifacts), SPECIFYING, SPECIFIED, IMPLEMENTING, or COMPLETE.
 
 This is the "what can I work on next?" entry point.
 
@@ -32,9 +32,9 @@ If `--all` flag is set:
 📊 WORK STATUS · all groups
 ───────────────────────────────────────────────
 
-| Group | WDs | Ready | Blocked | In Progress | Complete |
-|-------|-----|-------|---------|-------------|----------|
-| <slug> | <n> | <n> | <n> | <n> | <n> |
+| Group | WDs | Ready | Specifying | Specified | Implementing | Complete |
+|-------|-----|-------|------------|-----------|--------------|----------|
+| <slug> | <n> | <n> | <n> | <n> | <n> | <n> |
 ...
 
 Ready to work on:
@@ -153,10 +153,17 @@ Consider running a retrospective on the overall effort:
   /feature-retro for individual features created from this group
 ```
 
-### If WDs are IN_PROGRESS:
+### If WDs are SPECIFYING or IMPLEMENTING:
 ```
-In progress:
-  WD-<nn> (<title>) — resume with /feature-resume "<group>--<wd-slug>"
+Active:
+  WD-<nn> (<title>) — SPECIFYING — resume with /feature-resume "<group>--<wd-slug>"
+  WD-<nn> (<title>) — IMPLEMENTING — resume with /feature-resume "<group>--<wd-slug>"
+```
+
+### If WDs are SPECIFIED:
+```
+Ready for implementation:
+  /work-start "<group-slug>" WD-<nn>   — implement a specified WD
 ```
 
 Stop.


### PR DESCRIPTION
## Summary

Replaces ambiguous `IN_PROGRESS` with explicit phase states:

`DRAFT → READY → SPECIFYING → SPECIFIED → IMPLEMENTING → COMPLETE`

- `/work-plan` sets SPECIFYING on start, SPECIFIED on completion
- `/work-start` requires SPECIFIED (not READY) — can't skip spec phase
- `work-resolve.sh` maps legacy `IN_PROGRESS` → `IMPLEMENTING` automatically — no manual migration needed
- `/work-status` displays all 6 phase states

Fixes: WDs being marked COMPLETE after spec authoring, `/work-start` accepting READY WDs that hadn't been through `/work-plan`.

## Test plan

- [x] `bash tests/test-install.sh` — 0 failures
- [x] No stale `IN_PROGRESS` references in skill files
- [x] `work-resolve.sh` backwards compat: `IN_PROGRESS` → `IMPLEMENTING`
- [x] DRAFT remains initial state in work-decompose and decisions roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)