### PR TITLE
fix: spec-author self-contained + manifest single source of truth

### DIFF
--- a/skills/feature-domains/SKILL.md
+++ b/skills/feature-domains/SKILL.md
@@ -455,9 +455,10 @@ a single pass:
   Specs will define behavioral requirements before work planning begins.
   ```
 - Invoke `/spec-author "<feature-id>" "<slug>"` as a sub-agent immediately.
-  The spec-author reads brief.md and domains.md to produce hardened specs.
-  After spec-author completes, invoke `/spec-write "<feature-id>" "<slug>"`
-  to register the spec, then invoke `/feature-plan "<slug>"` as a sub-agent.
+  The spec-author handles the full lifecycle: draft → falsify → arbitrate →
+  register (via `/spec-write` internally). Do NOT call `/spec-write`
+  separately — `/spec-author` owns registration.
+  After spec-author completes, invoke `/feature-plan "<slug>"` as a sub-agent.
 
 If "Stop":
 ```

--- a/skills/spec-author/SKILL.md
+++ b/skills/spec-author/SKILL.md
@@ -580,13 +580,19 @@ fix-consequence bugs, pass 4+ is rarely productive.
 
 ---
 
-## Output
+## Output — Register the spec
 
-The final spec file, ready for `/spec-write <id> <title>` to register.
+After all adversarial passes are complete and arbitration decisions applied,
+register the spec by invoking `/spec-write "<id>" "<title>"` directly.
 
-The user runs `/spec-write` separately — this skill does not register the
-spec in the manifest. Separation of concerns: authoring is cognitive,
-registration is mechanical.
+**This is mandatory.** `/spec-author` owns the full lifecycle: draft →
+falsify → arbitrate → register. The caller should never need to call
+`/spec-write` separately. This prevents the shortcut where an unfalsified
+draft gets registered without adversarial review.
+
+After `/spec-write` completes, verify the spec is in APPROVED state in
+`.spec/registry/manifest.json`. If it registered as DRAFT (due to
+unresolved conflicts), report the issue — do not silently return.
 
 ---
 
@@ -602,3 +608,5 @@ registration is mechanical.
 - Always present the draft to the user between Pass 1 and Pass 2
 - The subagent for Pass 2 must receive the complete Pass 1 output, not
   a summary — summaries lose the detail that adversarial review needs
+- Always register the spec via `/spec-write` at the end — the caller
+  must never need to call `/spec-write` separately


### PR DESCRIPTION
## Summary

Batch of fixes from jlsm dogfooding. Root cause: agent bypasses `/spec-author` and calls `/spec-write` directly, skipping adversarial falsification entirely.

- **`/spec-author` owns full lifecycle** — draft → falsify (Pass 2) → depth pass (Pass 3) → arbitrate → register (calls `/spec-write` internally). Callers never call `/spec-write` separately. Removes the shortcut.
- **Sequential per-spec authoring** — each spec gets its own `/spec-author` subagent. Previous specs visible to later falsification passes.
- **APPROVED gate** — `/work-plan` verifies APPROVED state before marking WD as SPECIFIED.
- **Manifest single source of truth** — `work-resolve.sh` regenerates manifest table from WD frontmatter. No manual manifest updates.
- **kb-freshness false positive** — skip warning when branch ahead of main.

## Test plan

- [x] `bash tests/test-install.sh` — 0 failures
- [x] `/spec-author` Output section includes `/spec-write` invocation
- [x] `/feature-domains` no longer calls `/spec-write` externally
- [x] No manual manifest updates in any skill file

🤖 Generated with [Claude Code](https://claude.com/claude-code)