### PR TITLE
feat(spec): spec-verify verify-and-repair + obligation lifecycle + domain.slug kit support

### DIFF
--- a/.changelog-staging.md
+++ b/.changelog-staging.md
@@ -1,5 +1,7 @@
 ## Added
 
+- **@spec annotation standard** — `@spec FXX.RN` code comments for spec↔code traceability. Documented in `spec/CLAUDE.md` Code Traceability section.
+- **`spec-trace.sh`** — finds `@spec` annotations across codebases, groups by file, distinguishes implementation vs test locations. Summary/detail/JSON output formats. 13 scenario tests.
 - **Work layer (`.work/`)** — fourth knowledge layer for composable multi-feature work. Decompose large goals into work definitions with artifact-based dependencies and computed readiness. Same pull-model pattern as KB, decisions, and specs.
 - **`/work "<goal>"`** — create a work group with scoping interview
 - **`/work-decompose "<slug>"`** — break a work group into work definitions with dependency graph and shared interface contracts
@@ -9,6 +11,12 @@
 - **Pipeline modes** — `specification` (produce artifacts only), `implementation` (consume existing specs, skip scoping/domains), `full` (default, backwards compatible). Mode-aware routing in feature-resume.
 - **Work-aware context injection** — architect (forward compatibility, ordering gates), spec-author (downstream consumers), feature-domains (cross-WD domain reuse), feature-plan (interface stability constraints), feature-resume (work group grouping)
 - **Curate analyses 15-17** — cross-WD spec displacement, stalled work groups, artifact dependency drift
+
+## Changed
+
+- **`/spec-verify` redesigned as verify-and-repair loop** — 6-phase flow: verify all requirements → classify findings (code-bug/stale-spec/needs-decision/test-gap) → resolve decisions → amend stale specs → fix code via TDD with regression tests → finalize. Violations repaired inline, not parked as obligations.
+- **`/spec-verify` annotates during discovery** — adds `@spec` annotations to implementation and test files as it reads them, eliminating need for separate annotation pass.
+- **`/spec-verify` fills test gaps** — writes structural/behavioral tests for requirements with no test-side annotation coverage.
 
 ## Fixed
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,52 +20,45 @@ state of the project — what's happening now and what's next.
 
 ## Current focus
 
-*Last updated: 2026-04-16*
+*Last updated: 2026-04-19*
 
-**Work-start blocked by decisions-only WDs. Deep spec audit in progress.**
+**Spec verification and repair in progress. Kit tooling shipped. Domain reorg designed.**
 
-**What happened (2026-04-15/16):**
+**What happened (2026-04-16/17/19):**
 
-Attempted `/work-start decisions-backlog` in jlsm. Discovered all 13 WDs in the
-decisions-backlog group are decisions-only (produce only ADRs, no specs or
-implementation). This is structurally wrong — every spec change requires an
-implementation pass. The work layer was completely disconnected from the
-spec→audit→test→code chain that already exists in jlsm.
+Built the spec traceability and verification system, then used it to verify all
+jlsm specs with existing implementation code.
 
-**Key findings:**
+**Kit changes (vallorcine, feat/spec-traceability branch, 5 commits):**
+- `@spec FXX.RN` annotation standard for code↔spec traceability
+- `spec-trace.sh` — finds annotations across codebases (13 scenario tests)
+- spec-verify redesigned as 6-phase verify-and-repair loop (verify → classify →
+  decide → amend specs → fix code via TDD → finalize)
+- spec-verify annotates implementation AND test files during discovery
+- spec-verify fills test gaps (writes structural/reflection tests for uncovered
+  requirements)
 
-- **Decisions-only WDs are invalid.** Agreed: there is no valid "decisions-only"
-  WD type. Every WD must scope through to implementation consequences.
-- **26 DRAFT specs (F01-F26) deeply integrated with code** — 63 adversarial test
-  classes reference spec IDs, audit artifacts link to specs, code comments cite
-  spec requirements (`F17.R1-R3`). Not decorative artifacts.
-- **Work layer doesn't see the spec layer.** `/work-decompose` had no visibility
-  into `.spec/` state — created WDs around ADR resolution and completely missed
-  that specs already existed downstream of those decisions.
-- **Coverage script unreliable.** R-number matching across specs gives false
-  positives (F13 claimed 88% coverage, actual dedicated tests cover ~15 reqs).
-  Script at `jlsm/tools/spec-audit/` needs redesign.
-- **8 anchor spec audits completed** — requirement-by-requirement verification
-  against implementation code. Three tiers emerged:
-  - **Tier A (solid):** F13, F08, F15, F17, F02 — ~240 reqs, ~0 real gaps.
-    Ready for APPROVED with spec wording fixes.
-  - **Tier B (bugs found):** F11 — 2 genuine code bugs (mergeTopK tie handling
-    R60, suppressed exceptions lost R103). Needs code fixes before promotion.
-  - **Tier C (aspirational):** F04, F05 — 12 genuine gaps where specs describe
-    target architecture but implementation is a working simplification (F04:
-    no RAPID consensus/expander graph; F05: catalog not crash-safe, builder
-    not public, state filtering missing).
+**jlsm verification results (in progress):**
+- **7 specs APPROVED:** F02 (v2), F06, F08 (v3), F13 (v1), F14 (v2), F15 (v3),
+  F17 (v1) — real bugs found and fixed, stale spec text amended, regression tests
+  added, `@spec` annotations throughout
+- **Remaining:** F01, F03, F04, F05, F07, F09, F10 (in progress), F11, F12, F16, F18
+- **6 pipeline failure patterns identified** — each has root cause and fix task
+
+**Comprehensive gap analysis completed:** 11 spec-layer gaps found across skills,
+scripts, and agents. 4 critical (feature-implement, feature-refactor, spec-write
+invalidation, work-decompose state validation), 4 important (cross-spec conflict,
+audit feedback, displacement, test traceability), 3 lower priority.
+
+**Spec reorganization designed:** Feature-centric (`F13-jlsm-schema.md`) →
+behavioral-domain (`schema/construction.md`). 12 top-level domains, ~60 spec files.
+Annotation format changes from `@spec F13.R1` to `@spec schema.construction.R1`.
+Execute after verification pass completes.
 
 **Where things stand:**
-Anchor audits complete. Next: walk partial specs (F03, F06, F07, F09, F10, F14,
-F18) using the same process, then cross-check greenfield and WD-created specs
-against approved anchors. After spec integrity is established, fix the existing
-jlsm WDs, validate `/work-start` flow, then fix `/work-decompose` to prevent
-this pattern.
-
-**Analysis scripts at:** `jlsm/tools/spec-audit/` (req-inventory, ref-map,
-adr-linkage, test-coverage, run-audit.sh). Dashboard output at
-`tools/spec-audit/output/summary.md`.
+Verification pass ~50% complete (7/18 implementation specs APPROVED). F10 (139
+reqs, largest) in progress. After verification: domain reorg, then fix the 11
+spec-layer gaps, then unblock work-start with restructured WDs.
 
 ---
 
@@ -73,25 +66,30 @@ adr-linkage, test-coverage, run-audit.sh). Dashboard output at
 
 *Rolling window — graduate oldest entries to SETTLED.md when this exceeds ~10 items*
 
-*14 decisions graduated to SETTLED.md (2026-04-12): work layer (5), spec
-hardening (9). See SETTLED.md for details.*
+*4 decisions graduated to SETTLED.md (2026-04-19): WD validity, spec promotion,
+health model, work-decompose spec state. See SETTLED.md.*
 
-- **Decisions-only WDs are invalid** (2026-04-16) — every WD that produces or
-  modifies specs must include an implementation pass. If a decision results in
-  no spec changes and no code changes, it's a close/re-defer, not a WD.
+- **Spec violations are contracts, not backlog** (2026-04-16) — spec-verify
+  repairs violations inline (fix code or amend spec). Obligations created only
+  on explicit user deferral, never as default path.
 
-- **Spec promotion requires cross-check** (2026-04-16) — before DRAFT→APPROVED,
-  a spec must be verified against all APPROVED specs in its domain. Anchors go
-  first (nothing to cross-check), subsequent specs have a growing constraint set.
+- **@spec annotations as primary traceability** (2026-04-16) — `@spec FXX.RN`
+  comments in code link requirements to enforcement points. spec-verify
+  annotates during discovery. spec-trace.sh provides the reverse index.
 
-- **Three-tier spec health model** (2026-04-16) — Tier A (code matches spec,
-  promote), Tier B (spec correct but code has bugs, fix then promote), Tier C
-  (spec describes target architecture, code is a working simplification, keep
-  DRAFT with annotations).
+- **Correctness over context cost** (2026-04-17) — never drop correctness-relevant
+  context to save tokens. Solve context problems via phase splitting and condensed
+  handoffs instead of skipping information agents need.
 
-- **Work-decompose must check spec state** (2026-04-16) — decomposition without
-  visibility into `.spec/` produces WDs disconnected from reality. The algorithm
-  must read spec registry as part of its analysis.
+- **Spec reorganization: behavioral domains** (2026-04-17) — specs will migrate
+  from feature-centric (F13-jlsm-schema.md) to behavioral-domain
+  (schema/construction.md). 12 domains, ~60 files. Annotation format changes
+  to `@spec domain.slug.RN`. Execute after verification pass.
+
+- **Partial implementation state needed** (2026-04-19) — current model is binary
+  (APPROVED or DRAFT). Need a clean representation for "90% implemented, 10%
+  explicitly deferred." Domain reorg may solve naturally (implemented parts in
+  one spec, stubs in another).
 
 ---
 
@@ -104,39 +102,38 @@ exists, not yet coded. No tag = needs both design and implementation.*
 
 ### Do next
 
-- **Complete jlsm spec integrity audit** — walk partial specs (F03, F06, F07,
-  F09, F10, F14, F18) then cross-check greenfield and WD-created specs against
-  approved anchors. Four-round promotion process:
-  - Round 1 (done): anchor promotion (5 Tier A specs → APPROVED)
-  - Round 2: partial specs (7 specs, cross-check against anchors)
-  - Round 3: greenfield specs (11 specs, cross-check against Rounds 1+2)
-  - Round 4: WD-created specs (F27-F48, cross-check against everything)
+- **Complete jlsm spec verification** — 11 specs remaining with implementation
+  code (F01, F03, F04, F05, F07, F09, F10, F11, F12, F16, F18). F10 in progress.
+  Each goes through verify-and-repair loop: annotate, verify, classify, fix.
 
-- **Fix jlsm F11 code bugs** — R60 (mergeTopK tie handling) and R103
-  (suppressed exceptions lost in closeIterators). Real implementation defects.
+- **Spec domain reorganization** — migrate from feature-centric to behavioral-domain
+  organization. 12 domains, ~60 files. Mechanical: rename script + manifest rebuild
+  + `@spec` annotation find/replace. Execute after verification pass. `[designed]`
 
-- **Unblock jlsm work-start** — restructure decisions-backlog WDs to include
-  implementation scope, then validate `/work-start` flow end-to-end.
+- **Unblock jlsm work-start** — restructure decisions-backlog WDs, then validate
+  `/work-start` flow. Depends on spec verification + reorg completing first.
 
 ### Do soon (medium effort, clear designs)
 
-- **Fix `/work-decompose`** — must check `.spec/` state during decomposition,
-  prevent decisions-only WDs, ensure every WD scopes through implementation.
-  Test with synthetic work group + jlsm validation run.
+- **Fix spec-layer gaps (11 identified)** — 4 critical: feature-implement spec
+  awareness, feature-refactor spec awareness, spec-write two-file invalidation,
+  work-decompose spec state validation. Full gap analysis in session memory.
 
-- **Spec cross-check mechanism** — before DRAFT→APPROVED promotion, cross-check
-  against all APPROVED specs in same domain/overlapping types. Doesn't exist
-  yet. Design question: spec-side `enforced_by` annotations, code-side `F13.R59`
-  test comments, or script-side type tracing.
+- **Fix 6 pipeline failure patterns** — one-sided invalidation, audit outpacing
+  specs, assert-only guards, dead code wiring, spec asymmetry, feature-centric
+  organization. Each has root cause and fix task documented.
 
-- **Redesign coverage script** — current R-number matching gives false positives
-  across specs. Needs spec-scoped matching (only count R-numbers in files that
-  reference the specific spec ID in context).
+- **Partial implementation state model** — binary APPROVED/DRAFT insufficient for
+  specs that are 90% implemented. Need either per-requirement states, split specs,
+  or APPROVED-with-obligations. Data from verification pass will inform design.
 
 ### Do when needed (useful but workarounds exist)
 
 - **Large repo curation testing** — `/curate` needs testing on a repo with
   1000+ commits, 30+ contributors.
+
+- **spec-trace.sh sub-lettered IDs** — R39a-h pattern not matched by numeric-only
+  regex. Annotations exist in code but uncounted. Fix when reorg drops FXX IDs.
 
 ### Do when scale demands it (team/scale features)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,47 +20,52 @@ state of the project — what's happening now and what's next.
 
 ## Current focus
 
-*Last updated: 2026-04-13*
+*Last updated: 2026-04-16*
 
-**Spec hardening validated. Audit → pipeline feedback loop proven.**
+**Work-start blocked by decisions-only WDs. Deep spec audit in progress.**
 
-**What happened (2026-04-12/13):**
+**What happened (2026-04-15/16):**
 
-- **v0.13.0** — work layer shipped (PR #36 merged). 7 concerns, 40+ commands,
-  137 tests. Documentation overhauled (README, DESIGN, COMPETITIVE). MANIFEST
-  integrity fixes. Narrative generation made reliable. 50 prose prompts migrated
-  to AskUserQuestion. Session-end prevention rule. Status line truncation.
+Attempted `/work-start decisions-backlog` in jlsm. Discovered all 13 WDs in the
+decisions-backlog group are decisions-only (produce only ADRs, no specs or
+implementation). This is structurally wrong — every spec change requires an
+implementation pass. The work layer was completely disconnected from the
+spec→audit→test→code chain that already exists in jlsm.
 
-- **v0.13.1** — spec falsification hardened with 7 mandatory probe lenses derived
-  from 51 real audit findings: degenerate values, boundary validation, resource
-  lifecycle, cross-construct atomicity, error propagation, identity/equality, trust
-  boundaries. Mandatory concurrency contracts in every spec. KB adversarial findings
-  loaded into falsification. Concurrency contracts flow through full pipeline
-  (feature-test, feature-harden, audit cards, aTDD breaker).
+**Key findings:**
 
-- **v0.13.2** — standards compliance probe. RFC compliance claims checked against
-  all other requirements for contradictions.
-
-- **json-only-simd-jsonl audit** — 16 confirmed bugs fixed (vs 33 avg for earlier
-  features without specs). 13 of 16 map to spec lenses shipped in v0.13.1/v0.13.2.
-  2 are SIMD algorithm bugs (spec was correct, impl was wrong). Cost: $233 total,
-  $14.58/bug. 4 KB patterns created, 13 spec requirements added (R47-R59).
-
-- **ROI validated**: spec analysis costs ~$30 extra, saves ~$216 in audit costs.
-  With v0.13.1 spec improvements, projected reduction from 16 to ~3 audit bugs
-  (81% reduction). Feature pipeline is the quality gate; audit is the diagnostic.
-
-- **Roadmap → work group bridge** — `/decisions roadmap` now offers "Create work
-  group" (Step 9) that translates clusters into `.work/` WDs. New `/work-plan`
-  command for specification-only pipeline. `/work-start` simplified to
-  implementation-only (mode auto-detection removed).
+- **Decisions-only WDs are invalid.** Agreed: there is no valid "decisions-only"
+  WD type. Every WD must scope through to implementation consequences.
+- **26 DRAFT specs (F01-F26) deeply integrated with code** — 63 adversarial test
+  classes reference spec IDs, audit artifacts link to specs, code comments cite
+  spec requirements (`F17.R1-R3`). Not decorative artifacts.
+- **Work layer doesn't see the spec layer.** `/work-decompose` had no visibility
+  into `.spec/` state — created WDs around ADR resolution and completely missed
+  that specs already existed downstream of those decisions.
+- **Coverage script unreliable.** R-number matching across specs gives false
+  positives (F13 claimed 88% coverage, actual dedicated tests cover ~15 reqs).
+  Script at `jlsm/tools/spec-audit/` needs redesign.
+- **8 anchor spec audits completed** — requirement-by-requirement verification
+  against implementation code. Three tiers emerged:
+  - **Tier A (solid):** F13, F08, F15, F17, F02 — ~240 reqs, ~0 real gaps.
+    Ready for APPROVED with spec wording fixes.
+  - **Tier B (bugs found):** F11 — 2 genuine code bugs (mergeTopK tie handling
+    R60, suppressed exceptions lost R103). Needs code fixes before promotion.
+  - **Tier C (aspirational):** F04, F05 — 12 genuine gaps where specs describe
+    target architecture but implementation is a working simplification (F04:
+    no RAPID consensus/expander graph; F05: catalog not crash-safe, builder
+    not public, state filtering missing).
 
 **Where things stand:**
-Released v0.13.2. Roadmap → work group bridge implemented (pending release).
-Next jlsm feature will be the first authored with the hardened spec
-falsification — the real test of whether the 7 lenses prevent the bugs
-upstream. Remaining: lightweight post-TDD audit design (deferred, waiting for
-next feature's audit data).
+Anchor audits complete. Next: walk partial specs (F03, F06, F07, F09, F10, F14,
+F18) using the same process, then cross-check greenfield and WD-created specs
+against approved anchors. After spec integrity is established, fix the existing
+jlsm WDs, validate `/work-start` flow, then fix `/work-decompose` to prevent
+this pattern.
+
+**Analysis scripts at:** `jlsm/tools/spec-audit/` (req-inventory, ref-map,
+adr-linkage, test-coverage, run-audit.sh). Dashboard output at
+`tools/spec-audit/output/summary.md`.
 
 ---
 
@@ -68,14 +73,25 @@ next feature's audit data).
 
 *Rolling window — graduate oldest entries to SETTLED.md when this exceeds ~10 items*
 
-*5 work layer decisions graduated to SETTLED.md (2026-04-12): artifact-based
-dependencies, interface contracts as spec subtype, computed readiness, pipeline
-mode decomposition, work context as pull-model injection.*
+*14 decisions graduated to SETTLED.md (2026-04-12): work layer (5), spec
+hardening (9). See SETTLED.md for details.*
 
-*9 decisions graduated to SETTLED.md (2026-04-12): effort asymmetry removal,
-concurrency lens filtering, spec conflict detection, DRAFT specs blocked,
-spec extraction from implementation, [ABSENT] lifecycle, fix-spec resolution,
-architect adversarial hardening, Phase 0 already-fixed check.*
+- **Decisions-only WDs are invalid** (2026-04-16) — every WD that produces or
+  modifies specs must include an implementation pass. If a decision results in
+  no spec changes and no code changes, it's a close/re-defer, not a WD.
+
+- **Spec promotion requires cross-check** (2026-04-16) — before DRAFT→APPROVED,
+  a spec must be verified against all APPROVED specs in its domain. Anchors go
+  first (nothing to cross-check), subsequent specs have a growing constraint set.
+
+- **Three-tier spec health model** (2026-04-16) — Tier A (code matches spec,
+  promote), Tier B (spec correct but code has bugs, fix then promote), Tier C
+  (spec describes target architecture, code is a working simplification, keep
+  DRAFT with annotations).
+
+- **Work-decompose must check spec state** (2026-04-16) — decomposition without
+  visibility into `.spec/` produces WDs disconnected from reality. The algorithm
+  must read spec registry as part of its analysis.
 
 ---
 
@@ -88,22 +104,34 @@ exists, not yet coded. No tag = needs both design and implementation.*
 
 ### Do next
 
-- **First feature with hardened spec falsification** — author a jlsm feature
-  using v0.13.2 (7 falsification lenses, mandatory concurrency contracts, KB
-  adversarial findings, standards compliance probe). Then audit it. Compare
-  audit findings to json-only-simd-jsonl baseline (16 bugs). Target: <5 bugs.
+- **Complete jlsm spec integrity audit** — walk partial specs (F03, F06, F07,
+  F09, F10, F14, F18) then cross-check greenfield and WD-created specs against
+  approved anchors. Four-round promotion process:
+  - Round 1 (done): anchor promotion (5 Tier A specs → APPROVED)
+  - Round 2: partial specs (7 specs, cross-check against anchors)
+  - Round 3: greenfield specs (11 specs, cross-check against Rounds 1+2)
+  - Round 4: WD-created specs (F27-F48, cross-check against everything)
 
-- **Real-world work layer validation** `[implemented]` — exercise the full
-  `/work` → `/work-decompose` → `/work-start` flow on an actual multi-feature
-  task. First candidate: a jlsm feature set.
+- **Fix jlsm F11 code bugs** — R60 (mergeTopK tie handling) and R103
+  (suppressed exceptions lost in closeIterators). Real implementation defects.
+
+- **Unblock jlsm work-start** — restructure decisions-backlog WDs to include
+  implementation scope, then validate `/work-start` flow end-to-end.
 
 ### Do soon (medium effort, clear designs)
 
-- **Validate audit budget controls** `[implemented]` — run an audit with a
-  dollar budget to confirm the AskUserQuestion flow and soft cap work.
+- **Fix `/work-decompose`** — must check `.spec/` state during decomposition,
+  prevent decisions-only WDs, ensure every WD scopes through implementation.
+  Test with synthetic work group + jlsm validation run.
 
-- **Test architect hardening on a real ADR** `[implemented]` — the 6 hardening
-  changes are in the prompt but untested on a real decision session.
+- **Spec cross-check mechanism** — before DRAFT→APPROVED promotion, cross-check
+  against all APPROVED specs in same domain/overlapping types. Doesn't exist
+  yet. Design question: spec-side `enforced_by` annotations, code-side `F13.R59`
+  test comments, or script-side type tracing.
+
+- **Redesign coverage script** — current R-number matching gives false positives
+  across specs. Needs spec-scoped matching (only count R-numbers in files that
+  reference the specific spec ID in context).
 
 ### Do when needed (useful but workarounds exist)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -787,7 +787,7 @@ vallorcine/
 │   ├── spec/SKILL.md                ← /spec — query specs, discover gaps, trace change impact
 │   ├── spec-author/SKILL.md         ← /spec-author — two-pass adversarial spec authoring
 │   ├── spec-write/SKILL.md          ← /spec-write — register a spec in .spec/ storage
-│   ├── spec-verify/SKILL.md         ← /spec-verify — verify spec against implementation
+│   ├── spec-verify/SKILL.md         ← /spec-verify — verify spec against implementation, repair violations inline
 │   ├── spec-resolve/SKILL.md        ← /spec-resolve — resolved context bundle with displacement detection
 │   ├── spec-init/SKILL.md           ← /spec-init — initialise .spec/ directory structure
 │   │
@@ -858,6 +858,7 @@ vallorcine/
 │   ├── adr-validate.sh              ← warns if contradictory accepted ADRs exist
 │   ├── spec-resolve.sh             ← spec resolution with conflict detection
 │   ├── spec-validate.sh            ← spec structural validation (displacement fields, lifecycle)
+│   ├── spec-trace.sh               ← @spec annotation discovery across codebases
 │   ├── work-lib.sh                 ← work layer shared functions (YAML parsing, dep checking)
 │   ├── work-resolve.sh             ← work definition readiness computation + dependency graph
 │   ├── work-validate.sh            ← work definition structural validation + circular dep detection
@@ -890,6 +891,7 @@ vallorcine/
 │   ├── scenario-decisions-scan.sh    ← decisions scan tests
 │   ├── scenario-spec-validate.sh     ← spec validation: displacement fields (8 tests)
 │   ├── scenario-spec-resolve.sh      ← spec resolution: displacement detection (11 tests)
+│   ├── scenario-spec-trace.sh       ← @spec annotation discovery (13 tests)
 │   ├── scenario-index-verify.sh
 │   ├── scenario-narrative.sh         ← narrative pipeline parity tests (16 tests)
 │   ├── scenario-work-validate.sh     ← work definition structural validation (50 tests)

--- a/MANIFEST
+++ b/MANIFEST
@@ -122,6 +122,7 @@
 .claude/scripts/work-resolve.sh
 .claude/scripts/work-validate.sh
 .claude/scripts/work-context.sh
+.claude/scripts/work-finalize.sh
 .claude/scripts/narrative-wrapper.sh
 .claude/scripts/narrative/model.py
 .claude/scripts/narrative/tokenizer.py

--- a/MANIFEST
+++ b/MANIFEST
@@ -117,6 +117,7 @@
 .claude/scripts/spec-stats.sh
 .claude/scripts/spec-resolve.sh
 .claude/scripts/spec-obligations-gc.sh
+.claude/scripts/spec-trace.sh
 .claude/scripts/work-lib.sh
 .claude/scripts/work-resolve.sh
 .claude/scripts/work-validate.sh

--- a/SETTLED.md
+++ b/SETTLED.md
@@ -687,3 +687,29 @@ compatibility, ordering gates), spec-author (downstream consumers),
 feature-domains (cross-WD domain reuse), feature-plan (interface stability
 constraints), and feature-resume (work group grouping). Zero cost when no
 work groups exist — scripts exit immediately.
+
+## Decisions-only WDs are invalid (2026-04-16)
+
+Every WD that produces or modifies specs must include an implementation pass.
+If a decision results in no spec changes and no code changes, it's a close or
+re-defer, not a WD. Found when all 13 jlsm decisions-backlog WDs produced only
+ADRs with no implementation scope.
+
+## Spec promotion requires cross-check (2026-04-16)
+
+Before DRAFT→APPROVED, a spec must be verified against all APPROVED specs in
+its domain. Anchors go first (nothing to cross-check), subsequent specs have a
+growing constraint set. Prevents contradictory APPROVED specs in the same domain.
+
+## Three-tier spec health model (2026-04-16)
+
+Tier A: code matches spec → promote to APPROVED. Tier B: spec correct but code
+has bugs → fix code then promote. Tier C: spec describes target architecture,
+code is a working simplification → keep DRAFT with annotations. Found during
+jlsm anchor audit of 8 specs (5 Tier A, 1 Tier B, 2 Tier C).
+
+## Work-decompose must check spec state (2026-04-16)
+
+Decomposition without visibility into `.spec/` produces WDs disconnected from
+reality. The algorithm must read spec registry as part of its analysis. Found
+when work-decompose created 13 WDs that completely missed 26 existing DRAFT specs.

--- a/install.sh
+++ b/install.sh
@@ -300,6 +300,7 @@ install_file "$SCRIPT_DIR/scripts/work-lib.sh" "$TARGET/.claude/scripts/work-lib
 install_file "$SCRIPT_DIR/scripts/work-resolve.sh" "$TARGET/.claude/scripts/work-resolve.sh"
 install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/work-validate.sh"
 install_file "$SCRIPT_DIR/scripts/work-context.sh" "$TARGET/.claude/scripts/work-context.sh"
+install_file "$SCRIPT_DIR/scripts/work-finalize.sh" "$TARGET/.claude/scripts/work-finalize.sh"
 install_file "$SCRIPT_DIR/scripts/narrative-wrapper.sh" "$TARGET/.claude/scripts/narrative-wrapper.sh"
 chmod +x "$TARGET/.claude/scripts/narrative-wrapper.sh" 2>/dev/null || true
 mkdir -p "$TARGET/.claude/scripts/narrative"
@@ -324,6 +325,7 @@ chmod +x "$TARGET/.claude/scripts/spec-trace.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/work-finalize.sh" 2>/dev/null || true
 
 # ── Merge driver for index files ──────────────────────────────────────────────
 
@@ -402,7 +404,8 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/spec-trace.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
-      "Bash(bash .claude/scripts/work-context.sh:*)"
+      "Bash(bash .claude/scripts/work-context.sh:*)",
+      "Bash(bash .claude/scripts/work-finalize.sh:*)"
     ]
   },
   "hooks": {
@@ -509,7 +512,8 @@ HOOKJSON
       "Bash(bash .claude/scripts/spec-trace.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
-      "Bash(bash .claude/scripts/work-context.sh:*)"
+      "Bash(bash .claude/scripts/work-context.sh:*)",
+      "Bash(bash .claude/scripts/work-finalize.sh:*)"
         ] | unique)' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
         echo -e "  ${GREEN}merge${NC} Script permissions added to settings.json"
     elif [[ -f "$SETTINGS_FILE" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -295,6 +295,7 @@ install_file "$SCRIPT_DIR/scripts/spec-validate.sh" "$TARGET/.claude/scripts/spe
 install_file "$SCRIPT_DIR/scripts/spec-stats.sh" "$TARGET/.claude/scripts/spec-stats.sh"
 install_file "$SCRIPT_DIR/scripts/spec-resolve.sh" "$TARGET/.claude/scripts/spec-resolve.sh"
 install_file "$SCRIPT_DIR/scripts/spec-obligations-gc.sh" "$TARGET/.claude/scripts/spec-obligations-gc.sh"
+install_file "$SCRIPT_DIR/scripts/spec-trace.sh" "$TARGET/.claude/scripts/spec-trace.sh"
 install_file "$SCRIPT_DIR/scripts/work-lib.sh" "$TARGET/.claude/scripts/work-lib.sh"
 install_file "$SCRIPT_DIR/scripts/work-resolve.sh" "$TARGET/.claude/scripts/work-resolve.sh"
 install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/work-validate.sh"
@@ -319,6 +320,7 @@ chmod +x "$TARGET/.claude/scripts/spec-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-stats.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-obligations-gc.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/spec-trace.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
@@ -397,6 +399,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/spec-stats.sh:*)",
       "Bash(bash .claude/scripts/spec-resolve.sh:*)",
       "Bash(bash .claude/scripts/spec-obligations-gc.sh:*)",
+      "Bash(bash .claude/scripts/spec-trace.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)"
@@ -503,6 +506,7 @@ HOOKJSON
       "Bash(bash .claude/scripts/spec-stats.sh:*)",
       "Bash(bash .claude/scripts/spec-resolve.sh:*)",
       "Bash(bash .claude/scripts/spec-obligations-gc.sh:*)",
+      "Bash(bash .claude/scripts/spec-trace.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)"

--- a/rules/tdd-protocol.md
+++ b/rules/tdd-protocol.md
@@ -57,6 +57,9 @@ No command re-does completed work without explicit user confirmation.
                        .feature/<slug>/units/WU-N/cycle-log.md (parallel: code entries)
   Refactor Agent     → implementation files + .feature/<slug>/cycle-log.md (refactor entries)
                        .feature/<slug>/units/WU-N/cycle-log.md (parallel: refactor entries)
+                       .work/<group>/WD-*.md (status→COMPLETE, work-group features only)
+                       .spec/registry/_obligations.json (resolve obligations, if referenced in brief)
+                       .spec/domains/*/*.md (remove resolved IDs from open_obligations)
   PR command         → .feature/<slug>/pr-draft.md
   Retro command      → .feature/<slug>/cycle-log.md (retro-complete entry)
                        (invokes /architect, /decisions revisit, /research as sub-agents)

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -725,6 +725,26 @@ if [[ -d ".spec" && -d ".spec/domains" ]]; then
 
     sort -t'|' -k3 -rn "$TMPDIR_SCAN/spec-absent.txt" -o "$TMPDIR_SCAN/spec-absent.txt" 2>/dev/null || true
 
+    # ── 10e: Obligation registry (_obligations.json) ─────────────────────
+    # Scan for a centralized obligations registry and surface open items
+    # grouped by spec. This catches obligations that exist in the registry
+    # but may not appear as frontmatter markers in spec files.
+
+    > "$TMPDIR_SCAN/obligation-registry.txt"
+    OB_REGISTRY=".spec/registry/_obligations.json"
+    if [[ -f "$OB_REGISTRY" ]] && command -v jq >/dev/null 2>&1; then
+        # Extract open obligations grouped by spec
+        jq -r '
+          .obligations[]
+          | select(.status == "open")
+          | [.spec, .id, (.domains // [] | join(",")), (.affects // [] | length | tostring), (.blocked_by // "none")]
+          | @tsv
+        ' "$OB_REGISTRY" 2>/dev/null | while IFS=$'\t' read -r ob_spec ob_id ob_domains ob_affects ob_blocked; do
+            [[ -z "$ob_spec" ]] && continue
+            echo "OB_REGISTRY|$ob_spec|$ob_id|$ob_domains|$ob_affects|$ob_blocked" >> "$TMPDIR_SCAN/obligation-registry.txt"
+        done
+    fi
+
 fi
 
 # ── Analysis 11: Cross-reference repair candidates ──────────────────────────
@@ -1423,6 +1443,27 @@ if [[ -s "$TMPDIR_SCAN/spec-orphaned.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# Obligation registry
+if [[ -s "$TMPDIR_SCAN/obligation-registry.txt" ]]; then
+    echo "## Open Obligations Registry" >> "$SUMMARY_FILE"
+    echo "Open obligations from .spec/registry/_obligations.json that need resolution." >> "$SUMMARY_FILE"
+    echo "These represent spec requirements where the code does not match the spec." >> "$SUMMARY_FILE"
+    echo "Route to: \`/work-decompose \"<group>\" --from-obligations\` to create work definitions." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Spec | Obligation | Domains | Affected Reqs | Blocked By |" >> "$SUMMARY_FILE"
+    echo "|------|-----------|---------|---------------|------------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ ob_spec ob_id ob_domains ob_affects ob_blocked; do
+        echo "| $ob_spec | $ob_id | $ob_domains | $ob_affects | $ob_blocked |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/obligation-registry.txt"
+    echo "" >> "$SUMMARY_FILE"
+
+    # Summary line: count by spec
+    ob_total="$(wc -l < "$TMPDIR_SCAN/obligation-registry.txt")"
+    ob_specs="$(awk -F'|' '{print $2}' "$TMPDIR_SCAN/obligation-registry.txt" | sort -u | wc -l)"
+    echo "**Total:** $ob_total open obligations across $ob_specs specs." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # Deferred audit feedback
 if [[ -s "$TMPDIR_SCAN/audit-feedback.txt" ]]; then
     echo "## Deferred Audit Feedback" >> "$SUMMARY_FILE"
@@ -1506,6 +1547,7 @@ echo "  Unspecified shared types: $(wc -l < "$TMPDIR_SCAN/spec-unspecified.txt" 
 echo "  Specs with obligations: $(wc -l < "$TMPDIR_SCAN/spec-obligations.txt" 2>/dev/null || echo 0)"
 echo "  Spec-code drift: $(wc -l < "$TMPDIR_SCAN/spec-drift.txt" 2>/dev/null || echo 0)"
 echo "  Specs with [ABSENT] reqs: $(wc -l < "$TMPDIR_SCAN/spec-absent.txt" 2>/dev/null || echo 0)"
+echo "  Obligation registry: $(wc -l < "$TMPDIR_SCAN/obligation-registry.txt" 2>/dev/null || echo 0)"
 xref_total=$(( $(wc -l < "$TMPDIR_SCAN/xref-kb-tags.txt" 2>/dev/null || echo 0) + $(wc -l < "$TMPDIR_SCAN/xref-kb-applies.txt" 2>/dev/null || echo 0) + $(wc -l < "$TMPDIR_SCAN/xref-adr-kb.txt" 2>/dev/null || echo 0) ))
 echo "  Deferred audit feedback: $(wc -l < "$TMPDIR_SCAN/audit-feedback.txt" 2>/dev/null || echo 0)"
 echo "  Cross-ref candidates: $xref_total"

--- a/scripts/spec-lib.sh
+++ b/scripts/spec-lib.sh
@@ -78,17 +78,34 @@ count_tokens() {
   echo $(( ${#1} / 4 ))
 }
 
-# ── Resolve feature ID to file path via manifest registry ────────────────────
-# Never uses grep on file contents. Returns absolute path or empty string.
+# ── Resolve a spec ID to file path via manifest registry ─────────────────────
+# Supports both manifest schema versions:
+#   v1 (legacy): {"features": {"F01": {"latest_file": "...", ...}}}
+#   v2 (post-migration): {"schema_version": 2, "specs": [{"id": "...", "path": "..."}]}
+# Returns absolute path or empty string.
 spec_file_for_id() {
   local manifest="$1"
   local fid="$2"
   local spec_dir
   spec_dir="$(dirname "$(dirname "$manifest")")"
   local rel
-  rel=$(jq -r --arg id "$fid" '.features[$id].latest_file // ""' "$manifest")
+  # Try v2 first (specs[] array with id field), fall back to v1 (features{} object).
+  rel=$(jq -r --arg id "$fid" '
+    if .specs then
+      ((.specs[] | select(.id == $id) | .path) // "")
+    else
+      (.features[$id].latest_file // "")
+    end
+  ' "$manifest")
   [[ -z "$rel" ]] && echo "" && return 0
-  echo "$spec_dir/$rel"
+  # v2 manifest stores paths relative to the repo root (e.g., ".spec/domains/...").
+  # v1 stores paths relative to the .spec/ directory. Detect which form by checking
+  # if the path already starts with ".spec/" — if so, resolve against repo root.
+  if [[ "$rel" == .spec/* ]]; then
+    echo "$spec_dir/${rel#.spec/}"
+  else
+    echo "$spec_dir/$rel"
+  fi
 }
 
 # ── Update manifest registry entry atomically via temp file ──────────────────
@@ -105,25 +122,28 @@ spec_registry_update() {
   echo "[registry] $fid -> $latest_file ($state)" >&2
 }
 
-# ── Verify FXX.RN reference resolves to a real requirement ───────────────────
-# Returns 0 if valid, 1 with error message if not.
+# ── Verify a spec requirement reference resolves to a real requirement ────────
+# Accepts both legacy FXX.RN and new domain.slug.RN formats. Returns 0 if valid,
+# 1 with error message if not.
 spec_invalidates_check() {
   local manifest="$1" ref="$2"
-  local fid req_num
-  fid=$(echo "$ref" | grep -oE '^F[0-9]+' || true)
-  req_num=$(echo "$ref" | grep -oE 'R[0-9]+$' || true)
-  if [[ -z "$fid" || -z "$req_num" ]]; then
-    echo "  FAIL invalidates '$ref': cannot parse as FXX.RN" >&2
+  local sid req_num
+  # Strip the trailing .RN[a] to get the spec ID (works for both forms).
+  sid=$(echo "$ref" | sed -E 's/\.R[0-9]+[a-z]?$//')
+  # Capture the trailing R-number (with optional letter suffix).
+  req_num=$(echo "$ref" | grep -oE 'R[0-9]+[a-z]?$' || true)
+  if [[ -z "$sid" || -z "$req_num" || "$sid" == "$ref" ]]; then
+    echo "  FAIL invalidates '$ref': cannot parse as <spec-id>.RN (e.g. F01.R3 or schema.field-access.R3)" >&2
     return 1
   fi
   local target_file
-  target_file=$(spec_file_for_id "$manifest" "$fid")
+  target_file=$(spec_file_for_id "$manifest" "$sid")
   if [[ -z "$target_file" || ! -f "$target_file" ]]; then
-    echo "  FAIL invalidates '$ref': $fid not found in registry" >&2
+    echo "  FAIL invalidates '$ref': $sid not found in registry" >&2
     return 1
   fi
   if ! machine_section "$target_file" | grep -qE "^${req_num}\."; then
-    echo "  FAIL invalidates '$ref': $req_num not found in $fid" >&2
+    echo "  FAIL invalidates '$ref': $req_num not found in $sid" >&2
     return 1
   fi
   return 0

--- a/scripts/spec-resolve.sh
+++ b/scripts/spec-resolve.sh
@@ -244,11 +244,12 @@ for f in "${ALL_FILES[@]+"${ALL_FILES[@]}"}"; do
   src_id=$(fm "$f" '.id')
   while IFS= read -r inv_ref; do
     [[ -z "$inv_ref" ]] && continue
-    # Extract the feature ID from FXX.RN format
-    target_fid=$(echo "$inv_ref" | grep -oE '^F[0-9]+' || true)
-    [[ -z "$target_fid" ]] && continue
-    if [[ -n "${INCLUDED_IDS[$target_fid]+x}" ]]; then
-      CONFLICTS+="INVALIDATES: $src_id invalidates $inv_ref, but $target_fid is also in this bundle"$'\n'
+    # Strip trailing .RN to get the target spec ID. Works for both
+    # FXX.RN (→ FXX) and domain.slug.RN (→ domain.slug).
+    target_id=$(echo "$inv_ref" | sed -E 's/\.R[0-9]+[a-z]?$//')
+    [[ -z "$target_id" ]] && continue
+    if [[ -n "${INCLUDED_IDS[$target_id]+x}" ]]; then
+      CONFLICTS+="INVALIDATES: $src_id invalidates $inv_ref, but $target_id is also in this bundle"$'\n'
     fi
   done < <(fm "$f" '.invalidates // [] | .[]')
 done
@@ -279,9 +280,9 @@ for f in "${ALL_FILES[@]+"${ALL_FILES[@]}"}"; do
         prev="${REQ_SUBJECTS[$token]}"
         prev_id="${prev%%|*}"
         prev_line="${prev#*|}"
-        # Only flag if from different specs
-        prev_spec=$(echo "$prev_id" | grep -oE '^F[0-9]+' || true)
-        [[ "$prev_spec" == "$src_id" ]] && continue
+        # Only flag if from different specs (compare full spec IDs directly —
+        # works for both FXX and domain.slug forms)
+        [[ "$prev_id" == "$src_id" ]] && continue
 
         prev_lower=$(echo "$prev_line" | tr '[:upper:]' '[:lower:]')
         # Check for contradictory language patterns

--- a/scripts/spec-trace.sh
+++ b/scripts/spec-trace.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# spec-trace.sh — find @spec annotations for a feature across the codebase
+# Usage: spec-trace.sh <FXX> [project-root]
+# Optional env: SPEC_TRACE_DIRS="src,lib,test" — comma-separated dirs to scan (default: auto-detect)
+# Optional env: SPEC_TRACE_FORMAT="summary|detail|json" — output format (default: summary)
+# Output: grouped annotation report on stdout | diagnostics on stderr
+#
+# Scans implementation and test files for @spec annotations matching the given
+# feature ID. Groups results by file, distinguishes implementation vs test
+# locations, and reports per-requirement coverage.
+
+set -euo pipefail
+
+FEATURE_ID="${1:-}"
+PROJECT_ROOT="${2:-}"
+FORMAT="${SPEC_TRACE_FORMAT:-summary}"
+
+[[ -z "$FEATURE_ID" ]] && {
+  echo "Usage: spec-trace.sh <FXX> [project-root]" >&2
+  echo "  Example: spec-trace.sh F13" >&2
+  echo "  Example: spec-trace.sh F13 /path/to/project" >&2
+  echo "" >&2
+  echo "  Env: SPEC_TRACE_DIRS='src,lib,test'  — dirs to scan" >&2
+  echo "  Env: SPEC_TRACE_FORMAT='summary'      — summary|detail|json" >&2
+  exit 1
+}
+
+# Validate feature ID format: FXX with zero-padded 2+ digits
+if ! echo "$FEATURE_ID" | grep -qE '^F[0-9]{2,}$'; then
+  echo "ERROR: Invalid feature ID '$FEATURE_ID'. Must be FXX format (e.g., F01, F13)." >&2
+  exit 1
+fi
+
+# ── Locate project root ────────────────────────────────────────────────────────
+if [[ -z "$PROJECT_ROOT" ]]; then
+  dir="$PWD"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -d "$dir/.spec" ]] || [[ -d "$dir/.git" ]]; then
+      PROJECT_ROOT="$dir"
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+  [[ -z "$PROJECT_ROOT" ]] && {
+    echo "ERROR: Could not find project root (no .spec/ or .git/ found)." >&2
+    exit 1
+  }
+fi
+
+# ── Determine directories to scan ──────────────────────────────────────────────
+SCAN_DIRS=()
+if [[ -n "${SPEC_TRACE_DIRS:-}" ]]; then
+  IFS=',' read -ra USER_DIRS <<< "$SPEC_TRACE_DIRS"
+  for d in "${USER_DIRS[@]}"; do
+    d=$(echo "$d" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [[ -d "$PROJECT_ROOT/$d" ]] && SCAN_DIRS+=("$PROJECT_ROOT/$d")
+  done
+else
+  # Auto-detect: scan common source/test directory names
+  for candidate in src lib app main test tests spec; do
+    [[ -d "$PROJECT_ROOT/$candidate" ]] && SCAN_DIRS+=("$PROJECT_ROOT/$candidate")
+  done
+fi
+
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+  echo "ERROR: No source directories found to scan in $PROJECT_ROOT" >&2
+  echo "  Set SPEC_TRACE_DIRS='src,test' to specify directories." >&2
+  exit 1
+fi
+
+echo "[trace] Scanning for @spec $FEATURE_ID in: ${SCAN_DIRS[*]}" >&2
+
+# ── Grep pattern ────────────────────────────────────────────────────────────────
+# Match @spec annotations containing this feature ID.
+# Pattern: @spec followed by whitespace, then references that include our FXX.
+# We match the whole @spec line and filter in post-processing.
+GREP_PATTERN="@spec\s+.*${FEATURE_ID}\."
+
+# Collect all matching lines: file:line_number:content
+MATCHES_FILE=$(mktemp)
+trap 'rm -f "$MATCHES_FILE"' EXIT
+
+grep -rnE "$GREP_PATTERN" "${SCAN_DIRS[@]}" \
+  --include='*.java' --include='*.py' --include='*.js' --include='*.ts' \
+  --include='*.go' --include='*.rs' --include='*.kt' --include='*.scala' \
+  --include='*.c' --include='*.cpp' --include='*.h' --include='*.hpp' \
+  --include='*.cs' --include='*.rb' --include='*.swift' --include='*.m' \
+  --include='*.sh' \
+  > "$MATCHES_FILE" 2>/dev/null || true
+
+MATCH_COUNT=$(wc -l < "$MATCHES_FILE" | tr -d ' ')
+
+if [[ "$MATCH_COUNT" -eq 0 ]]; then
+  echo "No @spec annotations found for $FEATURE_ID" >&2
+  echo "## $FEATURE_ID — Trace Report"
+  echo ""
+  echo "**No annotations found.**"
+  echo ""
+  echo "Scanned: ${SCAN_DIRS[*]}"
+  exit 0
+fi
+
+echo "[trace] Found $MATCH_COUNT annotation(s)" >&2
+
+# ── Parse matches and extract requirement references ────────────────────────────
+# For each match line, extract all FXX.RN references belonging to our feature.
+# Track: file, line number, requirement IDs, whether it's a test file.
+
+declare -A FILE_LINES       # file -> "line1:R1,R3|line2:R7"
+declare -A REQ_FILES        # requirement -> "file1:line|file2:line"
+declare -A REQ_TEST_FILES   # requirement -> "testfile1:line|testfile2:line"
+ALL_REQS=()
+
+is_test_file() {
+  local f="$1"
+  # Common test file patterns across languages
+  case "$f" in
+    */test/*|*/tests/*|*/spec/*|*/__tests__/*) return 0 ;;
+    *Test.java|*Tests.java|*_test.go|*_test.py|*.test.js|*.test.ts|*.spec.js|*.spec.ts) return 0 ;;
+    *test_*.py|*_test.rb|*Tests.cs|*Test.kt|*Test.scala) return 0 ;;
+  esac
+  return 1
+}
+
+while IFS= read -r line; do
+  # Format: filepath:linenumber:content
+  file=$(echo "$line" | cut -d: -f1)
+  lineno=$(echo "$line" | cut -d: -f2)
+  content=$(echo "$line" | cut -d: -f3-)
+
+  # Make path relative to project root for display
+  rel_file="${file#"$PROJECT_ROOT"/}"
+
+  # Extract all FXX.RN references for our feature from the content.
+  # Handle both "F13.R1,R3,R7" (multi-req same spec) and "F13.R1 F08.R4" (multi-spec).
+  #
+  # Strategy: find the FXX. prefix, then collect subsequent R-numbers
+  # until we hit another FXX. prefix, whitespace without R, or end of refs.
+
+  # First, extract the @spec portion (everything after @spec until end of line or --)
+  spec_portion=$(echo "$content" | sed -E 's/.*@spec\s+//; s/\s*--.*//; s/\s*—.*//')
+
+  # Extract refs for our feature: FXX.RN[,RN,RN]
+  # This handles: F13.R1  F13.R1,R3,R7  F13.R1,R3 F08.R4
+  our_refs=$(echo "$spec_portion" | grep -oE "${FEATURE_ID}\\.R[0-9]+(,R[0-9]+)*" || true)
+
+  for ref_group in $our_refs; do
+    # ref_group is like "F13.R1,R3,R7" or "F13.R1"
+    # Strip the FXX. prefix, split on comma
+    req_part="${ref_group#"${FEATURE_ID}".}"
+    IFS=',' read -ra req_ids <<< "$req_part"
+    for rid in "${req_ids[@]}"; do
+      # Normalize: ensure it looks like RN
+      if echo "$rid" | grep -qE '^R[0-9]+$'; then
+        full_ref="${FEATURE_ID}.${rid}"
+
+        # Track unique requirements
+        if [[ -z "${REQ_FILES[$full_ref]+x}" ]]; then
+          ALL_REQS+=("$full_ref")
+          REQ_FILES[$full_ref]=""
+          REQ_TEST_FILES[$full_ref]=""
+        fi
+
+        # Classify as test or implementation
+        if is_test_file "$file"; then
+          REQ_TEST_FILES[$full_ref]="${REQ_TEST_FILES[$full_ref]:+${REQ_TEST_FILES[$full_ref]}|}${rel_file}:${lineno}"
+        else
+          REQ_FILES[$full_ref]="${REQ_FILES[$full_ref]:+${REQ_FILES[$full_ref]}|}${rel_file}:${lineno}"
+        fi
+      fi
+    done
+  done
+done < "$MATCHES_FILE"
+
+# ── Sort requirements naturally (F13.R1, F13.R2, ..., F13.R10, ...) ────────────
+IFS=$'\n' SORTED_REQS=($(for r in "${ALL_REQS[@]}"; do echo "$r"; done | sort -t. -k2 -V))
+unset IFS
+
+# ── Output ──────────────────────────────────────────────────────────────────────
+
+if [[ "$FORMAT" == "json" ]]; then
+  # JSON output for machine consumption
+  echo "{"
+  echo "  \"feature\": \"$FEATURE_ID\","
+  echo "  \"total_annotations\": $MATCH_COUNT,"
+  echo "  \"requirements\": {"
+  first=true
+  for req in "${SORTED_REQS[@]}"; do
+    $first || echo ","
+    first=false
+    impl_locations="${REQ_FILES[$req]}"
+    test_locations="${REQ_TEST_FILES[$req]}"
+
+    echo -n "    \"$req\": { \"implementation\": ["
+    if [[ -n "$impl_locations" ]]; then
+      ifirst=true
+      IFS='|' read -ra locs <<< "$impl_locations"
+      for loc in "${locs[@]}"; do
+        $ifirst || echo -n ", "
+        ifirst=false
+        echo -n "\"$loc\""
+      done
+    fi
+    echo -n "], \"test\": ["
+    if [[ -n "$test_locations" ]]; then
+      tfirst=true
+      IFS='|' read -ra locs <<< "$test_locations"
+      for loc in "${locs[@]}"; do
+        $tfirst || echo -n ", "
+        tfirst=false
+        echo -n "\"$loc\""
+      done
+    fi
+    echo -n "] }"
+  done
+  echo ""
+  echo "  }"
+  echo "}"
+
+elif [[ "$FORMAT" == "detail" ]]; then
+  # Detailed output: per-requirement with all locations
+  echo "## $FEATURE_ID — Trace Report (detail)"
+  echo ""
+  echo "**Annotations:** $MATCH_COUNT | **Requirements traced:** ${#SORTED_REQS[@]}"
+  echo ""
+
+  for req in "${SORTED_REQS[@]}"; do
+    impl_locations="${REQ_FILES[$req]}"
+    test_locations="${REQ_TEST_FILES[$req]}"
+    impl_count=0
+    test_count=0
+    [[ -n "$impl_locations" ]] && impl_count=$(echo "$impl_locations" | tr '|' '\n' | wc -l | tr -d ' ')
+    [[ -n "$test_locations" ]] && test_count=$(echo "$test_locations" | tr '|' '\n' | wc -l | tr -d ' ')
+
+    echo "### $req"
+    echo ""
+    if [[ -n "$impl_locations" ]]; then
+      echo "**Implementation** ($impl_count):"
+      IFS='|' read -ra locs <<< "$impl_locations"
+      for loc in "${locs[@]}"; do
+        echo "- \`$loc\`"
+      done
+    else
+      echo "**Implementation:** none"
+    fi
+    if [[ -n "$test_locations" ]]; then
+      echo "**Test** ($test_count):"
+      IFS='|' read -ra locs <<< "$test_locations"
+      for loc in "${locs[@]}"; do
+        echo "- \`$loc\`"
+      done
+    else
+      echo "**Test:** none"
+    fi
+    echo ""
+  done
+
+else
+  # Summary output (default): compact table
+  echo "## $FEATURE_ID — Trace Report"
+  echo ""
+  echo "**Annotations:** $MATCH_COUNT | **Requirements traced:** ${#SORTED_REQS[@]}"
+  echo ""
+  echo "| Requirement | Impl | Test | Locations |"
+  echo "|-------------|------|------|-----------|"
+
+  for req in "${SORTED_REQS[@]}"; do
+    impl_locations="${REQ_FILES[$req]}"
+    test_locations="${REQ_TEST_FILES[$req]}"
+    impl_count=0
+    test_count=0
+    [[ -n "$impl_locations" ]] && impl_count=$(echo "$impl_locations" | tr '|' '\n' | wc -l | tr -d ' ')
+    [[ -n "$test_locations" ]] && test_count=$(echo "$test_locations" | tr '|' '\n' | wc -l | tr -d ' ')
+
+    # Show first impl + first test location as summary
+    first_impl=""
+    first_test=""
+    if [[ -n "$impl_locations" ]]; then
+      first_impl=$(echo "$impl_locations" | cut -d'|' -f1)
+    fi
+    if [[ -n "$test_locations" ]]; then
+      first_test=$(echo "$test_locations" | cut -d'|' -f1)
+    fi
+
+    locations=""
+    [[ -n "$first_impl" ]] && locations="$first_impl"
+    [[ -n "$first_test" ]] && locations="${locations:+$locations, }$first_test"
+
+    echo "| $req | $impl_count | $test_count | \`$locations\` |"
+  done
+
+  # Summary: requirements with no implementation or no tests
+  no_impl=()
+  no_test=()
+  for req in "${SORTED_REQS[@]}"; do
+    [[ -z "${REQ_FILES[$req]}" ]] && no_impl+=("$req")
+    [[ -z "${REQ_TEST_FILES[$req]}" ]] && no_test+=("$req")
+  done
+
+  echo ""
+  if [[ ${#no_impl[@]} -gt 0 ]]; then
+    echo "**No implementation annotations:** ${no_impl[*]}"
+  fi
+  if [[ ${#no_test[@]} -gt 0 ]]; then
+    echo "**No test annotations:** ${no_test[*]}"
+  fi
+  if [[ ${#no_impl[@]} -eq 0 && ${#no_test[@]} -eq 0 ]]; then
+    echo "**All traced requirements have both implementation and test annotations.**"
+  fi
+fi

--- a/scripts/spec-trace.sh
+++ b/scripts/spec-trace.sh
@@ -1,35 +1,44 @@
 #!/usr/bin/env bash
-# spec-trace.sh — find @spec annotations for a feature across the codebase
-# Usage: spec-trace.sh <FXX> [project-root]
+# spec-trace.sh — find @spec annotations for a spec across the codebase
+# Usage: spec-trace.sh <spec-id> [project-root]
+#   spec-id: legacy FXX (e.g., F13) OR domain.slug (e.g., schema.field-access)
 # Optional env: SPEC_TRACE_DIRS="src,lib,test" — comma-separated dirs to scan (default: auto-detect)
 # Optional env: SPEC_TRACE_FORMAT="summary|detail|json" — output format (default: summary)
 # Output: grouped annotation report on stdout | diagnostics on stderr
 #
 # Scans implementation and test files for @spec annotations matching the given
-# feature ID. Groups results by file, distinguishes implementation vs test
+# spec ID. Groups results by file, distinguishes implementation vs test
 # locations, and reports per-requirement coverage.
 
 set -euo pipefail
 
-FEATURE_ID="${1:-}"
+SPEC_ID="${1:-}"
+# Backwards-compatible alias used internally by older code paths
 PROJECT_ROOT="${2:-}"
 FORMAT="${SPEC_TRACE_FORMAT:-summary}"
 
-[[ -z "$FEATURE_ID" ]] && {
-  echo "Usage: spec-trace.sh <FXX> [project-root]" >&2
-  echo "  Example: spec-trace.sh F13" >&2
-  echo "  Example: spec-trace.sh F13 /path/to/project" >&2
+[[ -z "$SPEC_ID" ]] && {
+  echo "Usage: spec-trace.sh <spec-id> [project-root]" >&2
+  echo "  Examples:" >&2
+  echo "    spec-trace.sh F13                      # legacy FXX format" >&2
+  echo "    spec-trace.sh schema.field-access      # domain.slug format" >&2
+  echo "    spec-trace.sh F13 /path/to/project" >&2
   echo "" >&2
   echo "  Env: SPEC_TRACE_DIRS='src,lib,test'  — dirs to scan" >&2
   echo "  Env: SPEC_TRACE_FORMAT='summary'      — summary|detail|json" >&2
   exit 1
 }
 
-# Validate feature ID format: FXX with zero-padded 2+ digits
-if ! echo "$FEATURE_ID" | grep -qE '^F[0-9]{2,}$'; then
-  echo "ERROR: Invalid feature ID '$FEATURE_ID'. Must be FXX format (e.g., F01, F13)." >&2
+# Validate spec ID format: legacy FXX (zero-padded 2+ digits) OR domain.slug
+# (lowercase letter + hyphenated segments separated by a single dot).
+if ! echo "$SPEC_ID" | grep -qE '^(F[0-9]{2,}|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)$'; then
+  echo "ERROR: Invalid spec ID '$SPEC_ID'." >&2
+  echo "  Expected: legacy FXX (e.g. F01, F13) OR domain.slug (e.g. schema.field-access)" >&2
   exit 1
 fi
+
+# Escape regex metachars in the spec ID so dots in domain.slug match literally
+SPEC_ID_RE=$(printf '%s' "$SPEC_ID" | sed 's/[.[\*^$()+?{|]/\\&/g')
 
 # ── Locate project root ────────────────────────────────────────────────────────
 if [[ -z "$PROJECT_ROOT" ]]; then
@@ -56,8 +65,10 @@ if [[ -n "${SPEC_TRACE_DIRS:-}" ]]; then
     [[ -d "$PROJECT_ROOT/$d" ]] && SCAN_DIRS+=("$PROJECT_ROOT/$d")
   done
 else
-  # Auto-detect: scan common source/test directory names
-  for candidate in src lib app main test tests spec; do
+  # Auto-detect: scan common source/test directory names. `modules` is included
+  # for multi-module Java/Kotlin projects (e.g., jlsm); `examples` and
+  # `benchmarks` cover sample/perf code that may also carry @spec annotations.
+  for candidate in src lib app main test tests spec modules examples benchmarks; do
     [[ -d "$PROJECT_ROOT/$candidate" ]] && SCAN_DIRS+=("$PROJECT_ROOT/$candidate")
   done
 fi
@@ -68,13 +79,12 @@ if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
   exit 1
 fi
 
-echo "[trace] Scanning for @spec $FEATURE_ID in: ${SCAN_DIRS[*]}" >&2
+echo "[trace] Scanning for @spec $SPEC_ID in: ${SCAN_DIRS[*]}" >&2
 
 # ── Grep pattern ────────────────────────────────────────────────────────────────
-# Match @spec annotations containing this feature ID.
-# Pattern: @spec followed by whitespace, then references that include our FXX.
-# We match the whole @spec line and filter in post-processing.
-GREP_PATTERN="@spec\s+.*${FEATURE_ID}\."
+# Match @spec annotations containing this spec ID. The spec ID is regex-escaped
+# (SPEC_ID_RE) so dots in domain.slug ids match literally.
+GREP_PATTERN="@spec\s+.*${SPEC_ID_RE}\."
 
 # Collect all matching lines: file:line_number:content
 MATCHES_FILE=$(mktemp)
@@ -91,8 +101,8 @@ grep -rnE "$GREP_PATTERN" "${SCAN_DIRS[@]}" \
 MATCH_COUNT=$(wc -l < "$MATCHES_FILE" | tr -d ' ')
 
 if [[ "$MATCH_COUNT" -eq 0 ]]; then
-  echo "No @spec annotations found for $FEATURE_ID" >&2
-  echo "## $FEATURE_ID — Trace Report"
+  echo "No @spec annotations found for $SPEC_ID" >&2
+  echo "## $SPEC_ID — Trace Report"
   echo ""
   echo "**No annotations found.**"
   echo ""
@@ -103,7 +113,7 @@ fi
 echo "[trace] Found $MATCH_COUNT annotation(s)" >&2
 
 # ── Parse matches and extract requirement references ────────────────────────────
-# For each match line, extract all FXX.RN references belonging to our feature.
+# For each match line, extract all <spec-id>.RN references belonging to our spec.
 # Track: file, line number, requirement IDs, whether it's a test file.
 
 declare -A FILE_LINES       # file -> "line1:R1,R3|line2:R7"
@@ -131,28 +141,26 @@ while IFS= read -r line; do
   # Make path relative to project root for display
   rel_file="${file#"$PROJECT_ROOT"/}"
 
-  # Extract all FXX.RN references for our feature from the content.
-  # Handle both "F13.R1,R3,R7" (multi-req same spec) and "F13.R1 F08.R4" (multi-spec).
-  #
-  # Strategy: find the FXX. prefix, then collect subsequent R-numbers
-  # until we hit another FXX. prefix, whitespace without R, or end of refs.
+  # Extract all <spec>.RN references for our spec from the content.
+  # Handle both "<spec>.R1,R3,R7" (multi-req same spec) and "<spec>.R1 <other>.R4" (multi-spec).
+  # Letter-suffixed RNs (R51a, R39h) are supported.
 
   # First, extract the @spec portion (everything after @spec until end of line or --)
   spec_portion=$(echo "$content" | sed -E 's/.*@spec\s+//; s/\s*--.*//; s/\s*—.*//')
 
-  # Extract refs for our feature: FXX.RN[,RN,RN]
-  # This handles: F13.R1  F13.R1,R3,R7  F13.R1,R3 F08.R4
-  our_refs=$(echo "$spec_portion" | grep -oE "${FEATURE_ID}\\.R[0-9]+(,R[0-9]+)*" || true)
+  # Extract refs for our spec: <SPEC_ID>.RN[,RN,RN]
+  # SPEC_ID_RE has dots regex-escaped so domain.slug ids match literally.
+  our_refs=$(echo "$spec_portion" | grep -oE "${SPEC_ID_RE}\\.R[0-9]+[a-z]?(,R[0-9]+[a-z]?)*" || true)
 
   for ref_group in $our_refs; do
-    # ref_group is like "F13.R1,R3,R7" or "F13.R1"
-    # Strip the FXX. prefix, split on comma
-    req_part="${ref_group#"${FEATURE_ID}".}"
+    # ref_group is like "<spec>.R1,R3,R7" or "<spec>.R1"
+    # Strip the spec id prefix, split on comma
+    req_part="${ref_group#"${SPEC_ID}".}"
     IFS=',' read -ra req_ids <<< "$req_part"
     for rid in "${req_ids[@]}"; do
-      # Normalize: ensure it looks like RN
-      if echo "$rid" | grep -qE '^R[0-9]+$'; then
-        full_ref="${FEATURE_ID}.${rid}"
+      # Normalize: ensure it looks like Rn or Rn<letter>
+      if echo "$rid" | grep -qE '^R[0-9]+[a-z]?$'; then
+        full_ref="${SPEC_ID}.${rid}"
 
         # Track unique requirements
         if [[ -z "${REQ_FILES[$full_ref]+x}" ]]; then
@@ -172,8 +180,14 @@ while IFS= read -r line; do
   done
 done < "$MATCHES_FILE"
 
-# ── Sort requirements naturally (F13.R1, F13.R2, ..., F13.R10, ...) ────────────
-IFS=$'\n' SORTED_REQS=($(for r in "${ALL_REQS[@]}"; do echo "$r"; done | sort -t. -k2 -V))
+# ── Sort requirements naturally by trailing R-number (R1, R2, ..., R10, R51a, ...) ──
+# Strip the spec ID prefix to get just the RN, sort version-aware on that, then re-attach.
+IFS=$'\n' SORTED_REQS=($(
+  for r in "${ALL_REQS[@]}"; do
+    rn="${r##*.}"   # drop everything up to and including the last "."
+    printf "%s\t%s\n" "$rn" "$r"
+  done | sort -V | cut -f2-
+))
 unset IFS
 
 # ── Output ──────────────────────────────────────────────────────────────────────
@@ -181,7 +195,7 @@ unset IFS
 if [[ "$FORMAT" == "json" ]]; then
   # JSON output for machine consumption
   echo "{"
-  echo "  \"feature\": \"$FEATURE_ID\","
+  echo "  \"spec\": \"$SPEC_ID\","
   echo "  \"total_annotations\": $MATCH_COUNT,"
   echo "  \"requirements\": {"
   first=true
@@ -219,7 +233,7 @@ if [[ "$FORMAT" == "json" ]]; then
 
 elif [[ "$FORMAT" == "detail" ]]; then
   # Detailed output: per-requirement with all locations
-  echo "## $FEATURE_ID — Trace Report (detail)"
+  echo "## $SPEC_ID — Trace Report (detail)"
   echo ""
   echo "**Annotations:** $MATCH_COUNT | **Requirements traced:** ${#SORTED_REQS[@]}"
   echo ""
@@ -257,7 +271,7 @@ elif [[ "$FORMAT" == "detail" ]]; then
 
 else
   # Summary output (default): compact table
-  echo "## $FEATURE_ID — Trace Report"
+  echo "## $SPEC_ID — Trace Report"
   echo ""
   echo "**Annotations:** $MATCH_COUNT | **Requirements traced:** ${#SORTED_REQS[@]}"
   echo ""

--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -77,11 +77,18 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
     echo "[validate] Warning: manifest not found, skipping requires check" >&2
   fi
 
+  # ── Spec ID format patterns (legacy FXX or new domain.slug) ───────────────
+  # Spec ID alone:           F01  OR  schema.field-access
+  # Spec requirement ref:    F01.R3  OR  schema.field-access.R3
+  #                          (letter-suffix RNs like R51a are supported)
+  spec_id_re='^(F[0-9]+|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)$'
+  spec_ref_re='^(F[0-9]+|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)\.R[0-9]+[a-z]?$'
+
   # ── Check 7: invalidates[] format AND target existence
   while IFS= read -r inv; do
     [[ -z "$inv" ]] && continue
-    if ! echo "$inv" | grep -qE '^F[0-9]+\.R[0-9]+$'; then
-      ERRORS+=("Invalid invalidates format: '$inv' (expected FXX.RN e.g. F01.R3)")
+    if ! echo "$inv" | grep -qE "$spec_ref_re"; then
+      ERRORS+=("Invalid invalidates format: '$inv' (expected FXX.RN or domain.slug.RN, e.g. F01.R3 or schema.field-access.R3)")
     elif [[ -f "$MANIFEST" ]]; then
       inv_err=$(spec_invalidates_check "$MANIFEST" "$inv" 2>&1 || true)
       if [[ -n "$inv_err" ]]; then
@@ -93,8 +100,8 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
   # ── Check 7b: displaced_by[] IDs resolve via registry (optional field)
   while IFS= read -r dby; do
     [[ -z "$dby" ]] && continue
-    if ! echo "$dby" | grep -qE '^F[0-9]+$'; then
-      ERRORS+=("Invalid displaced_by format: '$dby' (expected FXX e.g. F05)")
+    if ! echo "$dby" | grep -qE "$spec_id_re"; then
+      ERRORS+=("Invalid displaced_by format: '$dby' (expected FXX or domain.slug, e.g. F05 or schema.field-access)")
     elif [[ -f "$MANIFEST" ]]; then
       dby_file=$(spec_file_for_id "$MANIFEST" "$dby")
       if [[ -z "$dby_file" || ! -f "$dby_file" ]]; then
@@ -106,8 +113,8 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
   # ── Check 7c: revives[] IDs must be INVALIDATED specs
   while IFS= read -r rev; do
     [[ -z "$rev" ]] && continue
-    if ! echo "$rev" | grep -qE '^F[0-9]+$'; then
-      ERRORS+=("Invalid revives format: '$rev' (expected FXX e.g. F05)")
+    if ! echo "$rev" | grep -qE "$spec_id_re"; then
+      ERRORS+=("Invalid revives format: '$rev' (expected FXX or domain.slug)")
     elif [[ -f "$MANIFEST" ]]; then
       rev_file=$(spec_file_for_id "$MANIFEST" "$rev")
       if [[ -z "$rev_file" || ! -f "$rev_file" ]]; then
@@ -124,8 +131,8 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
   # ── Check 7d: revived_by[] IDs resolve via registry (optional field)
   while IFS= read -r rby; do
     [[ -z "$rby" ]] && continue
-    if ! echo "$rby" | grep -qE '^F[0-9]+$'; then
-      ERRORS+=("Invalid revived_by format: '$rby' (expected FXX e.g. F05)")
+    if ! echo "$rby" | grep -qE "$spec_id_re"; then
+      ERRORS+=("Invalid revived_by format: '$rby' (expected FXX or domain.slug)")
     elif [[ -f "$MANIFEST" ]]; then
       rby_file=$(spec_file_for_id "$MANIFEST" "$rby")
       if [[ -z "$rby_file" || ! -f "$rby_file" ]]; then

--- a/scripts/work-finalize.sh
+++ b/scripts/work-finalize.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# work-finalize.sh — finalize work group state after feature refactor
+# Usage: work-finalize.sh <feature-slug>
+#
+# Called by feature-refactor Step 6b. For work-group-sourced features:
+# 1. Sets WD status to COMPLETE
+# 2. Resolves obligations referenced in brief.md
+# 3. Removes resolved IDs from spec open_obligations frontmatter
+#
+# Idempotent — safe to run multiple times.
+
+set -euo pipefail
+
+SLUG="${1:-}"
+[[ -z "$SLUG" ]] && { echo "Usage: work-finalize.sh <feature-slug>" >&2; exit 0; }
+
+# Find .feature directory (check both active and archive)
+FEATURE_DIR=""
+if [[ -d ".feature/$SLUG" ]]; then
+    FEATURE_DIR=".feature/$SLUG"
+elif [[ -d ".feature/_archive/$SLUG" ]]; then
+    FEATURE_DIR=".feature/_archive/$SLUG"
+fi
+
+[[ -z "$FEATURE_DIR" ]] && { echo "[finalize] Feature directory not found for $SLUG" >&2; exit 0; }
+
+STATUS_FILE="$FEATURE_DIR/status.md"
+BRIEF_FILE="$FEATURE_DIR/brief.md"
+
+[[ ! -f "$STATUS_FILE" ]] && { echo "[finalize] No status.md — skipping" >&2; exit 0; }
+
+# ── Detect work group ──────────────────────────────────────────────────────
+
+WORK_GROUP=""
+WORK_DEF=""
+
+# Try status.md fields first
+if [[ -f "$STATUS_FILE" ]]; then
+    WORK_GROUP="$(grep -m1 '^work_group:' "$STATUS_FILE" 2>/dev/null | sed 's/^work_group:[[:space:]]*//' || true)"
+    WORK_DEF="$(grep -m1 '^work_definition:' "$STATUS_FILE" 2>/dev/null | sed 's/^work_definition:[[:space:]]*//' || true)"
+fi
+
+# Fallback: derive from slug convention (group--wd)
+if [[ -z "$WORK_GROUP" && "$SLUG" == *"--"* ]]; then
+    WORK_GROUP="${SLUG%%--*}"
+    wd_suffix="${SLUG##*--}"
+    WORK_DEF="$(echo "$wd_suffix" | tr '[:lower:]' '[:upper:]' | sed 's/-/\-/g')"
+fi
+
+[[ -z "$WORK_GROUP" ]] && { echo "[finalize] Not a work-group feature — skipping" >&2; exit 0; }
+
+echo "[finalize] Work group: $WORK_GROUP, WD: $WORK_DEF"
+
+# ── 1. Set WD status to COMPLETE ──────────────────────────────────────────
+
+WORK_DIR=".work/$WORK_GROUP"
+[[ ! -d "$WORK_DIR" ]] && { echo "[finalize] Work group directory not found: $WORK_DIR" >&2; exit 0; }
+
+# Find the WD file
+WD_FILE=""
+for f in "$WORK_DIR"/WD-*.md; do
+    [[ ! -f "$f" ]] && continue
+    wd_id="$(awk '/^---$/{n++; next} n==1 && /^id:/{sub(/^id:[[:space:]]*/, ""); gsub(/["'"'"']/, ""); print; exit} n>=2{exit}' "$f")"
+    if [[ "$wd_id" == "$WORK_DEF" ]]; then
+        WD_FILE="$f"
+        break
+    fi
+done
+
+if [[ -n "$WD_FILE" ]]; then
+    current_status="$(awk '/^---$/{n++; next} n==1 && /^status:/{sub(/^status:[[:space:]]*/, ""); gsub(/["'"'"']/, ""); print; exit} n>=2{exit}' "$WD_FILE")"
+    if [[ "$current_status" == "COMPLETE" ]]; then
+        echo "[finalize] WD already COMPLETE — skipping status update"
+    else
+        sed -i "s/^status:.*$/status: COMPLETE/" "$WD_FILE"
+        echo "[finalize] WD status → COMPLETE"
+    fi
+else
+    echo "[finalize] WD file not found for $WORK_DEF in $WORK_DIR" >&2
+fi
+
+# ── 2. Resolve obligations ────────────────────────────────────────────────
+
+OB_REGISTRY=".spec/registry/_obligations.json"
+[[ ! -f "$OB_REGISTRY" ]] && { echo "[finalize] No _obligations.json — skipping obligation resolution" >&2; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "[finalize] jq not available — skipping obligation resolution" >&2; exit 0; }
+
+# Extract obligation IDs from brief.md and WD file, then validate against registry
+CANDIDATE_IDS=()
+for src_file in "$BRIEF_FILE" "$WD_FILE"; do
+    [[ -z "$src_file" || ! -f "$src_file" ]] && continue
+    while IFS= read -r ob_id; do
+        [[ -n "$ob_id" ]] && CANDIDATE_IDS+=("$ob_id")
+    done < <(grep -oE 'OBL-[A-Za-z0-9_-]+' "$src_file" 2>/dev/null | sort -u)
+done
+
+# Validate candidates against actual IDs in the registry — drop partial matches
+KNOWN_IDS="$(jq -r '.obligations[].id' "$OB_REGISTRY" 2>/dev/null)"
+OB_IDS=()
+for candidate in $(printf '%s\n' "${CANDIDATE_IDS[@]}" | sort -u); do
+    if echo "$KNOWN_IDS" | grep -qx "$candidate" 2>/dev/null; then
+        OB_IDS+=("$candidate")
+    fi
+done
+
+if [[ ${#OB_IDS[@]} -eq 0 ]]; then
+    echo "[finalize] No obligation IDs found in brief or WD — skipping"
+    exit 0
+fi
+
+echo "[finalize] Found obligation IDs: ${OB_IDS[*]}"
+
+TODAY="$(date -u +%Y-%m-%d)"
+RESOLVED_IDS=()
+SPEC_IDS=()
+
+for ob_id in "${OB_IDS[@]}"; do
+    # Check if this obligation exists and is open
+    ob_status="$(jq -r --arg id "$ob_id" '.obligations[] | select(.id == $id) | .status' "$OB_REGISTRY" 2>/dev/null || true)"
+
+    if [[ "$ob_status" == "open" ]]; then
+        # Build resolved_by from the feature slug
+        resolved_by="$SLUG"
+
+        # Resolve the obligation
+        jq --arg id "$ob_id" \
+           --arg resolved_by "$resolved_by" \
+           --arg date "$TODAY" \
+           '(.obligations[] | select(.id == $id)) |= . + {status: "resolved", resolved_by: $resolved_by, resolved_date: $date}' \
+           "$OB_REGISTRY" > "$OB_REGISTRY.tmp" && mv "$OB_REGISTRY.tmp" "$OB_REGISTRY"
+
+        echo "[finalize] Resolved: $ob_id"
+        RESOLVED_IDS+=("$ob_id")
+
+        # Track which specs need frontmatter update
+        spec_id="$(jq -r --arg id "$ob_id" '.obligations[] | select(.id == $id) | .spec' "$OB_REGISTRY" 2>/dev/null || true)"
+        [[ -n "$spec_id" ]] && SPEC_IDS+=("$spec_id")
+    elif [[ "$ob_status" == "resolved" ]]; then
+        echo "[finalize] Already resolved: $ob_id"
+    else
+        echo "[finalize] Obligation $ob_id not found or status=$ob_status — skipping"
+    fi
+done
+
+# ── 3. Update spec open_obligations frontmatter ────────────────────────────
+
+# Deduplicate spec IDs
+SPEC_IDS=($(printf '%s\n' "${SPEC_IDS[@]}" 2>/dev/null | sort -u))
+
+MANIFEST=".spec/registry/manifest.json"
+for spec_id in "${SPEC_IDS[@]}"; do
+    # Find the spec file via manifest
+    spec_file=""
+    if [[ -f "$MANIFEST" ]]; then
+        rel_path="$(jq -r --arg id "$spec_id" '.features[$id].latest_file // ""' "$MANIFEST" 2>/dev/null || true)"
+        [[ -n "$rel_path" ]] && spec_file=".spec/$rel_path"
+    fi
+
+    # Fallback: search .spec/domains/
+    if [[ -z "$spec_file" || ! -f "$spec_file" ]]; then
+        spec_file="$(find .spec/domains -name "${spec_id}-*.md" -o -name "${spec_id}.md" 2>/dev/null | head -1 || true)"
+    fi
+
+    [[ -z "$spec_file" || ! -f "$spec_file" ]] && continue
+
+    # Remove resolved obligation IDs from open_obligations array
+    for ob_id in "${RESOLVED_IDS[@]}"; do
+        # Check if this obligation belongs to this spec
+        ob_spec="$(jq -r --arg id "$ob_id" '.obligations[] | select(.id == $id) | .spec' "$OB_REGISTRY" 2>/dev/null || true)"
+        [[ "$ob_spec" != "$spec_id" ]] && continue
+
+        # Remove from the JSON frontmatter's open_obligations array
+        if grep -q "$ob_id" "$spec_file" 2>/dev/null; then
+            # Handle the JSON frontmatter between --- delimiters
+            # Remove the obligation ID from the open_obligations array
+            sed -i "s/\"$ob_id\",\?//g" "$spec_file"
+            # Clean up trailing commas in array
+            sed -i 's/,\]/]/g' "$spec_file"
+            # Clean up leading commas after [
+            sed -i 's/\[,/[/g' "$spec_file"
+            # Clean up double commas
+            sed -i 's/,,/,/g' "$spec_file"
+            echo "[finalize] Removed $ob_id from $spec_file open_obligations"
+        fi
+    done
+done
+
+echo "[finalize] Done. Resolved ${#RESOLVED_IDS[@]} obligations."

--- a/scripts/work-lib.sh
+++ b/scripts/work-lib.sh
@@ -143,6 +143,7 @@ work_fm_artifact_deps() {
             if (kv[1] == "type") dep_type = val
             else if (kv[1] == "path") dep_path = val
             else if (kv[1] == "slug") dep_slug = val
+            else if (kv[1] == "ref") dep_path = val
             else if (kv[1] == "required_state") req_state = val
             else if (kv[1] == "required_status") req_state = val
             else if (kv[1] == "kind") kind = val

--- a/scripts/work-resolve.sh
+++ b/scripts/work-resolve.sh
@@ -92,8 +92,28 @@ while IFS= read -r wd_file; do
   fi
 
   if [[ "$wd_status" == "SPECIFIED" ]]; then
-    WD_STATUS["$wd_id"]="SPECIFIED"
-    ((SPECIFIED_COUNT++)) || true
+    # Check wd-type deps — SPECIFIED WDs may be blocked by predecessor WDs
+    spec_blockers=""
+    spec_dep_count=0
+    while IFS='|' read -r dep_type dep_ref dep_req_state dep_kind; do
+      [[ -z "$dep_type" ]] && continue
+      ((spec_dep_count++)) || true
+      if [[ "$dep_type" == "wd" ]]; then
+        ref_status="${WD_STATUS[$dep_ref]:-}"
+        if [[ -z "$ref_status" || "$ref_status" != "$dep_req_state" ]]; then
+          spec_blockers+="wd:$dep_ref — need $dep_req_state, currently ${ref_status:-not found}"$'\n'
+        fi
+      fi
+    done < <(work_fm_artifact_deps "$wd_file")
+    WD_DEP_COUNT["$wd_id"]=$spec_dep_count
+    if [[ -z "$spec_blockers" ]]; then
+      WD_STATUS["$wd_id"]="SPECIFIED"
+      ((SPECIFIED_COUNT++)) || true
+    else
+      WD_STATUS["$wd_id"]="BLOCKED"
+      WD_BLOCKERS["$wd_id"]="$spec_blockers"
+      ((BLOCKED_COUNT++)) || true
+    fi
     continue
   fi
 
@@ -115,6 +135,12 @@ while IFS= read -r wd_file; do
         ;;
       kb)
         reason=$(work_check_kb_dep "$PROJECT_ROOT" "$dep_ref") || true
+        ;;
+      wd)
+        ref_wd_status="${WD_STATUS[$dep_ref]:-}"
+        if [[ -z "$ref_wd_status" || "$ref_wd_status" != "$dep_req_state" ]]; then
+          reason="WD $dep_ref is ${ref_wd_status:-not found} (need $dep_req_state)"
+        fi
         ;;
       *)
         reason="unknown dependency type: $dep_type"
@@ -165,6 +191,22 @@ for wd_id in "${!WD_FILE[@]}"; do
       done < <(work_fm_artifact_deps "${WD_FILE[$other_id]}")
     done
   done < <(work_fm_produces "${WD_FILE[$wd_id]}")
+done
+
+# ── Add wd-type dep edges to the graph ──────────────────────────────────────
+# wd-type deps create direct WD-to-WD edges without needing produces/artifact
+# matching.
+
+for wd_id in "${!WD_FILE[@]}"; do
+  while IFS='|' read -r dep_type dep_ref dep_req_state dep_kind; do
+    [[ -z "$dep_type" || "$dep_type" != "wd" ]] && continue
+    [[ -z "${WD_FILE[$dep_ref]+x}" ]] && continue
+    if [[ -z "${WD_UNBLOCKS[$dep_ref]+x}" ]]; then
+      WD_UNBLOCKS["$dep_ref"]="$wd_id"
+    else
+      WD_UNBLOCKS["$dep_ref"]="${WD_UNBLOCKS[$dep_ref]},$wd_id"
+    fi
+  done < <(work_fm_artifact_deps "${WD_FILE[$wd_id]}")
 done
 
 # ── Sync manifest table (single source of truth: WD frontmatter) ────────────

--- a/scripts/work-validate.sh
+++ b/scripts/work-validate.sh
@@ -69,9 +69,9 @@ validate_wd_file() {
       [[ -z "$dep_type" ]] && continue
       ((dep_count++)) || true
 
-      # Type must be spec, adr, or kb
-      if [[ ! "$dep_type" =~ ^(spec|adr|kb)$ ]]; then
-        errors+=("artifact_deps: invalid type '$dep_type' (must be spec|adr|kb)")
+      # Type must be spec, adr, kb, or wd
+      if [[ ! "$dep_type" =~ ^(spec|adr|kb|wd)$ ]]; then
+        errors+=("artifact_deps: invalid type '$dep_type' (must be spec|adr|kb|wd)")
       fi
 
       # Reference must be non-empty
@@ -79,8 +79,8 @@ validate_wd_file() {
         errors+=("artifact_deps: missing path/slug for $dep_type dependency")
       fi
 
-      # spec and adr must have required_state/required_status
-      if [[ "$dep_type" =~ ^(spec|adr)$ && -z "$dep_req_state" ]]; then
+      # spec, adr, and wd must have required_state/required_status
+      if [[ "$dep_type" =~ ^(spec|adr|wd)$ && -z "$dep_req_state" ]]; then
         errors+=("artifact_deps: $dep_type:$dep_ref missing required_state/required_status")
       fi
     done < <(work_fm_artifact_deps "$file")
@@ -160,6 +160,12 @@ check_circular_deps() {
     DEP_EDGES["$wd_id"]=""
     while IFS='|' read -r dep_type dep_ref dep_req_state dep_kind; do
       [[ -z "$dep_type" ]] && continue
+      # wd-type deps are direct WD-to-WD edges
+      if [[ "$dep_type" == "wd" ]]; then
+        [[ "$dep_ref" == "$wd_id" ]] && continue  # self-reference
+        DEP_EDGES["$wd_id"]="${DEP_EDGES[$wd_id]} $dep_ref"
+        continue
+      fi
       local key="$dep_type|$dep_ref"
       if [[ -n "${PRODUCES_MAP[$key]+x}" ]]; then
         local producer="${PRODUCES_MAP[$key]}"

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -197,6 +197,16 @@ From "Spec Coverage Gaps" in the scan summary (if present):
    obligations are resolved
 3. Higher obligation count = more blocking
 
+**Obligation registry (from _obligations.json):**
+1. Open obligations from the centralized registry — spec requirements where the
+   code does not match the spec. These are the gap between what was specified
+   and what was built.
+2. Group by spec for display. Show affected requirement count and blocked_by.
+3. Route to `/work-decompose "<group>" --from-obligations` to convert
+   obligations into a work group with proper WD ordering. This is the primary
+   action — obligations without a work group have no implementation path.
+4. Higher affected-requirement count = larger implementation gap.
+
 **Spec-code drift:**
 1. Specs whose domain files have been committed since the spec was created
 2. Higher commit count = more likely the spec no longer matches reality
@@ -585,6 +595,21 @@ are: <list>."
 Use AskUserQuestion:
   - "Resolve via /spec-resolve"
   - "Skip"
+
+**Obligation registry:** Present the obligations grouped by spec: "Spec <ID>
+has <N> open obligations affecting <M> requirements. Blocked by: <blockers>."
+
+Use AskUserQuestion:
+  - "Create work group from obligations" (description: "Run /work-decompose
+    with --from-obligations to convert these into actionable work definitions")
+  - "View obligation details" (description: "Read the full obligation
+    descriptions from _obligations.json")
+  - "Skip"
+
+When "Create work group": guide the user to create a work group with `/work`
+for the affected spec(s), then run `/work-decompose "<group>" --from-obligations`.
+When "View details": read and display the full obligation entries from
+_obligations.json for the selected spec.
 
 **Spec-code drift:** Present the commit count and affected domains: "This spec
 was written on <date> and <N> commits have touched its domain files since."

--- a/skills/feature-complete/SKILL.md
+++ b/skills/feature-complete/SKILL.md
@@ -107,7 +107,7 @@ If this is a work-group-sourced feature:
 
 1. Determine the work group slug (from status.md `work_group` field or slug prefix)
 2. Verify the WD frontmatter has `status: COMPLETE` (should already be set
-   by the retro step)
+   by feature-refactor Step 6b). If not COMPLETE, set it now as a fallback.
 3. Update `.work/CLAUDE.md` — increment the Complete count for this group
 
 The manifest table is automatically synced by `work-resolve.sh` — do not

--- a/skills/feature-refactor/SKILL.md
+++ b/skills/feature-refactor/SKILL.md
@@ -587,6 +587,29 @@ Append `refactor-complete` to cycle-log.md:
 
 Update `.feature/CLAUDE.md`.
 
+### Step 6b — Work group finalization
+
+Run the finalization script. This is a **script call, not an LLM task** —
+the script handles WD status, obligation resolution, and spec frontmatter
+updates mechanically.
+
+```bash
+bash .claude/scripts/work-finalize.sh "<slug>"
+```
+
+The script:
+1. Sets the WD status to COMPLETE
+2. Resolves obligations referenced in brief.md (`_obligations.json`)
+3. Removes resolved IDs from spec `open_obligations` frontmatter
+
+It is idempotent and exits cleanly if the feature is not work-group-sourced.
+Display the script output to the user.
+
+These changes are committed with the feature so the PR includes the
+updated obligation and work group state.
+
+---
+
 Read `automation_mode` from status.md.
 
 **If `execution_strategy` is `balanced` or `speed` (parallel mode):**

--- a/skills/feature-retro/SKILL.md
+++ b/skills/feature-retro/SKILL.md
@@ -425,11 +425,13 @@ If this feature is work-group-sourced:
    whose id matches the `work_definition` field in status.md (or derive from
    the slug's WD portion).
 
-3. **Update WD status to COMPLETE:**
-   - Edit the WD file's front matter: set `status: COMPLETE`
+3. **Update WD status to COMPLETE (idempotent):**
+   - Read the WD file's front matter. If `status` is already `COMPLETE`,
+     skip — feature-refactor Step 6b already handled this.
+   - If not COMPLETE: edit the WD file's front matter: set `status: COMPLETE`
 
-4. **Update the manifest:** Edit `.work/<group>/manifest.md` — update the WD's
-   status in the Work Definitions table.
+4. **Update the manifest:** The manifest table is automatically synced by
+   `work-resolve.sh` in step 5 below — do not update it manually.
 
 5. **Check readiness cascade:**
    ```bash

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -59,12 +59,35 @@ Identify the implementation files. Sources (in priority order):
 Focus on the code that implements the requirements. Do not read the entire
 codebase — read targeted files.
 
-**Annotate as you go.** For every enforcement point discovered during
-verification — whether from existing annotations, work plans, or domain
-scanning — ensure an `@spec` annotation exists in the code. If an
-enforcement point is found but not annotated, add the annotation before
-proceeding to the verdict. This ensures that every verification pass
-leaves the codebase with complete traceability for the verified spec.
+**Annotate implementation as you go.** For every enforcement point
+discovered during verification — whether from existing annotations, work
+plans, or domain scanning — ensure an `@spec` annotation exists in the
+code. If an enforcement point is found but not annotated, add the
+annotation before proceeding to the verdict.
+
+**Annotate tests as you go.** For every test method that validates a
+requirement, ensure an `@spec` annotation exists on the test. Find tests
+by:
+1. Existing `@spec` annotations in test files (from spec-trace.sh)
+2. Test names/assertions that correspond to requirements (e.g.,
+   `testNullKeyRejection` → R15 null key check)
+3. Adversarial test classes that reference spec findings
+
+If a test validates a requirement but lacks an `@spec` annotation, add it.
+
+**Track test coverage gaps.** After annotating both implementation and
+test files, identify requirements with:
+- Implementation annotation but no test annotation — **test gap**
+- Neither implementation nor test annotation — **missing implementation**
+
+Report test gaps in the verification output. Requirements with test gaps
+are still verifiable (the implementation exists) but the test traceability
+is incomplete. Phase 5 (repair) should write structural/behavioral tests
+for requirements that have zero test coverage, including:
+- Reflection tests for structural requirements (final class, sealed
+  interface, absent methods, package visibility)
+- Behavioral tests for validation/rejection requirements
+- Skip negative concurrency claims (flaky test territory)
 
 Annotation rules (from `.spec/CLAUDE.md` Code Traceability section):
 - Format: `// @spec FXX.RN` or `// @spec FXX.RN — brief description`
@@ -113,6 +136,7 @@ For each non-SATISFIED requirement, classify it into one of three categories:
 | **code-bug** | Spec is correct, code doesn't match | Fix code + write regression test |
 | **stale-spec** | Code is correct (or stricter), spec text is outdated | Amend spec text |
 | **needs-decision** | Genuinely ambiguous — code does Y, spec says X, both are defensible | User decides direction |
+| **test-gap** | Requirement SATISFIED but no test-side @spec annotation | Write/annotate tests |
 
 Present ALL findings batched, grouped by classification:
 
@@ -132,6 +156,12 @@ Stale spec text (code is correct, spec needs update):
   R42 — spec says "silently ignores trailing bytes" but code now rejects them.
         Code is stricter, which is better.
   R43 — spec says "document in public API" but javadoc is missing.
+
+Test gaps (SATISFIED but no test traceability):
+  R1 — final class, testable via reflection (Modifier.isFinal)
+  R54 — private final fields, testable via reflection
+  R62 — no toString override, testable via reflection
+  ... (N requirements with implementation but no linked tests)
 
 Use AskUserQuestion with relevant options.
 ```
@@ -268,6 +298,43 @@ requirement against the spec:
 If any requirement is still not SATISFIED after the fix, investigate.
 Either the fix is incomplete (iterate) or the spec needs amendment
 (reclassify as stale-spec and return to Phase 4).
+
+### Step 5.5 — Fill test gaps
+
+For each **test-gap** finding (requirement SATISFIED but no test-side
+`@spec` annotation):
+
+1. **Check if an existing test already validates this requirement.** Search
+   test files for assertions that exercise the requirement's behavior (e.g.,
+   a test named `testNullKeyRejection` likely covers a null-rejection
+   requirement). If found, add the `@spec` annotation to the existing test.
+
+2. **If no existing test covers the requirement, write one.** Categorize
+   the requirement and write the appropriate test type:
+
+   | Requirement type | Test approach |
+   |-----------------|---------------|
+   | Behavioral (validation, rejection, output) | Standard input/output assertion |
+   | Structural (final class, sealed, package) | Reflection test (Modifier checks) |
+   | Absent behavior (no toString, no Serializable) | Reflection test (method/interface absence) |
+   | Documentation (javadoc, API contract) | Skip — not testable |
+   | Negative concurrency (no synchronization) | Skip — flaky test territory |
+
+3. **Annotate every test** with `@spec FXX.RN` linking it to the requirement.
+
+4. **Run the test suite** to confirm all new tests pass. Test-gap tests
+   must pass immediately (unlike regression tests for violations which must
+   fail first) — the implementation already satisfies the requirement, the
+   test just didn't exist.
+
+Present test-gap results:
+```
+── Test gap results: <id> ──────────────────────
+  Existing tests annotated: <count>
+  New tests written: <count>
+  Skipped (untestable): <count>
+  Total test coverage: <annotated>/<total requirements>
+```
 
 ---
 

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -90,10 +90,13 @@ for requirements that have zero test coverage, including:
 - Skip negative concurrency claims (flaky test territory)
 
 Annotation rules (from `.spec/CLAUDE.md` Code Traceability section):
-- Format: `// @spec FXX.RN` or `// @spec FXX.RN — brief description`
+- Format: `// @spec <spec-id>.RN` or `// @spec <spec-id>.RN — brief description`
+- Spec ID can be legacy `FXX` (e.g., `F13.R5`) or new domain.slug (e.g.,
+  `schema.field-access.R5`). Match the project's convention — check
+  `.spec/domains/` to see which is in use.
 - Place above the enforcing method or code block
 - Same format in both implementation and test files
-- Multiple requirements per annotation: `// @spec FXX.R1,R3,R7`
+- Multiple requirements per annotation: `// @spec <spec-id>.R1,R3,R7`
 
 After discovery and annotation, run `spec-trace.sh` again to confirm
 coverage. Report any requirements with zero enforcement points — these
@@ -320,7 +323,8 @@ For each **test-gap** finding (requirement SATISFIED but no test-side
    | Documentation (javadoc, API contract) | Skip — not testable |
    | Negative concurrency (no synchronization) | Skip — flaky test territory |
 
-3. **Annotate every test** with `@spec FXX.RN` linking it to the requirement.
+3. **Annotate every test** with `@spec <spec-id>.RN` linking it to the
+   requirement (FXX.RN or domain.slug.RN, matching the project's convention).
 
 4. **Run the test suite** to confirm all new tests pass. Test-gap tests
    must pass immediately (unlike regression tests for violations which must

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -1,13 +1,21 @@
 ---
-description: "Verify a spec against its implementation"
+description: "Verify a spec against its implementation and repair violations"
 argument-hint: "<feature-id>"
 effort: high
 ---
 
 # /spec-verify <feature-id>
 
-Reconcile a spec's requirements against the current implementation.
-Idempotent — safe to re-run. Updates spec state on success.
+Verify a spec's requirements against the current implementation. When
+violations are found, repair them inline — fix code or amend spec text —
+then re-verify. A spec is not done until every requirement is SATISFIED
+or the user explicitly defers a finding.
+
+**Spec violations are broken contracts, not backlog items.** Every downstream
+consumer (work-plan, spec-author, audit, domain analysis) operates on the
+assumption that specs are true. A VIOLATED requirement means the system
+doesn't do what it claims. This skill owns the full lifecycle: diagnose,
+classify, repair, confirm.
 
 ---
 
@@ -31,27 +39,28 @@ Idempotent — safe to re-run. Updates spec state on success.
 
 ---
 
-## Step 1 — Load the spec
+## Phase 1 — Verify all requirements
+
+### Step 1.1 — Load the spec
 
 Read the spec file's machine section (requirements only, not narrative).
 Note the feature ID and version.
 
----
-
-## Step 2 — Load the implementation
+### Step 1.2 — Load the implementation
 
 Identify the implementation files. Sources (in priority order):
-- If `.feature/<slug>/` exists for this feature, read the work plan and
-  implementation files listed there
-- Otherwise, use the spec's `domains` to identify likely source directories,
-  and read the relevant files
+1. **@spec annotations** — run `bash .claude/scripts/spec-trace.sh <id>`
+   to find all annotated enforcement points. This is the primary discovery
+   mechanism.
+2. If `.feature/<slug>/` exists for this feature, read the work plan and
+   implementation files listed there.
+3. Otherwise, use the spec's `domains` to identify likely source
+   directories and read the relevant files.
 
 Focus on the code that implements the requirements. Do not read the entire
 codebase — read targeted files.
 
----
-
-## Step 3 — Verify each requirement
+### Step 1.3 — Verify each requirement
 
 For each numbered requirement (R1, R2, ...), determine one of:
 
@@ -64,29 +73,191 @@ For each numbered requirement (R1, R2, ...), determine one of:
 
 For each verdict, provide a one-line evidence reference (file:line or method name).
 
----
-
-## Step 4 — Check obligations
-
-Review the spec's `open_obligations` array. For each obligation:
-- If addressed by the implementation, note it as resolved
-- If not addressed, flag it
-
----
-
-## Step 5 — Check for undocumented behavior
+### Step 1.4 — Check for undocumented behavior
 
 Scan the implementation for significant behavior that is NOT covered by
-any requirement. If found, note it as:
-```
-Undocumented: <description> — consider adding as R<N+1>
-```
+any requirement. Note these as informational findings — they may become
+new requirements during the repair phase.
 
-This is informational, not a verification failure.
+### Step 1.5 — Present verification results
+
+Display the full verdict table. If all requirements are SATISFIED (or
+SATISFIED + UNTESTABLE only), skip to Phase 6 (Finalize).
+
+If any requirements are PARTIAL or VIOLATED, proceed to Phase 2.
 
 ---
 
-## Step 6 — Write verification note
+## Phase 2 — Classify findings
+
+For each non-SATISFIED requirement, classify it into one of three categories:
+
+| Classification | When to use | Repair action |
+|----------------|-------------|---------------|
+| **code-bug** | Spec is correct, code doesn't match | Fix code + write regression test |
+| **stale-spec** | Code is correct (or stricter), spec text is outdated | Amend spec text |
+| **needs-decision** | Genuinely ambiguous — code does Y, spec says X, both are defensible | User decides direction |
+
+Present ALL findings batched, grouped by classification:
+
+```
+── Verification findings: <id> ─────────────────────
+
+Needs decision (resolve before fixes):
+  R39g — spec requires IOException on buffer exceed, code gracefully falls
+         back. Fallback may be the better design (avoids data loss on large
+         files). Which is correct?
+
+Code bugs (will write regression tests + fix):
+  R33 — readKeyIndexV2 missing bounds validation on blockIndex/intraBlockOffset.
+        Corrupt data throws internal exceptions instead of descriptive IOException.
+
+Stale spec text (code is correct, spec needs update):
+  R42 — spec says "silently ignores trailing bytes" but code now rejects them.
+        Code is stricter, which is better.
+  R43 — spec says "document in public API" but javadoc is missing.
+
+Use AskUserQuestion with relevant options.
+```
+
+---
+
+## Phase 3 — Resolve decisions
+
+For each **needs-decision** finding, present the tradeoff and ask the user
+to choose a direction.
+
+For each finding, present:
+1. What the spec says
+2. What the code does
+3. Why each approach is defensible
+4. The implication of each direction
+
+Use AskUserQuestion with options:
+- "Fix the code (spec is correct)"
+- "Amend the spec (code is correct)"
+- "Defer (create obligation for later)" — only if user explicitly chooses
+- "Need more analysis" — invoke `/architect` if a design decision is needed
+
+After each decision:
+- If "fix the code": reclassify as **code-bug**
+- If "amend the spec": reclassify as **stale-spec**
+- If "defer": create an obligation and exclude from repair
+- If "need more analysis": pause spec-verify, invoke `/architect` with the
+  ambiguity framed as a constraint. Resume after the decision is made.
+
+After all decisions are resolved, proceed to Phase 4.
+
+---
+
+## Phase 4 — Amend stale specs
+
+For each **stale-spec** finding:
+
+1. **Draft the amendment.** Write the updated requirement text. The
+   requirement number stays the same — this is an in-place update, not a
+   new requirement.
+
+2. **Check for displacement.** Run displacement detection against other
+   specs in the same domains:
+   ```bash
+   NEW_SPEC_FILES=".spec/$spec_file" \
+     bash .claude/scripts/spec-resolve.sh "<domains>" 2>&1
+   ```
+   If the amendment would displace requirements in another spec, **stop and
+   present the chain to the user.** Do not auto-follow displacement chains.
+
+   Use AskUserQuestion with options:
+   - "Apply amendment (I'll handle downstream impact separately)"
+   - "Skip this amendment"
+
+3. **Apply the amendment.** Update the requirement text in the spec file.
+
+4. **Bump the version** in the spec's front matter (increment by 1).
+
+5. **Re-validate structure:**
+   ```bash
+   bash .claude/scripts/spec-validate.sh ".spec/$spec_file"
+   ```
+
+After all amendments are applied, proceed to Phase 5.
+
+---
+
+## Phase 5 — Fix code violations (TDD)
+
+This is the core repair phase. For each **code-bug** finding, run a
+scoped TDD cycle: write a regression test that enforces the spec
+requirement, then implement the fix.
+
+### Step 5.1 — Plan all fixes
+
+Before writing any code, present the fix plan for all code-bug findings
+together:
+
+```
+── Fix plan: <id> ──────────────────────────────
+
+<n> code violations to fix:
+
+  R33 — Add bounds validation to readKeyIndexV2
+        Test: verify IOException on out-of-range blockIndex
+        Fix: add range check before CompressionMap.entry() call
+
+  R15 — Add blank key rejection to JsonObject.of/Builder.put
+        Test: verify IAE on blank/whitespace key
+        Fix: add isBlank() check after requireNonNull
+
+Use AskUserQuestion with options:
+  - "Approve fix plan"
+  - "Adjust" (with Other for custom input)
+```
+
+### Step 5.2 — Write regression tests (all violations, batched)
+
+For each code-bug finding, write a test that:
+1. Is annotated with `@spec <id>.R<n>` linking it to the requirement
+2. Exercises the specific violation (e.g., passes corrupt data, passes
+   blank key)
+3. Asserts the behavior the spec requires (e.g., IOException with
+   descriptive message, IAE on blank key)
+4. **Currently fails** against the unfixed code — this confirms the
+   violation is real and the test is meaningful
+
+Run the test suite. Confirm all new regression tests fail. If a test
+passes, the violation may not be real — re-examine the finding.
+
+Read `.feature/project-config.md` for test framework, conventions, and
+source directories. Follow the project's existing test patterns.
+
+### Step 5.3 — Implement fixes
+
+For each violation, implement the minimum correct fix:
+- Follow the project's coding conventions
+- Do not modify existing tests — only add new regression tests
+- Do not refactor surrounding code — fix only the violation
+- Add `@spec` annotations to the new/changed code
+
+Run the test suite after each fix. All tests (existing + new regression
+tests) must pass before proceeding to the next fix.
+
+### Step 5.4 — Verify fixes
+
+After all fixes are implemented and tests pass, re-verify each fixed
+requirement against the spec:
+- Re-read the implementation code at the fix location
+- Confirm the verdict is now SATISFIED
+- Update the evidence reference
+
+If any requirement is still not SATISFIED after the fix, investigate.
+Either the fix is incomplete (iterate) or the spec needs amendment
+(reclassify as stale-spec and return to Phase 4).
+
+---
+
+## Phase 6 — Finalize
+
+### Step 6.1 — Write verification note
 
 Append to the spec file's `## Verification Notes` section:
 
@@ -96,25 +267,31 @@ Append to the spec file's `## Verification Notes` section:
 | Req | Verdict | Evidence |
 |-----|---------|----------|
 | R1 | SATISFIED | <file:line or method> |
-| R2 | PARTIAL | <what's missing> |
+| R2 | SATISFIED | <file:line or method> |
 | ... | ... | ... |
 
 **Overall: PASS | PASS_WITH_NOTES | FAIL**
 
-Obligations resolved: <count>
-Obligations remaining: <count>
+Amendments applied: <count or "none">
+Code fixes applied: <count or "none">
+Regression tests added: <count or "none">
+Obligations deferred: <count or "none">
 Undocumented behavior: <count or "none">
 ```
 
----
+If any requirements were amended, note the old and new text:
+```markdown
+#### Amendments
+- R42: "silently ignores trailing bytes" → "rejects trailing bytes with
+  IllegalArgumentException"
+```
 
-## Step 7 — Update state and status
+### Step 6.2 — Update state and registry
 
-**Only if overall verdict is PASS or PASS_WITH_NOTES:**
+**If all requirements are SATISFIED (or SATISFIED + UNTESTABLE only):**
 
 Update the spec file's front matter:
-- `state`: DRAFT -> APPROVED
-- `status`: keep as-is (status tracks lifecycle maturity, not verification)
+- `state`: DRAFT → APPROVED
 
 Update the registry:
 ```bash
@@ -124,40 +301,41 @@ jq --arg id "<feature-id>" '.features[$id].state = "APPROVED"' \
   && mv "$tmp" .spec/registry/manifest.json
 ```
 
-**If overall verdict is FAIL:**
-- Do NOT change state or status
-- Create an obligation in `_obligations.json` for each VIOLATED requirement:
-  ```json
-  {
-    "id": "OBL-<next>",
-    "domains": ["<spec domains>"],
-    "description": "<requirement text> — VIOLATED in verification",
-    "target_feature": "<feature-id>",
-    "created_by": "spec-verify",
-    "status": "open"
-  }
-  ```
+**If any requirements remain VIOLATED or PARTIAL (deferred by user):**
+- Do NOT change state
+- Ensure obligations exist in `_obligations.json` for each deferred finding
 
----
+### Step 6.3 — Resolve existing obligations
 
-## Step 8 — Run obligations GC
+Check `_obligations.json` for obligations targeting this spec. If any
+are now resolved by the fixes applied in Phase 5, update their status:
+```json
+{ "status": "resolved", "resolved_by": "spec-verify", "resolved_date": "<date>" }
+```
 
+Run obligations GC:
 ```bash
 bash .claude/scripts/spec-obligations-gc.sh
 ```
 
----
-
-## Step 9 — Report
+### Step 6.4 — Report
 
 ```
-Verification complete: <feature-id> v<version>
+── Verification complete: <id> v<version> ──────
+
 Overall: <PASS | PASS_WITH_NOTES | FAIL>
-  SATISFIED: <count>
-  PARTIAL: <count>
-  VIOLATED: <count>
+  SATISFIED:  <count>
+  PARTIAL:    <count>
+  VIOLATED:   <count>
   UNTESTABLE: <count>
-State: <DRAFT | APPROVED>
+
+Repairs applied:
+  Amendments: <count>
+  Code fixes: <count>
+  Regression tests: <count>
+  Deferred: <count>
+
+State: <DRAFT → APPROVED | DRAFT (unchanged)>
 ```
 
 ---
@@ -167,5 +345,16 @@ State: <DRAFT | APPROVED>
 - Never verify a spec that fails structural validation
 - Never double-verify the same version (idempotency check in pre-flight)
 - State and status are updated together or not at all
-- FAIL verdict creates obligations, not silent annotations
 - Verification notes are append-only — never delete previous notes
+- **Violations are repaired inline, not parked as obligations.** Obligations
+  are created ONLY when the user explicitly defers a finding via
+  AskUserQuestion — never as the default path.
+- **Regression tests are mandatory for code fixes.** A code fix without a
+  regression test is incomplete — the violation will recur on the next
+  change that touches the same code.
+- **Displacement chains are not auto-followed.** If a spec amendment would
+  displace requirements in another spec, present the chain and let the
+  user decide. Do not create a cascade of automated amendments.
+- **@spec annotations are added to all new/changed code.** Every regression
+  test and every code fix must be annotated with the requirement it
+  enforces.

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -46,12 +46,11 @@ classify, repair, confirm.
 Read the spec file's machine section (requirements only, not narrative).
 Note the feature ID and version.
 
-### Step 1.2 — Load the implementation
+### Step 1.2 — Discover and annotate implementation
 
 Identify the implementation files. Sources (in priority order):
 1. **@spec annotations** — run `bash .claude/scripts/spec-trace.sh <id>`
-   to find all annotated enforcement points. This is the primary discovery
-   mechanism.
+   to find all annotated enforcement points.
 2. If `.feature/<slug>/` exists for this feature, read the work plan and
    implementation files listed there.
 3. Otherwise, use the spec's `domains` to identify likely source
@@ -59,6 +58,23 @@ Identify the implementation files. Sources (in priority order):
 
 Focus on the code that implements the requirements. Do not read the entire
 codebase — read targeted files.
+
+**Annotate as you go.** For every enforcement point discovered during
+verification — whether from existing annotations, work plans, or domain
+scanning — ensure an `@spec` annotation exists in the code. If an
+enforcement point is found but not annotated, add the annotation before
+proceeding to the verdict. This ensures that every verification pass
+leaves the codebase with complete traceability for the verified spec.
+
+Annotation rules (from `.spec/CLAUDE.md` Code Traceability section):
+- Format: `// @spec FXX.RN` or `// @spec FXX.RN — brief description`
+- Place above the enforcing method or code block
+- Same format in both implementation and test files
+- Multiple requirements per annotation: `// @spec FXX.R1,R3,R7`
+
+After discovery and annotation, run `spec-trace.sh` again to confirm
+coverage. Report any requirements with zero enforcement points — these
+are candidates for UNTESTABLE or may indicate missing implementation.
 
 ### Step 1.3 — Verify each requirement
 

--- a/skills/spec-write/SKILL.md
+++ b/skills/spec-write/SKILL.md
@@ -100,10 +100,13 @@ supersedes (partial overlap allowed).
 runtime (not just at build time). Includes prerequisite stubs created
 in Step 2.
 
-**invalidates:** Specific `FXX.RN` requirement IDs this feature makes
-obsolete. Use exact format: `F01.R3`. Cross-check against the context
-bundle requirements to confirm they exist before writing them.
-MUST include any conflicts identified in Step 1.
+**invalidates:** Specific requirement IDs this feature makes obsolete.
+Format is `<spec-id>.RN` where `<spec-id>` is either legacy `FXX`
+(e.g., `F01.R3`) or new domain.slug (e.g., `schema.field-access.R3`).
+Match the format your project uses — check existing specs in `.spec/domains/`
+to determine which is in use. Cross-check against the context bundle
+requirements to confirm they exist before writing them. MUST include any
+conflicts identified in Step 1.
 
 **decision_refs:** ADR slugs from `.decisions/` that informed this feature.
 Check that `.decisions/<slug>/adr.md` exists.
@@ -112,8 +115,8 @@ Check that `.decisions/<slug>/adr.md` exists.
 Check that `.kb/<path>.md` exists.
 
 **displaced_by:** Set by the pipeline during displacement finalization — do
-not populate manually. Array of spec IDs (FXX format) that caused this spec
-to be INVALIDATED.
+not populate manually. Array of spec IDs (FXX or domain.slug) that caused
+this spec to be INVALIDATED.
 
 **revived_by:** Set by the pipeline when a new spec revives this one — do
 not populate manually. Array of spec IDs.
@@ -128,19 +131,38 @@ inspection.
 
 ---
 
-## Step 5 — Determine version and file path
+## Step 5 — Determine spec ID, version, and file path
 
-Check the registry for existing versions of this feature:
+**Spec ID format:** Two conventions are supported. Use whichever matches
+the project's existing specs (check `.spec/domains/` to see what's in use).
+
+- **`domain.slug`** (recommended for new projects) — e.g., `schema.field-access`,
+  `query.full-text-index`. Self-describing, greppable, dimensional. The spec
+  lives at `.spec/domains/<domain>/<slug>.md`.
+- **`FXX`** (legacy) — e.g., `F07`, `F13`. Numeric feature ID. The spec lives
+  at `.spec/domains/<domain>/F<nn>-<slug>.md` (filename has both ID and slug).
+
+Check the registry for existing versions:
 ```bash
-jq -r --arg id "$FEATURE_ID" '.features[$id].latest_file // ""' \
-  .spec/registry/manifest.json
+# Try v2 manifest schema (specs[] array) first; falls back to v1 (features{}).
+jq -r --arg id "$SPEC_ID" '
+  if .specs then
+    ((.specs[] | select(.id == $id) | .path) // "")
+  else
+    (.features[$id].latest_file // "")
+  end
+' .spec/registry/manifest.json
 ```
 
-If no entry exists: version = 1, filename = `F<nn>-<slug>.md`
-If entry exists: increment version, filename = `F<nn>-<slug>.v<N>.md`
+If no entry exists: version = 1.
+  - For domain.slug: filename = `<slug>.md`
+  - For FXX: filename = `F<nn>-<slug>.md`
+
+If entry exists: increment version. Filename gains `.v<N>` suffix
+(e.g., `field-access.v2.md` or `F07-compaction-engine.v2.md`).
 
 The slug is the title lowercased with spaces replaced by hyphens,
-truncated to 30 chars. Example: `F07-compaction-engine.md`
+truncated to 30 chars.
 
 ---
 
@@ -166,9 +188,9 @@ Use this exact structure:
   "amends": [<feature ids or empty>],
   "amended_by": [],
   "requires": [<feature ids or empty>],
-  "invalidates": [<FXX.RN refs or empty>],
+  "invalidates": [<spec.RN refs or empty — FXX.RN or domain.slug.RN>],
   "displaced_by": [],
-  "revives": [<FXX ids of INVALIDATED specs this revives, or empty>],
+  "revives": [<spec ids of INVALIDATED specs this revives, or empty>],
   "revived_by": [],
   "displacement_reason": "",
   "decision_refs": [<ADR slugs or empty>],

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -1,9 +1,9 @@
 ---
 description: "Decompose a work group into work definitions with dependency graph"
-argument-hint: "<group-slug> [--from-obligations [--spec FXX] [--domain <domain>]]"
+argument-hint: "<group-slug> [--from-obligations [--spec <spec-id>] [--domain <domain>]]"
 ---
 
-# /work-decompose "<group-slug>" [--from-obligations [--spec FXX] [--domain <domain>]]
+# /work-decompose "<group-slug>" [--from-obligations [--spec <spec-id>] [--domain <domain>]]
 
 Decomposes a work group into individual work definitions. Identifies natural
 boundaries, artifact dependencies, shared interface contracts, and the
@@ -68,7 +68,8 @@ Read `.spec/registry/_obligations.json`. Filter to open obligations only
 (`status == "open"`).
 
 Apply filters if provided:
-- `--spec FXX` → only obligations where `spec` matches
+- `--spec <spec-id>` → only obligations where `spec` matches. Spec ID can be
+  legacy `FXX` (e.g., `F12`) or domain.slug (e.g., `query.full-text-index`).
 - `--domain <domain>` → only obligations where `domains` array contains the value
 
 If no open obligations match the filters:

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -1,15 +1,24 @@
 ---
 description: "Decompose a work group into work definitions with dependency graph"
-argument-hint: "<group-slug>"
+argument-hint: "<group-slug> [--from-obligations [--spec FXX] [--domain <domain>]]"
 ---
 
-# /work-decompose "<group-slug>"
+# /work-decompose "<group-slug>" [--from-obligations [--spec FXX] [--domain <domain>]]
 
 Decomposes a work group into individual work definitions. Identifies natural
 boundaries, artifact dependencies, shared interface contracts, and the
 ordering graph.
 
 Run after `/work "<goal>"` has created the work group.
+
+**Modes:**
+- **Default:** Analyze the work group scope and decompose by identified
+  boundaries.
+- **`--from-obligations`:** Ingest open obligations from
+  `.spec/registry/_obligations.json` and synthesize WDs from them. Filters
+  by `--spec` (spec ID) or `--domain` (domain name) if provided. This mode
+  creates SPECIFIED WDs (specs already exist) that go directly to
+  `/work-start`.
 
 ---
 
@@ -46,6 +55,71 @@ Display opening header:
 🔧 DECOMPOSE · <group-slug>
 ───────────────────────────────────────────────
 ```
+
+---
+
+## Obligation intake mode (--from-obligations)
+
+If `--from-obligations` is present, skip Steps 1-4 and use this flow instead.
+
+### OB-1 — Read and filter obligations
+
+Read `.spec/registry/_obligations.json`. Filter to open obligations only
+(`status == "open"`).
+
+Apply filters if provided:
+- `--spec FXX` → only obligations where `spec` matches
+- `--domain <domain>` → only obligations where `domains` array contains the value
+
+If no open obligations match the filters:
+```
+No open obligations found matching the filters.
+```
+Stop.
+
+Display:
+```
+Found <N> open obligations:
+
+| # | ID | Spec | Affected Reqs | Blocked By |
+|---|-----|------|---------------|------------|
+| 1 | <id> | <spec> | <count> | <blocked_by> |
+...
+```
+
+### OB-2 — Group obligations into WDs
+
+Analyze the obligations and group them by natural boundaries:
+
+1. **Same blocked_by** → obligations sharing a blocker should be in the same
+   WD (they need the same prerequisite work)
+2. **Code locality** — obligations affecting the same class/module should be
+   together
+3. **Dependency ordering** — if obligation A's fix is a prerequisite for
+   obligation B's fix, A's WD must come first (use `type: wd` deps)
+4. **Size** — keep each WD at a manageable scope. Split obligations that
+   represent multi-week efforts into separate WDs.
+
+For each proposed WD, determine:
+- **status: SPECIFIED** — specs already exist, these are implementation-only
+- **artifact_deps** — add `type: wd` deps for ordering constraints between WDs
+- **Acceptance criteria** — map from the obligation's `affects` list:
+  each affected requirement becomes a testable criterion
+- **Summary** — synthesize from the obligation `description` field
+- **Implementation notes** — include `blocked_by` context and any
+  implementation hints from the description
+
+### OB-3 — Present decomposition
+
+Present the proposed WDs using the same table format as Step 3 (below).
+Include the dependency graph and note which obligations map to which WD.
+
+Proceed to Step 4 (confirm with user), then Step 5 (write WDs), Step 6
+(update manifest), and Step 7 (summary).
+
+**Key difference from default mode:** all WDs are written with
+`status: SPECIFIED` (not DRAFT) because the specification work is already
+done — the specs exist and the obligations describe the gap.
 
 ---
 
@@ -174,7 +248,11 @@ produces:
 - `type: spec` — path is relative to `.spec/domains/`, must include domain prefix
 - `type: adr` — slug matches `.decisions/<slug>/adr.md`
 - `type: kb` — path matches `.kb/<path>.md`
-- spec and adr deps must include `required_state` or `required_status`
+- `type: wd` — ref is a WD ID in the same group (e.g., "WD-01"). Use for
+  code-level dependencies where one WD's implementation must complete before
+  another can start. Unlike artifact deps, wd deps express ordering constraints
+  that aren't mediated by a spec or ADR artifact.
+- spec, adr, and wd deps must include `required_state` or `required_status`
 - kb deps are existence-only (no state check)
 
 **produces rules:**

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -57,7 +57,28 @@ Check the WD's status in the resolver output.
 
 If SPECIFIED: proceed to Step 4.
 
-If READY or BLOCKED or SPECIFYING: the WD has not been through `/work-plan` yet.
+If BLOCKED: check the blocker detail from the resolver output.
+- If blocked by `wd:` deps (predecessor WDs not complete): report which WDs
+  must complete first. Do not offer to start — the ordering exists for a reason.
+  ```
+  WD-<nn> (<title>) is BLOCKED by predecessor work definitions:
+    <list blockers from resolver>
+
+  Complete these first, or use /work-start "<group-slug>" next to auto-select
+  a WD that is ready.
+  ```
+  Stop.
+- If blocked by unmet artifact deps (spec/adr/kb): this WD needs specification.
+  ```
+  WD-<nn> (<title>) needs specification before implementation.
+  Run /work-plan "<group-slug>" WD-<nn> first.
+  ```
+  Use AskUserQuestion with options:
+    - "Run /work-plan first"
+    - "Start anyway (skip specification)"
+    - "Stop"
+
+If READY or SPECIFYING: the WD has not been through `/work-plan` yet.
 ```
 WD-<nn> (<title>) needs specification before implementation.
 Run /work-plan "<group-slug>" WD-<nn> first.

--- a/spec/CLAUDE.md
+++ b/spec/CLAUDE.md
@@ -52,7 +52,7 @@ R2. ...
 - `domains` — array of domain slugs this spec belongs to
 - `amends` / `amended_by` — cross-feature amendment links
 - `requires` — feature IDs this spec depends on at runtime
-- `invalidates` — specific FXX.RN references this spec supersedes
+- `invalidates` — specific `<spec-id>.RN` references this spec supersedes
 - `decision_refs` — ADR slugs from .decisions/ (cross-reference, not duplication)
 - `kb_refs` — KB paths from .kb/ (topic/category/subject)
 - `open_obligations` — work items that must be addressed
@@ -80,17 +80,30 @@ requirement is enforced (implementation) and where it is validated (tests).
 ### Format
 
 ```
-@spec FXX.RN              — single requirement
-@spec FXX.RN,RN,RN        — multiple reqs from same spec
-@spec FXX.RN FYY.RN       — multiple specs (space-separated)
-@spec FXX.RN — description — optional human-readable note after dash
+@spec <spec-id>.RN              — single requirement
+@spec <spec-id>.RN,RN,RN        — multiple reqs from same spec
+@spec <spec-id>.RN <other>.RN   — multiple specs (space-separated)
+@spec <spec-id>.RN — description — optional human-readable note after dash
 ```
 
+`<spec-id>` is the spec's identifier from its frontmatter `id` field. Two
+formats are supported:
+
+- **`FXX`** (legacy) — zero-padded numeric feature ID like `F01`, `F13`.
+  Example: `@spec F13.R1`.
+- **`domain.slug`** (recommended for new projects) — behavioral-domain
+  identifier like `schema.field-access`, `query.full-text-index`.
+  Example: `@spec schema.field-access.R1`.
+
+Use whichever format your project's specs use — check `.spec/domains/`
+to see the convention. Mixing both formats in the same project works but
+is discouraged.
+
 **Identifier rules:**
-- Feature ID is always `FXX` — zero-padded, minimum 2 digits (`F01` not `F1`)
-- Requirement number is `RN` — no zero-padding (`R1`, `R27`, `R156`)
-- The `FXX.` prefix is mandatory on every reference — bare `R1` is invalid
-- Canonical grep pattern: `@spec\s+F\d{2,}\.R\d+`
+- Requirement number is `RN` (with optional letter suffix for amendments —
+  `R1`, `R27`, `R51a`). No zero-padding.
+- The `<spec-id>.` prefix is mandatory on every reference — bare `R1` is invalid
+- Canonical grep pattern: `@spec\s+(F\d{2,}|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)\.R\d+[a-z]?`
 
 ### Placement
 
@@ -131,7 +144,8 @@ def serialize(self, record):
 
 ### Tooling
 
-- `spec-trace.sh <FXX>` — finds all `@spec` annotations for a feature,
+- `spec-trace.sh <spec-id>` — finds all `@spec` annotations for a spec
+  (accepts FXX or domain.slug),
   grouped by file, distinguishing implementation vs test locations
 - `spec-verify` uses annotations as discovery hints when verifying requirements
-- Coverage scripts use scoped `FXX.RN` matching (not bare R-numbers)
+- Coverage scripts use scoped `<spec-id>.RN` matching (not bare R-numbers)

--- a/spec/CLAUDE.md
+++ b/spec/CLAUDE.md
@@ -70,3 +70,68 @@ R2. ...
 
 **Registry:** `.spec/registry/manifest.json` — machine-readable index.
 **Obligations:** `.spec/registry/_obligations.json` — cross-feature work items.
+
+## Code Traceability — @spec Annotations
+
+Implementation and test code links back to specs via `@spec` annotations in
+comments. These annotations are the primary mechanism for finding where a
+requirement is enforced (implementation) and where it is validated (tests).
+
+### Format
+
+```
+@spec FXX.RN              — single requirement
+@spec FXX.RN,RN,RN        — multiple reqs from same spec
+@spec FXX.RN FYY.RN       — multiple specs (space-separated)
+@spec FXX.RN — description — optional human-readable note after dash
+```
+
+**Identifier rules:**
+- Feature ID is always `FXX` — zero-padded, minimum 2 digits (`F01` not `F1`)
+- Requirement number is `RN` — no zero-padding (`R1`, `R27`, `R156`)
+- The `FXX.` prefix is mandatory on every reference — bare `R1` is invalid
+- Canonical grep pattern: `@spec\s+F\d{2,}\.R\d+`
+
+### Placement
+
+- Use the host language's comment syntax (`//`, `#`, `/* */`, `--`, etc.)
+- Place above the enforcing method or code block (like `@Override` in Java)
+- One annotation per enforcement region — if a whole method implements R1,
+  annotate the method once, not each line
+- Same format in both implementation files and test files
+
+### Examples
+
+```java
+// @spec F13.R1 — rejects null keys at index boundary
+public void add(Key key, Value value) {
+    if (key == null) throw new NullKeyException();
+    ...
+}
+
+// @spec F13.R1,R3
+@Test void testNullKeyRejection() { ... }
+```
+
+```python
+# @spec F08.R12 F05.R4 — shared serialization constraint
+def serialize(self, record):
+    ...
+```
+
+### Relationship model
+
+- **Many-to-many:** one requirement can have many enforcement points across
+  files; one code location can enforce multiple requirements
+- **No primary/secondary distinction:** all annotations are equal
+- **Implementation vs test:** distinguished by file path, not annotation syntax
+- **Drift detection:** `/curate` checks annotation consistency — annotations
+  are written at implementation time and verified periodically, not maintained
+  in real-time
+
+### Tooling
+
+- `spec-trace.sh <FXX>` — finds all `@spec` annotations for a feature,
+  grouped by file, distinguishing implementation vs test locations
+- `spec-verify` uses annotations as discovery hints when verifying requirements
+- Coverage scripts use scoped `FXX.RN` matching (not bare R-numbers)

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -966,6 +966,102 @@ fi
 
 rm -rf "$GREP_TEST_DIR" 2>/dev/null || true
 
+# ── Test 28: Obligation registry scanning ─────────────────────────────────────
+
+echo ""
+echo "── Test 28: Obligation registry scanning"
+
+OB_TEST_DIR="/tmp/vallorcine/scenario-ob-registry"
+rm -rf "$OB_TEST_DIR" 2>/dev/null || true
+mkdir -p "$OB_TEST_DIR/.curate"
+mkdir -p "$OB_TEST_DIR/.spec/registry"
+mkdir -p "$OB_TEST_DIR/.spec/domains/engine"
+mkdir -p "$OB_TEST_DIR/.claude/scripts"
+
+cp "$REPO_ROOT/scripts/curate-scan.sh" "$OB_TEST_DIR/.claude/scripts/"
+
+cd "$OB_TEST_DIR"
+git init -q .
+git add -A && git commit -q -m "init" --allow-empty
+
+# Create obligation registry with 2 open and 1 resolved obligation
+cat > .spec/registry/_obligations.json << 'OBJEOF'
+{
+  "version": 1,
+  "obligations": [
+    {
+      "id": "OBL-F04-R39",
+      "spec": "F04",
+      "domains": ["engine"],
+      "description": "Async listeners not implemented",
+      "blocked_by": "listener executor design",
+      "affects": ["F04.R39"],
+      "status": "open",
+      "created": "2026-04-18"
+    },
+    {
+      "id": "OBL-F04-R53",
+      "spec": "F04",
+      "domains": ["engine"],
+      "description": "Monotonic clock not used",
+      "blocked_by": "MonotonicClock design",
+      "affects": ["F04.R53"],
+      "status": "open",
+      "created": "2026-04-18"
+    },
+    {
+      "id": "OBL-F02-R33",
+      "spec": "F02",
+      "domains": ["serialization"],
+      "description": "Already fixed",
+      "affects": ["F02.R33"],
+      "status": "resolved",
+      "resolved_by": "spec-verify",
+      "created": "2026-04-16"
+    }
+  ]
+}
+OBJEOF
+
+git add -A && git commit -q -m "add obligations"
+
+if command -v jq >/dev/null 2>&1; then
+    output="$(bash .claude/scripts/curate-scan.sh --init 2>&1)"
+
+    # Check that obligation registry section exists in summary
+    if grep -q "Open Obligations Registry" .curate/scan-summary.md 2>/dev/null; then
+        pass "obligation registry section present in summary"
+    else
+        fail "obligation registry section should be in scan-summary.md" "got: $(cat .curate/scan-summary.md 2>/dev/null)"
+    fi
+
+    # Check that only open obligations appear (not resolved)
+    if grep -q "OBL-F04-R39" .curate/scan-summary.md 2>/dev/null && \
+       grep -q "OBL-F04-R53" .curate/scan-summary.md 2>/dev/null; then
+        pass "open obligations listed in summary"
+    else
+        fail "both open obligations should appear" "got: $(cat .curate/scan-summary.md 2>/dev/null)"
+    fi
+
+    if ! grep -q "OBL-F02-R33" .curate/scan-summary.md 2>/dev/null; then
+        pass "resolved obligations excluded from summary"
+    else
+        fail "resolved obligations should not appear" "got: $(grep F02 .curate/scan-summary.md 2>/dev/null)"
+    fi
+
+    # Check stats output includes obligation registry count
+    if echo "$output" | grep -q "Obligation registry: 2"; then
+        pass "obligation registry count in stats output"
+    else
+        fail "stats should show 'Obligation registry: 2'" "got: $(echo "$output" | grep -i oblig)"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+rm -rf "$OB_TEST_DIR" 2>/dev/null || true
+cd "$REPO_ROOT"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/scenario-spec-trace.sh
+++ b/tests/scenario-spec-trace.sh
@@ -115,10 +115,28 @@ PY
 # ── Test 1: Invalid feature ID rejected ─────────────────────────────────────
 
 output=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" F1 2>&1 || true)
-if echo "$output" | grep -q "Invalid feature ID"; then
+if echo "$output" | grep -q "Invalid spec ID"; then
     pass "rejects F1 (not zero-padded)"
 else
     fail "should reject F1" "got: $output"
+fi
+
+# ── Test 1b: Accepts new domain.slug format ─────────────────────────────────
+
+output=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" schema.field-access 2>&1 || true)
+if echo "$output" | grep -q "Invalid spec ID"; then
+    fail "should accept domain.slug format" "got: $output"
+else
+    pass "accepts domain.slug format (schema.field-access)"
+fi
+
+# ── Test 1c: Rejects malformed mixed format ─────────────────────────────────
+
+output=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" "Schema.field" 2>&1 || true)
+if echo "$output" | grep -q "Invalid spec ID"; then
+    pass "rejects uppercase domain (Schema.field)"
+else
+    fail "should reject uppercase domain" "got: $output"
 fi
 
 # ── Test 2: Valid feature ID accepted ────────────────────────────────────────
@@ -204,13 +222,13 @@ fi
 # ── Test 10: JSON format produces valid structure ────────────────────────────
 
 output_json=$(cd "$TEST_BASE/project" && SPEC_TRACE_FORMAT=json bash "$TRACE_SCRIPT" F01 2>/dev/null)
-if echo "$output_json" | grep -q '"feature": "F01"' && \
+if echo "$output_json" | grep -q '"spec": "F01"' && \
    echo "$output_json" | grep -q '"F01.R1"' && \
    echo "$output_json" | grep -q '"implementation"' && \
    echo "$output_json" | grep -q '"test"'; then
-    pass "JSON format produces structured output with feature, requirements, impl/test arrays"
+    pass "JSON format produces structured output with spec, requirements, impl/test arrays"
 else
-    fail "JSON format should have feature, requirements, impl/test" "got: $output_json"
+    fail "JSON format should have spec, requirements, impl/test" "got: $output_json"
 fi
 
 # ── Test 11: SPEC_TRACE_DIRS limits scan scope ──────────────────────────────

--- a/tests/scenario-spec-trace.sh
+++ b/tests/scenario-spec-trace.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Scenario: spec-trace.sh finds @spec annotations across source and test files
+#
+# Tests:
+# - Single requirement annotation (@spec F01.R1)
+# - Multi-requirement same spec (@spec F01.R1,R3,R7)
+# - Multi-spec annotation (@spec F01.R1 F02.R4)
+# - Implementation vs test file classification
+# - Feature ID isolation (F01 trace doesn't include F02-only annotations)
+# - Invalid feature ID rejection (F1 not zero-padded)
+# - No-match case exits cleanly
+# - Summary, detail, and JSON output formats
+# - SPEC_TRACE_DIRS override
+#
+# Run from repo root: bash tests/scenario-spec-trace.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-spec-trace"
+TRACE_SCRIPT="$REPO_ROOT/scripts/spec-trace.sh"
+
+# ── Test helpers ─────────────────────────────────────────────────────────────
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ""
+echo "scenario: spec-trace annotation discovery"
+echo "────────────────────────────────────────────────"
+
+# ── Setup: create a mock project with @spec annotations ─────────────────────
+
+cleanup
+mkdir -p "$TEST_BASE/project/src/auth" "$TEST_BASE/project/test/auth"
+mkdir -p "$TEST_BASE/project/src/data" "$TEST_BASE/project/lib"
+mkdir -p "$TEST_BASE/project/.git"  # so project root detection works
+
+# Source file with single annotation
+cat > "$TEST_BASE/project/src/auth/Auth.java" << 'JAVA'
+package com.example.auth;
+
+// @spec F01.R1 — rejects null keys
+public void add(Key key, Value value) {
+    if (key == null) throw new NullKeyException();
+}
+JAVA
+
+# Source file with multi-req same spec
+cat > "$TEST_BASE/project/src/auth/Validator.java" << 'JAVA'
+package com.example.auth;
+
+// @spec F01.R3,R7
+public void validate(Token token) {
+    // validation logic
+}
+JAVA
+
+# Source file with cross-spec annotation
+cat > "$TEST_BASE/project/src/data/Serializer.java" << 'JAVA'
+package com.example.data;
+
+// @spec F01.R1 F02.R4 — shared serialization constraint
+public void serialize(Record record) {
+    // serialization
+}
+JAVA
+
+# Test file with annotations
+cat > "$TEST_BASE/project/test/auth/AuthTest.java" << 'JAVA'
+package com.example.auth;
+
+// @spec F01.R1,R3
+@Test void testNullKeyRejection() { }
+
+// @spec F01.R7
+@Test void testTokenValidation() { }
+JAVA
+
+# File with only F02 annotations (should NOT appear in F01 trace)
+cat > "$TEST_BASE/project/src/data/Other.java" << 'JAVA'
+package com.example.data;
+
+// @spec F02.R1
+public void otherThing() { }
+JAVA
+
+# Python file with annotation
+cat > "$TEST_BASE/project/lib/helper.py" << 'PY'
+# @spec F01.R12 — helper constraint
+def helper():
+    pass
+PY
+
+# ── Test 1: Invalid feature ID rejected ─────────────────────────────────────
+
+output=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" F1 2>&1 || true)
+if echo "$output" | grep -q "Invalid feature ID"; then
+    pass "rejects F1 (not zero-padded)"
+else
+    fail "should reject F1" "got: $output"
+fi
+
+# ── Test 2: Valid feature ID accepted ────────────────────────────────────────
+
+output=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" F01 2>/dev/null)
+if echo "$output" | grep -q "F01 — Trace Report"; then
+    pass "accepts F01 and produces report"
+else
+    fail "should produce trace report for F01" "got: $output"
+fi
+
+# ── Test 3: Finds all F01 requirements ───────────────────────────────────────
+
+output=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" F01 2>/dev/null)
+if echo "$output" | grep -q "F01.R1" && \
+   echo "$output" | grep -q "F01.R3" && \
+   echo "$output" | grep -q "F01.R7" && \
+   echo "$output" | grep -q "F01.R12"; then
+    pass "finds all four F01 requirements (R1, R3, R7, R12)"
+else
+    fail "should find R1, R3, R7, R12" "got: $output"
+fi
+
+# ── Test 4: F01.R1 has 2 impl + 1 test ──────────────────────────────────────
+
+output=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" F01 2>/dev/null)
+r1_line=$(echo "$output" | grep "F01.R1 " || true)
+if echo "$r1_line" | grep -qE "\| 2 \| 1 \|"; then
+    pass "F01.R1 has 2 implementation + 1 test annotations"
+else
+    fail "F01.R1 should have 2 impl + 1 test" "got: $r1_line"
+fi
+
+# ── Test 5: F01.R12 has 1 impl + 0 tests ────────────────────────────────────
+
+r12_line=$(echo "$output" | grep "F01.R12" || true)
+if echo "$r12_line" | grep -qE "\| 1 \| 0 \|"; then
+    pass "F01.R12 has 1 implementation + 0 test annotations"
+else
+    fail "F01.R12 should have 1 impl + 0 test" "got: $r12_line"
+fi
+
+# ── Test 6: No-impl/no-test summary ─────────────────────────────────────────
+
+if echo "$output" | grep -q "No test annotations.*F01.R12"; then
+    pass "summary reports F01.R12 has no test annotations"
+else
+    fail "should report F01.R12 has no test annotations" "got last lines: $(echo "$output" | tail -3)"
+fi
+
+# ── Test 7: F02 trace only shows F02 annotations ────────────────────────────
+
+output_f02=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" F02 2>/dev/null)
+if echo "$output_f02" | grep -q "F02.R4" && \
+   echo "$output_f02" | grep -q "F02.R1" && \
+   ! echo "$output_f02" | grep -q "F01"; then
+    pass "F02 trace shows only F02 annotations (R1, R4), no F01 leakage"
+else
+    fail "F02 trace should only show F02 refs" "got: $output_f02"
+fi
+
+# ── Test 8: No-match feature exits cleanly ───────────────────────────────────
+
+output_none=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" F99 2>/dev/null)
+if echo "$output_none" | grep -q "No annotations found"; then
+    pass "F99 (no matches) reports no annotations found"
+else
+    fail "F99 should report no annotations" "got: $output_none"
+fi
+
+# ── Test 9: Detail format produces per-requirement sections ──────────────────
+
+output_detail=$(cd "$TEST_BASE/project" && SPEC_TRACE_FORMAT=detail bash "$TRACE_SCRIPT" F01 2>/dev/null)
+if echo "$output_detail" | grep -q "### F01.R1" && \
+   echo "$output_detail" | grep -q "### F01.R3" && \
+   echo "$output_detail" | grep -q "**Implementation**" && \
+   echo "$output_detail" | grep -q "**Test**"; then
+    pass "detail format produces per-requirement sections with impl/test grouping"
+else
+    fail "detail format should have ### headings and impl/test groups"
+fi
+
+# ── Test 10: JSON format produces valid structure ────────────────────────────
+
+output_json=$(cd "$TEST_BASE/project" && SPEC_TRACE_FORMAT=json bash "$TRACE_SCRIPT" F01 2>/dev/null)
+if echo "$output_json" | grep -q '"feature": "F01"' && \
+   echo "$output_json" | grep -q '"F01.R1"' && \
+   echo "$output_json" | grep -q '"implementation"' && \
+   echo "$output_json" | grep -q '"test"'; then
+    pass "JSON format produces structured output with feature, requirements, impl/test arrays"
+else
+    fail "JSON format should have feature, requirements, impl/test" "got: $output_json"
+fi
+
+# ── Test 11: SPEC_TRACE_DIRS limits scan scope ──────────────────────────────
+
+output_limited=$(cd "$TEST_BASE/project" && SPEC_TRACE_DIRS="src" bash "$TRACE_SCRIPT" F01 2>/dev/null)
+# With only src/, we should not see test annotations
+r1_limited=$(echo "$output_limited" | grep "F01.R1 " || true)
+if echo "$r1_limited" | grep -qE "\| 0 \|"; then
+    pass "SPEC_TRACE_DIRS=src excludes test directory from scan"
+else
+    fail "limiting to src/ should show 0 test annotations" "got: $r1_limited"
+fi
+
+# ── Test 12: Cross-spec annotation parsed correctly ──────────────────────────
+
+# F01.R1 should appear in Serializer.java (cross-spec line: @spec F01.R1 F02.R4)
+if echo "$output_detail" | grep "F01.R1" | grep -q "Serializer"; then
+    pass "cross-spec annotation correctly parsed (F01.R1 from @spec F01.R1 F02.R4 line)"
+else
+    # Check if Serializer appears anywhere in R1 section
+    r1_section=$(echo "$output_detail" | sed -n '/### F01.R1/,/### F01.R3/p')
+    if echo "$r1_section" | grep -q "Serializer"; then
+        pass "cross-spec annotation correctly parsed (F01.R1 from @spec F01.R1 F02.R4 line)"
+    else
+        fail "cross-spec annotation should include Serializer.java for F01.R1" "R1 section: $r1_section"
+    fi
+fi
+
+# ── Test 13: Description text after -- doesn't interfere ────────────────────
+
+# The "— rejects null keys" text should not be parsed as a requirement reference
+req_count=$(echo "$output" | grep -oP 'Requirements traced:\*\*\s+\K[0-9]+' || echo "0")
+if [[ "$req_count" -eq 4 ]]; then
+    pass "description text after — separator does not create false requirement matches"
+else
+    fail "should have exactly 4 requirements (R1, R3, R7, R12)" "got: $req_count"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Results: $passed passed, $failed failed, $total total"
+
+if [[ $failed -gt 0 ]]; then
+    exit 1
+fi

--- a/tests/scenario-work-resolve.sh
+++ b/tests/scenario-work-resolve.sh
@@ -292,10 +292,10 @@ Test.
 EOF
 
 output="$(bash .claude/scripts/work-resolve.sh auth-migration 2>&1)"
-if echo "$output" | grep "WD-05" | grep -q "IN_PROGRESS"; then
-    pass "IN_PROGRESS status is respected"
+if echo "$output" | grep "WD-05" | grep -q "IMPLEMENTING"; then
+    pass "IN_PROGRESS status is normalized to IMPLEMENTING"
 else
-    fail "IN_PROGRESS status should be reported as-is" "got: $output"
+    fail "IN_PROGRESS should be normalized to IMPLEMENTING" "got: $output"
 fi
 
 # ── Test 8: Scope signal for high-dep-count WDs ─────────────────────────────
@@ -359,8 +359,164 @@ else
     fail "curate mode should emit correlation data" "got: $output"
 fi
 
-# ── Cleanup WDs used only for specific tests ─────────────────────────────────
-# (Already cleaned up by trap)
+# ── Test 11: SPECIFIED WD with unmet wd dep is BLOCKED ──────────────────────
+
+echo ""
+echo "── Test 11: SPECIFIED WD with unmet wd dep is BLOCKED"
+
+# Create a fresh group for wd-dep tests
+mkdir -p "$TEST_BASE/project/.work/wd-dep-test"
+
+cat > .work/wd-dep-test/WD-01.md << 'EOF'
+---
+id: WD-01
+title: Foundation work
+group: wd-dep-test
+status: SPECIFIED
+domains: [auth]
+artifact_deps: []
+produces: []
+---
+
+## Summary
+Foundation that must complete first.
+
+## Acceptance Criteria
+Test.
+EOF
+
+cat > .work/wd-dep-test/WD-02.md << 'EOF'
+---
+id: WD-02
+title: Dependent work
+group: wd-dep-test
+status: SPECIFIED
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: COMPLETE }
+produces: []
+---
+
+## Summary
+Depends on WD-01 completing.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-resolve.sh wd-dep-test 2>&1)"
+if echo "$output" | grep "WD-02" | grep -q "BLOCKED"; then
+    pass "SPECIFIED WD with unmet wd dep is BLOCKED"
+else
+    fail "SPECIFIED WD with unmet wd dep should be BLOCKED" "got: $output"
+fi
+
+# ── Test 12: SPECIFIED WD with met wd dep stays SPECIFIED ───────────────────
+
+echo ""
+echo "── Test 12: SPECIFIED WD with met wd dep stays SPECIFIED"
+
+# Mark WD-01 as COMPLETE
+sed -i 's/status: SPECIFIED/status: COMPLETE/' .work/wd-dep-test/WD-01.md
+
+output="$(bash .claude/scripts/work-resolve.sh wd-dep-test 2>&1)"
+if echo "$output" | grep "WD-02" | grep -q "SPECIFIED"; then
+    pass "SPECIFIED WD with met wd dep stays SPECIFIED"
+else
+    fail "SPECIFIED WD with met wd dep should stay SPECIFIED" "got: $output"
+fi
+
+# ── Test 13: wd dep creates unblocks edge in graph ──────────────────────────
+
+echo ""
+echo "── Test 13: wd dep creates unblocks edge in graph"
+
+# Reset WD-01 to SPECIFIED so WD-02 is blocked again
+sed -i 's/status: COMPLETE/status: SPECIFIED/' .work/wd-dep-test/WD-01.md
+
+output="$(bash .claude/scripts/work-resolve.sh wd-dep-test 2>&1)"
+if echo "$output" | grep "WD-01" | grep -q "WD-02"; then
+    pass "wd dep creates unblocks edge (WD-01 unblocks WD-02)"
+else
+    fail "WD-01 should show it unblocks WD-02" "got: $output"
+fi
+
+# ── Test 14: DRAFT WD with unmet wd dep is BLOCKED ─────────────────────────
+
+echo ""
+echo "── Test 14: DRAFT WD with unmet wd dep is BLOCKED"
+
+cat > .work/wd-dep-test/WD-03.md << 'EOF'
+---
+id: WD-03
+title: Draft with wd dep
+group: wd-dep-test
+status: DRAFT
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: COMPLETE }
+produces: []
+---
+
+## Summary
+DRAFT that depends on WD-01.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-resolve.sh wd-dep-test 2>&1)"
+if echo "$output" | grep "WD-03" | grep -q "BLOCKED"; then
+    pass "DRAFT WD with unmet wd dep is BLOCKED"
+else
+    fail "DRAFT WD with unmet wd dep should be BLOCKED" "got: $output"
+fi
+
+# ── Test 15: Blocker detail shows wd dep reason ────────────────────────────
+
+echo ""
+echo "── Test 15: Blocker detail shows wd dep reason"
+
+output="$(bash .claude/scripts/work-resolve.sh wd-dep-test 2>&1)"
+if echo "$output" | grep -q "wd:WD-01 — need COMPLETE"; then
+    pass "blocker detail shows wd dep reason"
+else
+    fail "blocker should mention wd:WD-01 and required state" "got: $output"
+fi
+
+# ── Test 16: Chained wd deps compute transitively ──────────────────────────
+
+echo ""
+echo "── Test 16: Chained wd deps block transitively"
+
+cat > .work/wd-dep-test/WD-04.md << 'EOF'
+---
+id: WD-04
+title: End of chain
+group: wd-dep-test
+status: SPECIFIED
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-02", required_state: COMPLETE }
+produces: []
+---
+
+## Summary
+Depends on WD-02 which depends on WD-01.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-resolve.sh wd-dep-test 2>&1)"
+if echo "$output" | grep "WD-04" | grep -q "BLOCKED"; then
+    pass "chained wd deps block transitively"
+else
+    fail "WD-04 should be BLOCKED (WD-02 is BLOCKED)" "got: $output"
+fi
+
+# ── Cleanup wd-dep-test group ───────────────────────────────────────────────
+rm -rf .work/wd-dep-test
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 

--- a/tests/scenario-work-validate.sh
+++ b/tests/scenario-work-validate.sh
@@ -403,6 +403,91 @@ else
     fail "acyclic group should pass" "got: $output"
 fi
 
+# ── Test 11: wd type in artifact_deps is valid ──────────────────────────────
+
+echo ""
+echo "── Test 11: wd type in artifact_deps is valid"
+
+cat > "$TEST_BASE/wd-type-valid.md" << 'EOF'
+---
+id: WD-02
+title: Depends on WD-01
+group: test-group
+status: SPECIFIED
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: COMPLETE }
+produces: []
+---
+
+## Summary
+Depends on another WD completing.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-validate.sh "$TEST_BASE/wd-type-valid.md" 2>&1)"
+if echo "$output" | grep -q "PASS"; then
+    pass "wd type in artifact_deps is valid"
+else
+    fail "wd type should be accepted" "got: $output"
+fi
+
+# ── Test 12: Circular wd deps detected (group mode) ────────────────────────
+
+echo ""
+echo "── Test 12: Circular wd deps detected (group mode)"
+
+mkdir -p "$TEST_BASE/project/.work/wd-circular"
+
+cat > "$TEST_BASE/project/.work/wd-circular/WD-01.md" << 'EOF'
+---
+id: WD-01
+title: First
+group: wd-circular
+status: SPECIFIED
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-02", required_state: COMPLETE }
+produces: []
+---
+
+## Summary
+Depends on WD-02.
+
+## Acceptance Criteria
+Test.
+EOF
+
+cat > "$TEST_BASE/project/.work/wd-circular/WD-02.md" << 'EOF'
+---
+id: WD-02
+title: Second
+group: wd-circular
+status: SPECIFIED
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: COMPLETE }
+produces: []
+---
+
+## Summary
+Depends on WD-01.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-validate.sh --group wd-circular 2>&1)" || true
+if echo "$output" | grep -q "CIRCULAR"; then
+    pass "circular wd deps detected"
+else
+    fail "circular wd deps should be detected" "got: $output"
+fi
+
+rm -rf "$TEST_BASE/project/.work/wd-circular"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -312,7 +312,13 @@ echo ""
 echo "── Test 7: --dev installs to temp directory"
 
 dev_output="$(bash "$REPO_ROOT/install.sh" --dev 2>&1)"
-dev_target="$(echo "$dev_output" | grep -o '/tmp/[^ ]*' | head -1)"
+# Use bash regex (not grep|head) — the pipe SIGPIPEs grep under `set -euo pipefail`
+# and kills the whole test script. BASH_REMATCH gives us the first match directly.
+if [[ "$dev_output" =~ /tmp/[^[:space:]]+ ]]; then
+    dev_target="${BASH_REMATCH[0]}"
+else
+    dev_target=""
+fi
 
 if [[ -n "$dev_target" && -d "$dev_target" ]]; then
     if [[ -f "$dev_target/.claude/skills/feature-quick/SKILL.md" ]]; then


### PR DESCRIPTION
## Summary

Three layers of spec-system work, bundled because they share the `.spec/`
surface and Stage 4 depends on the earlier layers.

**Layer 1 — spec-verify verify-and-repair loop** (5 commits)
- `@spec FXX.RN` annotation standard + `spec-trace.sh` traceability tool
- `/spec-verify` redesigned as 6-phase verify-and-repair loop: verify →
  classify → decide → amend specs → fix code via TDD → finalize
- `/spec-verify` annotates implementation + test files during discovery
- `/spec-verify` fills test gaps (structural/behavioral tests for
  uncovered requirements)

**Layer 2 — Obligation lifecycle kit** (3 commits)
- Work-definition-to-work-definition dependencies (`type: wd` in artifact_deps)
- Obligation scanning in `/curate` (analysis 10e reads registry,
  emits work-decompose-routable findings)
- `/work-decompose --from-obligations` mode — synthesizes SPECIFIED WDs
  from obligations with dependency ordering
- `work-finalize.sh` auto-resolves WD status + obligation entries on
  feature complete
- `/work-start` distinguishes hard wd-type blocks from soft artifact blocks

**Layer 3 — Kit-side domain.slug format support** (1 commit)
- `spec-trace.sh`, `spec-validate.sh`, `spec-resolve.sh`, `spec-lib.sh` all
  accept both legacy `FXX.RN` and new `domain.slug.RN` spec IDs
- `spec_file_for_id` handles both manifest schema versions (v1 features{}
  object, v2 specs[] array)
- `/spec-write`, `/spec-verify`, `spec/CLAUDE.md`, `/work-decompose`
  docs updated to teach both formats
- Tests: 2 new in scenario-spec-trace (domain.slug accepted, uppercase
  rejected); 2 updates for renamed JSON key
- End-to-end: kit's `spec-validate.sh` passes on all 75 specs in jlsm's
  migrated domain.slug layout

**Also fixed**
- `test-install.sh` SIGPIPE at test 7 (silent regression — tests 8-14
  hadn't been running; 13 PASS → 56 PASS after fix)

## Test plan

- [x] `scenario-work-resolve` 16/16
- [x] `scenario-work-validate` 12/12
- [x] `scenario-curate-scan` 54/54
- [x] `scenario-spec-validate` 8/8
- [x] `scenario-spec-resolve` 11/11
- [x] `scenario-spec-trace` 15/15 (includes new domain.slug tests)
- [x] `test-install.sh` 56/56 (up from 13 under the SIGPIPE)
- [x] End-to-end: kit validates all 75 jlsm post-migration specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)