### PR TITLE
feat: sequential spec authoring + manifest single source of truth

### DIFF
--- a/scripts/kb-freshness-check.sh
+++ b/scripts/kb-freshness-check.sh
@@ -24,6 +24,11 @@ done
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
 [[ "$CURRENT_BRANCH" == "$MAIN_BRANCH" ]] && exit 0
 
+# Skip if the branch is ahead of or at main — differences are our changes,
+# not missing entries. Only warn when main has commits we don't have.
+BEHIND_COUNT="$(git rev-list --count HEAD.."$MAIN_BRANCH" 2>/dev/null || echo "0")"
+[[ "$BEHIND_COUNT" == "0" ]] && exit 0
+
 # Compare each index file against main's version
 stale_files=()
 

--- a/scripts/work-resolve.sh
+++ b/scripts/work-resolve.sh
@@ -167,6 +167,41 @@ for wd_id in "${!WD_FILE[@]}"; do
   done < <(work_fm_produces "${WD_FILE[$wd_id]}")
 done
 
+# ── Sync manifest table (single source of truth: WD frontmatter) ────────────
+
+MANIFEST_FILE="$GROUP_DIR/manifest.md"
+if [[ -f "$MANIFEST_FILE" ]]; then
+  # Build the updated WD table from computed state
+  NEW_TABLE="| WD | Title | Status | Domains | Deps | Produces |"
+  NEW_TABLE+=$'\n'"|----|-------|--------|---------|------|----------|"
+  for wd_id in $(echo "${!WD_FILE[@]}" | tr ' ' '\n' | sort); do
+    wd_file="${WD_FILE[$wd_id]}"
+    domains=$(work_fm "$wd_file" "domains" | tr -d '[]' | sed 's/,/, /g')
+    [[ -z "$domains" ]] && domains="—"
+    dep_count="${WD_DEP_COUNT[$wd_id]}"
+    # Summarize produces
+    produces=""
+    while IFS='|' read -r prod_type prod_path _ prod_kind; do
+      [[ -z "$prod_type" ]] && continue
+      if [[ -n "$produces" ]]; then produces+=", "; fi
+      produces+="$prod_type:$prod_path"
+    done < <(work_fm_produces "$wd_file")
+    [[ -z "$produces" ]] && produces="—"
+    NEW_TABLE+=$'\n'"| $wd_id | ${WD_TITLE[$wd_id]} | ${WD_STATUS[$wd_id]} | $domains | $dep_count | $produces |"
+  done
+
+  # Replace the table in manifest.md between the header row and the next
+  # blank line or section header. Use awk for reliable multi-line replacement.
+  awk -v new_table="$NEW_TABLE" '
+    /^\| WD / { in_table=1; print new_table; next }
+    in_table && /^\|/ { next }
+    in_table && !/^\|/ { in_table=0 }
+    { print }
+  ' "$MANIFEST_FILE" > "$MANIFEST_FILE.tmp" && mv "$MANIFEST_FILE.tmp" "$MANIFEST_FILE"
+
+  echo "[resolve] Synced manifest.md with computed status" >&2
+fi
+
 # ── Emit readiness report ────────────────────────────────────────────────────
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/skills/feature-complete/SKILL.md
+++ b/skills/feature-complete/SKILL.md
@@ -106,11 +106,12 @@ status.md and does not match the `<group>--<wd>` double-dash convention.**
 If this is a work-group-sourced feature:
 
 1. Determine the work group slug (from status.md `work_group` field or slug prefix)
-2. Update `.work/<group>/manifest.md` — set the WD's status to COMPLETE in the table
+2. Verify the WD frontmatter has `status: COMPLETE` (should already be set
+   by the retro step)
 3. Update `.work/CLAUDE.md` — increment the Complete count for this group
 
-This is a bookkeeping step only — the WD status itself should already be COMPLETE
-from the retro step. This updates the index files.
+The manifest table is automatically synced by `work-resolve.sh` — do not
+update it manually.
 
 ---
 

--- a/skills/feature-domains/SKILL.md
+++ b/skills/feature-domains/SKILL.md
@@ -434,6 +434,21 @@ as its primary input.
 
 If "Proceed":
 - Update status.md: Spec Authoring stage → `in-progress`
+
+**If `pipeline_mode: specification` (from `/work-plan`):** stop here.
+Domain analysis is complete. The calling command (`/work-plan`) will
+iterate over the identified specs and invoke `/spec-author` for each
+one sequentially. Display:
+```
+Domain analysis complete. Specs to produce:
+  <list of spec titles and domains from domains.md>
+
+Returning to /work-plan for sequential spec authoring.
+```
+Return control to the caller.
+
+**Otherwise (full or implementation mode):** invoke spec authoring as
+a single pass:
 - Display:
   ```
   Spec infrastructure detected — routing through spec authoring.

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -224,10 +224,20 @@ WHAT the system must do as a result. Without specs, the adversarial
 hardening and audit pipeline have nothing to falsify. Do not skip or
 bypass spec authoring for any WD type.
 
-**After spec authoring completes, stop.** Update the WD status to
-`SPECIFIED` in `.work/<group-slug>/WD-<nn>.md` and the manifest. Do not
-proceed to `/feature-retro` or `/feature-complete` — those run after
-implementation. Display:
+---
+
+## Step 6 — Finalize WD status
+
+After spec authoring completes, update the WD to SPECIFIED:
+
+1. Edit `.work/<group-slug>/WD-<nn>.md` — set `status: SPECIFIED`
+2. Update `.work/<group-slug>/manifest.md` — set the WD's status to
+   SPECIFIED in the Work Definitions table
+
+Do NOT proceed to `/feature-retro` or `/feature-complete` — those run
+after implementation.
+
+Display:
 ```
 ───────────────────────────────────────────────
 📝 WORK PLAN complete · <group-slug> / WD-<nn>

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -202,7 +202,9 @@ Stage Completion table — specification mode only:
 ### 4c — Update WD status
 
 Edit `.work/<group-slug>/WD-<nn>.md` — set `status: SPECIFYING`.
-Update `.work/<group-slug>/manifest.md` — update the WD's status in the table.
+
+The manifest table is automatically synced by `work-resolve.sh` — do not
+update it manually.
 
 ---
 
@@ -231,8 +233,9 @@ bypass spec authoring for any WD type.
 After spec authoring completes, update the WD to SPECIFIED:
 
 1. Edit `.work/<group-slug>/WD-<nn>.md` — set `status: SPECIFIED`
-2. Update `.work/<group-slug>/manifest.md` — set the WD's status to
-   SPECIFIED in the Work Definitions table
+
+The manifest table is automatically synced by `work-resolve.sh` — do not
+update it manually.
 
 Do NOT proceed to `/feature-retro` or `/feature-complete` — those run
 after implementation.

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -208,16 +208,24 @@ update it manually.
 
 ---
 
-## Step 5 — Hand off to pipeline
+## Step 5 — Domain analysis
 
 ```
 Feature directory created: .feature/<slug>/
 Pipeline mode: specification (produce artifacts only)
 
 Scoping is pre-populated from the work definition — proceeding to domain
-analysis and spec authoring.
+analysis.
 ```
 Invoke `/feature-domains "<slug>"`.
+
+In specification mode, `/feature-domains` returns after domain analysis
+without chaining into spec authoring. It produces `domains.md` which
+identifies the specs to write.
+
+---
+
+## Step 5b — Sequential spec authoring
 
 **Spec authoring is mandatory.** Even for decisions-focused WDs, the
 architectural choices made in ADRs have behavioral implications that must
@@ -226,17 +234,36 @@ WHAT the system must do as a result. Without specs, the adversarial
 hardening and audit pipeline have nothing to falsify. Do not skip or
 bypass spec authoring for any WD type.
 
+Read `domains.md` to identify the specs that need to be authored. For
+each spec to produce, **in sequence**:
+
+1. Invoke `/spec-author "<feature-id>" "<title>"` as a separate subagent.
+   Each invocation gets a clean context but reads previously registered
+   specs via the resolver — so spec 2 sees spec 1's requirements, spec 3
+   sees both. This is the compounding loop: each spec's falsification
+   catches contradictions with prior specs.
+
+2. After `/spec-author` completes, verify the spec is registered and in
+   APPROVED state via `.spec/registry/manifest.json`. If still DRAFT,
+   falsification was incomplete — stop and report the error.
+
+3. Proceed to the next spec.
+
+Display progress between specs:
+```
+Spec authoring: <completed>/<total>
+  ✓ F24 — Pool-Aware Block Size Configuration (APPROVED)
+  → F25 — Byte-Budget Block Cache (authoring...)
+```
+
 ---
 
 ## Step 6 — Verify specs and finalize WD status
 
-Before marking the WD as SPECIFIED, verify that all specs produced by
-this WD are in APPROVED state (not DRAFT). Check `.spec/registry/manifest.json`
-for each spec ID produced during this session.
+After all specs are authored, verify that every spec produced by this WD
+is in APPROVED state. Check `.spec/registry/manifest.json`.
 
-**If any spec is still DRAFT:** the adversarial falsification passes
-(Pass 2 + Pass 3) were not completed. Do NOT mark the WD as SPECIFIED.
-Instead:
+**If any spec is still DRAFT:** do NOT mark the WD as SPECIFIED.
 ```
 ⚠ Spec <ID> is still in DRAFT state — falsification incomplete.
 Run /spec-author "<feature-id>" "<title>" to complete adversarial review.

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -228,9 +228,22 @@ bypass spec authoring for any WD type.
 
 ---
 
-## Step 6 — Finalize WD status
+## Step 6 — Verify specs and finalize WD status
 
-After spec authoring completes, update the WD to SPECIFIED:
+Before marking the WD as SPECIFIED, verify that all specs produced by
+this WD are in APPROVED state (not DRAFT). Check `.spec/registry/manifest.json`
+for each spec ID produced during this session.
+
+**If any spec is still DRAFT:** the adversarial falsification passes
+(Pass 2 + Pass 3) were not completed. Do NOT mark the WD as SPECIFIED.
+Instead:
+```
+⚠ Spec <ID> is still in DRAFT state — falsification incomplete.
+Run /spec-author "<feature-id>" "<title>" to complete adversarial review.
+```
+Stop and wait for the user to resolve.
+
+**If all specs are APPROVED:** update the WD:
 
 1. Edit `.work/<group-slug>/WD-<nn>.md` — set `status: SPECIFIED`
 

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -199,7 +199,9 @@ Stage Completion table — implementation stages only:
 ### 4d — Update WD status
 
 Edit `.work/<group-slug>/WD-<nn>.md` — set `status: IMPLEMENTING`.
-Update `.work/<group-slug>/manifest.md` — update the WD's status in the table.
+
+The manifest table is automatically synced by `work-resolve.sh` — do not
+update it manually.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Sequential per-spec authoring** — each spec gets its own `/spec-author` subagent with clean context instead of batching all specs into one call. Sequential ordering means each spec's falsification sees prior specs, catching cross-spec contradictions. Root cause: 3 specs × 3 passes in one subagent hit context saturation — Pass 1 drafts were treated as complete.
- **APPROVED gate** — `/work-plan` verifies each spec is APPROVED (not DRAFT) before proceeding. DRAFT specs block WD completion.
- **Manifest single source of truth** — `work-resolve.sh` regenerates the manifest table from WD frontmatter on every run. Skills no longer update manifest manually, eliminating status/manifest divergence.
- **`/feature-domains` specification mode** — returns after domain analysis without chaining into spec authoring. `/work-plan` controls the iteration.
- **kb-freshness false positive** — skip warning when branch is ahead of main (differences are our changes, not missing entries).

## Test plan

- [x] `bash tests/test-install.sh` — 0 failures
- [x] No manual manifest updates in any skill file
- [x] work-resolve.sh syncs manifest on every run
- [x] kb-freshness-check.sh skips when branch ahead of main

🤖 Generated with [Claude Code](https://claude.com/claude-code)