### PR TITLE
feat(audit): escalation flow for FIX_IMPOSSIBLE relaxation requests

### DIFF
--- a/prompts/audit/aggregate-results.py
+++ b/prompts/audit/aggregate-results.py
@@ -86,6 +86,27 @@ def parse_prove_fix(path):
     if m:
         finding['test_class'] = m.group(1).strip()
 
+    # Impossibility proof block — only present for FIX_IMPOSSIBLE.
+    # Captures the structured request the user needs to act on.
+    m = re.search(
+        r'### Impossibility proof.*?\n- \*\*Approaches tried:\*\* (.+)',
+        content
+    )
+    if m:
+        finding['approaches_tried'] = m.group(1).strip()
+    m = re.search(
+        r'### Impossibility proof.*?\n(?:.*?\n)*?- \*\*Structural reason:\*\* (.+)',
+        content
+    )
+    if m:
+        finding['structural_reason'] = m.group(1).strip()
+    m = re.search(
+        r'### Impossibility proof.*?\n(?:.*?\n)*?- \*\*Relaxation request:\*\* (.+)',
+        content
+    )
+    if m:
+        finding['relaxation_request'] = m.group(1).strip()
+
     return finding
 
 
@@ -174,6 +195,21 @@ def format_finding(f):
             lines.append(f"- **Reason:** Already fixed by prior finding")
         elif f.get('phase0_detail'):
             lines.append(f"- **Detail:** {f['phase0_detail']}")
+    elif result == 'FIX_IMPOSSIBLE':
+        if f.get('test_method'):
+            lines.append(f"- **Test:** {f['test_method']}")
+        if f.get('test_class'):
+            lines.append(f"  - Class: {f['test_class']}")
+        if f.get('fix_change'):
+            lines.append(f"- **Attempted fix:** {f['fix_change']}")
+        if f.get('approaches_tried'):
+            lines.append(f"- **Approaches tried:** {f['approaches_tried']}")
+        if f.get('structural_reason'):
+            lines.append(f"- **Structural reason:** {f['structural_reason']}")
+        if f.get('relaxation_request'):
+            lines.append(f"- **Relaxation request:** {f['relaxation_request']}")
+        if f.get('fix_detail'):
+            lines.append(f"- **Detail:** {f['fix_detail']}")
 
     return '\n'.join(lines)
 
@@ -232,10 +268,15 @@ def main():
             out.write(f"\nPhase 0 short-circuits (ALREADY_FIXED): {phase0_fixed}\n")
             out.write("\n---\n\n")
 
-            # Group by result for easier report consumption
+            # Group by result for easier report consumption.
+            # FIX_IMPOSSIBLE is split out separately because it carries a
+            # relaxation request the orchestrator needs to escalate to the
+            # user — distinct from IMPOSSIBLE (Phase 1 found no bug).
             confirmed = [f for f in findings if f.get('result') == 'CONFIRMED_AND_FIXED']
             impossible = [f for f in findings if f.get('result') == 'IMPOSSIBLE']
-            other = [f for f in findings if f.get('result') not in ('CONFIRMED_AND_FIXED', 'IMPOSSIBLE')]
+            fix_impossible = [f for f in findings if f.get('result') == 'FIX_IMPOSSIBLE']
+            other = [f for f in findings if f.get('result') not in
+                     ('CONFIRMED_AND_FIXED', 'IMPOSSIBLE', 'FIX_IMPOSSIBLE')]
 
             if confirmed:
                 out.write(f"## Confirmed and Fixed ({len(confirmed)})\n\n")
@@ -245,6 +286,17 @@ def main():
             if impossible:
                 out.write(f"## Impossible ({len(impossible)})\n\n")
                 for f in impossible:
+                    out.write(format_finding(f) + "\n\n")
+
+            if fix_impossible:
+                out.write(f"## Fix Impossible ({len(fix_impossible)})\n\n")
+                out.write(
+                    "These findings have a confirmed bug but the fix conflicts with\n"
+                    "an existing test or contract. Each carries a relaxation request\n"
+                    "that needs explicit user resolution — see the audit report's\n"
+                    "*Fix Impossible — needs resolution* section.\n\n"
+                )
+                for f in fix_impossible:
                     out.write(format_finding(f) + "\n\n")
 
             if other:

--- a/prompts/audit/report.md
+++ b/prompts/audit/report.md
@@ -146,6 +146,24 @@ For each conflict found, create a structured entry:
 
 If no fix-spec conflicts: omit this section entirely.
 
+### 5b. Fix-impossible relaxation requests
+
+Read all FIX_IMPOSSIBLE findings from `prove-fix-summary.md` (the
+"Fix Impossible" section). Each carries:
+
+- **Approaches tried:** what the prove-fix subagent attempted
+- **Structural reason:** why no fix-without-test-change is possible
+- **Relaxation request:** the specific behavior change the fix requires
+  and the test that pins the old behavior
+
+These are not statistics — they are open decisions the orchestrator must
+present to the user. Surface them in the report's *Fix Impossible — needs
+resolution* section so the orchestrator can route each one through an
+explicit AskUserQuestion (relax test / accept wontfix / escalate to
+spec-author / defer to obligation).
+
+If no FIX_IMPOSSIBLE findings exist, omit this section.
+
 ### 6. Spec coverage (if specs were in scope)
 
 If `.spec/` exists and specs were loaded by Classification, assess how the
@@ -242,6 +260,21 @@ If no specs were in scope, skip this section entirely.
 - **Impact:** <what breaks if fix stays vs spec stays>
 - **Tradeoff:** <why this is a genuine design tension>
 
+## Fix Impossible — needs resolution
+[If no FIX_IMPOSSIBLE findings: omit this section]
+[One entry per FIX_IMPOSSIBLE finding from prove-fix-summary.md.
+The orchestrator routes each through an AskUserQuestion to choose:
+relax test / accept wontfix / escalate to spec-author / defer.]
+### RELAX-<N>: <finding ID> — <one-line summary>
+- **Confirmed bug:** <what the test proved>
+- **Blocking test:** <test method> in <test class>
+- **Approaches tried:** <list from prove-fix>
+- **Structural reason:** <why no fix without test change is possible>
+- **Relaxation request:** <specific behavior change required + which
+  test pins the old behavior>
+- **Suggested route:** <relax-test | wontfix | spec-author | defer> —
+  <one-sentence justification>
+
 ## Spec Coverage
 [If no specs in scope: "No specs in scope for this audit."]
 [If specs in scope:]
@@ -322,5 +355,13 @@ Cross-domain compositions: <n>
 Removed: <n> (INVALID=<n>, DESIGN-CHANGE=<n>, NEEDS-REVISIT=<n>)
 Pre-existing tests modified: <n>
 Cross-cluster unresolved: <n>
+Fix-spec conflicts: <n>
+Fix-impossible needing resolution: <n>
 Health: confirmation=<n>% fix=<n>% impossible=<n>%
 ```
+
+The `Fix-impossible needing resolution` count tells the orchestrator
+how many AskUserQuestion rounds to drive after presenting the report.
+Zero means clean exit; non-zero means the orchestrator opens the
+report's *Fix Impossible — needs resolution* section and walks each
+RELAX-<N> entry through the user.

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -856,6 +856,7 @@ Display the Report subagent's summary as the final output:
   Cross-domain compositions: <n>
   Deferred (budget): <n>
   Spec conflicts: <n> (or "none")
+  Fix-impossible needing resolution: <n> (or "none")
   Pipeline health: fix=<n>% impossible=<n>%
   Report: .feature/<slug>/audit-report.md
 ───────────────────────────────────────────────
@@ -897,6 +898,69 @@ architectural constraint.
 
 For option 3: add `[UNRESOLVED]` marker to the spec requirement and add
 an `open_obligations` entry. The spec becomes DRAFT if it was APPROVED.
+
+If the report summary mentions `Fix-impossible needing resolution: N` with
+N > 0, walk each RELAX-<N> entry from the report's *Fix Impossible —
+needs resolution* section. Each entry represents a confirmed bug whose
+fix conflicts with an existing test that pins the old behavior; without
+explicit resolution the bug stays in the codebase invisibly.
+
+```
+── Fix-impossible findings need resolution ────
+A fix was blocked by an existing test that pins the old behavior.
+The bug is real (Phase 1 confirmed it). The decision is whether the
+test, the spec, or the bug is authoritative.
+
+  RELAX-1: <finding ID> — <one-line summary>
+    Confirmed bug: <what the test proved>
+    Blocking test: <test method> in <test class>
+    Relaxation request: <what the fix would change + which test pins old behavior>
+    Suggested route: <relax-test | wontfix | spec-author | defer>
+```
+
+Ask the user using AskUserQuestion for each RELAX-<N>:
+
+- Question: "RELAX-<N>: <finding ID> — <summary>\n
+  Confirmed bug: <bug description>\n
+  Blocking test: <test method> in <test class>\n
+  Relaxation request: <what the fix needs + which test pins>\n\n
+  How should this be resolved?"
+- Options:
+  1. "Relax the blocking test" — the test pinned an implementation
+     detail. Update it to match the new (correct) behavior, re-run
+     prove-fix to confirm the fix now lands.
+  2. "Accept as wontfix" — the old behavior is authoritative (backward
+     compat, external contract). Record the finding in the report as a
+     known-accepted-risk with rationale.
+  3. "Escalate to /spec-author" — the pin test encodes an implicit spec
+     requirement that was never written down. Author the spec, then the
+     decision becomes a normal spec-conflict.
+  4. "Defer to obligation" — log on the relevant spec as an open
+     obligation; the spec becomes DRAFT if APPROVED.
+
+For option 1: read the blocking test, update it to assert the new
+behavior, re-invoke the prove-fix subagent for this finding (now
+unblocked). Update the report with the new outcome (CONFIRMED_AND_FIXED).
+Append a `pre-existing-test-modified` entry to the report's *Pre-existing
+Test Modifications* section with the diff and proof of safety.
+
+For option 2: append to the report's *Removed Tests (Not Fixed)* section
+classified `DESIGN-CHANGE` with the rationale (e.g. "external API
+contract pins this behavior; cannot change without versioned migration").
+Update the prove-fix output's `fix_detail` to record the user's
+rationale. The finding stays FIX_IMPOSSIBLE in the audit report but is
+now explicitly accepted, not silent drag.
+
+For option 3: invoke `/spec-author` with a brief describing the pinned
+behavior the test encodes. After spec-author returns, re-evaluate the
+finding under the new spec — it usually becomes a spec-conflict
+(handled above) or wontfix.
+
+For option 4: add an `open_obligations` entry on the most-relevant spec
+(the one whose domain matches the construct under test). The
+obligation text references the finding ID and the relaxation request so
+a future `/curate` analysis 19 (aging obligations) can resurface it.
+The spec becomes DRAFT if it was APPROVED.
 
 If cross-cluster unresolved findings exist, ask the user using
 AskUserQuestion:

--- a/tests/scenario-aggregate-results.sh
+++ b/tests/scenario-aggregate-results.sh
@@ -496,6 +496,118 @@ else
     fail "sort order wrong" "got: $order"
 fi
 
+# ── Test 8: FIX_IMPOSSIBLE finding surfaces relaxation request ──────────────
+# Regression: FIX_IMPOSSIBLE used to be invisible after audit completed —
+# the relaxation request stayed in the individual prove-fix file and the
+# orchestrator had no way to escalate it. Now aggregate-results.py extracts
+# the relaxation_request, structural_reason, and approaches_tried into the
+# Fix Impossible group of prove-fix-summary.md so the report subagent can
+# surface it for the orchestrator's AskUserQuestion flow.
+
+echo ""
+echo "  FIX_IMPOSSIBLE relaxation surfacing"
+echo "  ───────────────────────────────────"
+
+relax_dir="$TEST_BASE/run-relax"
+rm -rf "$relax_dir"
+mkdir -p "$relax_dir"
+
+cat > "$relax_dir/prove-fix-F-R1-cb-1-1.md" << 'EOF'
+# Prove-Fix — F-R1.cb.1.1
+
+## Result: FIX_IMPOSSIBLE
+
+### Phase 0: Already-fixed check
+- **Result:** STILL_VULNERABLE
+- **Detail:** splitmix64 produces correlated outputs for sequential seeds.
+
+### Phase 1: Verify
+- **Test method:** test_splitmix64_decorrelated_seeds
+- **Test class:** src/test/HashTest.java
+- **Result:** CONFIRMED
+- **Detail:** Sequential seeds produce hashes within 1 bit of each other.
+
+### Phase 2: Fix
+- **Change:** Replace splitmix64 with rrxmrrxmsx_0
+- **File:** src/main/Hash.java:42
+- **Result:** FIX_IMPOSSIBLE
+- **Detail:** Pin test test_splitmix64_known_outputs asserts specific output values.
+
+### Impossibility proof
+- **Approaches tried:** Replace algorithm, add post-mixing step, change seed encoding
+- **Structural reason:** test_splitmix64_known_outputs encodes hex values from the original splitmix64 paper as ground truth; any change to the hash function fails the pin test.
+- **Relaxation request:** Replace splitmix64 with rrxmrrxmsx_0; requires updating test_splitmix64_known_outputs to either (a) accept the new hash's outputs or (b) be removed if the pin was an implementation-detail not a contract.
+EOF
+
+output=$(python3 "$SCRIPT" "$relax_dir" 2>&1)
+
+if echo "$output" | grep -q "FIX_IMPOSSIBLE: 1"; then
+    pass "FIX_IMPOSSIBLE counted in tally"
+else
+    fail "FIX_IMPOSSIBLE not in tally" "got: $output"
+fi
+
+if grep -q "## Fix Impossible (1)" "$relax_dir/prove-fix-summary.md"; then
+    pass "summary has 'Fix Impossible' section"
+else
+    fail "missing Fix Impossible section" \
+        "$(cat "$relax_dir/prove-fix-summary.md")"
+fi
+
+if grep -q "Relaxation request:" "$relax_dir/prove-fix-summary.md"; then
+    pass "summary surfaces relaxation request"
+else
+    fail "relaxation request missing from summary" \
+        "$(cat "$relax_dir/prove-fix-summary.md")"
+fi
+
+if grep -q "Structural reason:" "$relax_dir/prove-fix-summary.md"; then
+    pass "summary surfaces structural reason"
+else
+    fail "structural reason missing from summary" \
+        "$(cat "$relax_dir/prove-fix-summary.md")"
+fi
+
+if grep -q "Approaches tried:" "$relax_dir/prove-fix-summary.md"; then
+    pass "summary surfaces approaches tried"
+else
+    fail "approaches tried missing from summary" \
+        "$(cat "$relax_dir/prove-fix-summary.md")"
+fi
+
+if grep -q "needs explicit user resolution" "$relax_dir/prove-fix-summary.md"; then
+    pass "Fix Impossible section instructs orchestrator to escalate"
+else
+    fail "missing escalation guidance in section header"
+fi
+
+# Confirm IMPOSSIBLE and FIX_IMPOSSIBLE remain distinct categories
+mixed_dir="$TEST_BASE/run-mixed"
+rm -rf "$mixed_dir"
+mkdir -p "$mixed_dir"
+
+cp "$relax_dir/prove-fix-F-R1-cb-1-1.md" "$mixed_dir/"
+
+cat > "$mixed_dir/prove-fix-F-R1-cb-2-1.md" << 'EOF'
+# Prove-Fix — F-R1.cb.2.1
+
+## Result: IMPOSSIBLE
+
+### Phase 0: Already-fixed check
+- **Result:** ALREADY_FIXED
+- **Detail:** Defensive copy added in earlier finding.
+EOF
+
+output_mixed=$(python3 "$SCRIPT" "$mixed_dir" 2>&1)
+
+if grep -q "## Fix Impossible (1)" "$mixed_dir/prove-fix-summary.md" \
+   && grep -q "## Impossible (1)" "$mixed_dir/prove-fix-summary.md"; then
+    pass "FIX_IMPOSSIBLE and IMPOSSIBLE remain in separate sections"
+else
+    fail "FIX_IMPOSSIBLE / IMPOSSIBLE not separated" \
+        "$(cat "$mixed_dir/prove-fix-summary.md")"
+fi
+
 # ── Summary ─────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

- /audit had no escalation path for FIX_IMPOSSIBLE findings. The prove-fix subagent could detect "fix is real but blocked by an existing pin test" and emit a structured Relaxation request, but nothing surfaced it — the request stayed in the individual prove-fix file and the user only saw a count. Findings became invisible drag (e.g. the splitmix64 case that surfaced this gap).
- The existing spec-conflict flow (skills/audit/SKILL.md:864-899) already handled the symmetric case (fix WAS made, contradicts a spec). FIX_IMPOSSIBLE is the same shape: fix could NOT be made because a test pins old behavior, user needs to choose relax-test / wontfix / escalate-to-spec-author / defer.

## What changed

- `prompts/audit/aggregate-results.py` — `parse_prove_fix()` now extracts the Impossibility proof block (`approaches_tried`, `structural_reason`, `relaxation_request`); `format_finding()` includes them for FIX_IMPOSSIBLE; the summary file groups FIX_IMPOSSIBLE in its own section with an explicit "needs explicit user resolution" header.
- `prompts/audit/report.md` — adds a *Fix Impossible — needs resolution* section to the audit-report.md template (one entry per finding with relaxation request + suggested route); adds `Fix-impossible needing resolution: <n>` to the orchestrator summary; adds §5b analytical step instructing the report subagent to assemble the section.
- `skills/audit/SKILL.md` — adds an AskUserQuestion escalation block parallel to the existing spec-conflicts handling, with four options + mechanical handling (relax-test, accept-wontfix, escalate-to-/spec-author, defer-to-obligation).

## Test plan

- [x] `bash tests/scenario-aggregate-results.sh` — 32/32 passing (7 new tests for FIX_IMPOSSIBLE extraction, dedicated section, relaxation/structural/approaches surfaced, escalation guidance, and FIX_IMPOSSIBLE staying distinct from IMPOSSIBLE).
- [ ] Manual verification on a real audit run with a FIX_IMPOSSIBLE outcome (e.g. the splitmix64 case) to confirm the orchestrator presents the AskUserQuestion correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)