### PR TITLE
feat(spec): quantitative ambiguity gate for /spec-write

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -115,6 +115,7 @@
 .claude/scripts/spec-lib.sh
 .claude/scripts/audit-state-gate.sh
 .claude/scripts/spec-validate.sh
+.claude/scripts/spec-ambiguity-score.sh
 .claude/scripts/spec-stats.sh
 .claude/scripts/spec-resolve.sh
 .claude/scripts/spec-obligations-gc.sh

--- a/install.sh
+++ b/install.sh
@@ -293,6 +293,7 @@ install_file "$SCRIPT_DIR/scripts/uninstall.sh" "$TARGET/.claude/scripts/uninsta
 install_file "$SCRIPT_DIR/scripts/spec-lib.sh" "$TARGET/.claude/scripts/spec-lib.sh"
 install_file "$SCRIPT_DIR/scripts/audit-state-gate.sh" "$TARGET/.claude/scripts/audit-state-gate.sh"
 install_file "$SCRIPT_DIR/scripts/spec-validate.sh" "$TARGET/.claude/scripts/spec-validate.sh"
+install_file "$SCRIPT_DIR/scripts/spec-ambiguity-score.sh" "$TARGET/.claude/scripts/spec-ambiguity-score.sh"
 install_file "$SCRIPT_DIR/scripts/spec-stats.sh" "$TARGET/.claude/scripts/spec-stats.sh"
 install_file "$SCRIPT_DIR/scripts/spec-resolve.sh" "$TARGET/.claude/scripts/spec-resolve.sh"
 install_file "$SCRIPT_DIR/scripts/spec-obligations-gc.sh" "$TARGET/.claude/scripts/spec-obligations-gc.sh"
@@ -320,6 +321,7 @@ chmod +x "$TARGET/.claude/upgrade.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/uninstall.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/audit-state-gate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-validate.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/spec-ambiguity-score.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-stats.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-obligations-gc.sh" 2>/dev/null || true
@@ -400,6 +402,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/index-verify.sh:*)",
       "Bash(bash .claude/scripts/narrative-wrapper.sh:*)",
       "Bash(bash .claude/scripts/spec-validate.sh:*)",
+      "Bash(bash .claude/scripts/spec-ambiguity-score.sh:*)",
       "Bash(bash .claude/scripts/audit-state-gate.sh:*)",
       "Bash(bash .claude/scripts/spec-stats.sh:*)",
       "Bash(bash .claude/scripts/spec-resolve.sh:*)",
@@ -509,6 +512,7 @@ HOOKJSON
             "Bash(bash .claude/scripts/index-verify.sh:*)",
             "Bash(bash .claude/scripts/narrative-wrapper.sh:*)",
       "Bash(bash .claude/scripts/spec-validate.sh:*)",
+      "Bash(bash .claude/scripts/spec-ambiguity-score.sh:*)",
       "Bash(bash .claude/scripts/audit-state-gate.sh:*)",
       "Bash(bash .claude/scripts/spec-stats.sh:*)",
       "Bash(bash .claude/scripts/spec-resolve.sh:*)",

--- a/scripts/spec-ambiguity-score.sh
+++ b/scripts/spec-ambiguity-score.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# spec-ambiguity-score.sh — quantitative ambiguity gate for specs.
+#
+# Computes a numeric ambiguity score for a spec file based on red-flag markers
+# that indicate the spec is not yet ready for downstream consumers. Replaces
+# the implicit "any [UNVERIFIED] marker -> DRAFT" rule with a transparent
+# score + configurable threshold so authors can see *why* a spec is DRAFT.
+#
+# Inspired by adversarial-authoring critique (2026-04-21): binary gates hide
+# signal — a spec with 1/30 unresolved claims shouldn't be classed the same
+# as one with 15/30.
+#
+# Usage:
+#   spec-ambiguity-score.sh <spec-file> [--threshold <n>] [--json]
+#
+# Exit 0 → score <= threshold (spec is ready)
+# Exit 1 → score > threshold (spec needs more work) OR file unreadable
+#
+# Output (stdout):
+#   Human-readable breakdown (default)
+#   JSON with --json (for tooling pipelines)
+#
+# Score = (unverified + unresolved + conflict) / max(1, total_requirements)
+# Default threshold: 0.20
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+FILE=""
+THRESHOLD="0.20"
+JSON_OUTPUT=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threshold)
+      THRESHOLD="${2:-}"
+      [[ -z "$THRESHOLD" ]] && { echo "ERROR: --threshold requires a value" >&2; exit 1; }
+      shift 2
+      ;;
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag '$1'" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "$FILE" ]]; then
+        FILE="$1"
+      else
+        echo "ERROR: only one file argument allowed" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$FILE" ]]; then
+  echo "Usage: spec-ambiguity-score.sh <spec-file> [--threshold <n>] [--json]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$FILE" ]]; then
+  echo "ERROR: file not found: $FILE" >&2
+  exit 1
+fi
+
+# ── Machine section extraction ───────────────────────────────────────────────
+# The spec format is: front matter (---...---) + machine section + Design
+# Narrative. Ambiguity scoring applies to the machine section only —
+# Design Narrative may legitimately contain "unresolved" in natural English.
+
+machine_section() {
+  awk '
+    /^---$/ {
+      delim++
+      if (delim == 3) { exit }
+      next
+    }
+    delim == 2 { print }
+  ' "$FILE"
+}
+
+# If there are only two --- delimiters (no Design Narrative separator), the
+# machine section is everything after the second delimiter. This handles
+# specs that haven't yet been through spec-author's narrative phase.
+SECTION_CONTENT="$(machine_section)"
+if [[ -z "$SECTION_CONTENT" ]]; then
+  SECTION_CONTENT="$(awk '/^---$/{n++; next} n>=2{print}' "$FILE")"
+fi
+
+# ── Counters ─────────────────────────────────────────────────────────────────
+
+# Requirement count: lines starting with R<digits>. (allowing optional letter
+# suffix like R3a)
+TOTAL_REQS=$(echo "$SECTION_CONTENT" | grep -cE '^R[0-9]+[a-z]?\.' || true)
+
+# Red-flag markers (case-sensitive by convention).
+UNVERIFIED=$(echo "$SECTION_CONTENT" | grep -cE '\[UNVERIFIED' || true)
+UNRESOLVED=$(echo "$SECTION_CONTENT" | grep -cE '\[UNRESOLVED' || true)
+CONFLICT=$(echo "$SECTION_CONTENT" | grep -cE '\[CONFLICT' || true)
+
+# Advisory signal (not in score): requirements that name class/method/file
+# paths — structural leaks, per spec rules "behavioral, not structural".
+# This is a heuristic and will have false positives.
+CODE_REF=$(echo "$SECTION_CONTENT" \
+  | grep -cE '(class|method|function)[[:space:]]+[A-Z][A-Za-z0-9_]+|[A-Z][A-Za-z0-9_]+\.(java|py|ts|js|go|rs):|src/[a-z]' \
+  || true)
+
+TOTAL_REDFLAGS=$(( UNVERIFIED + UNRESOLVED + CONFLICT ))
+
+# Divide-by-zero guard: if the spec has no parseable requirements, score is
+# 0 if there are also no red flags (empty spec), or 1.0 if there are flags
+# with no requirements (broken spec).
+if (( TOTAL_REQS == 0 )); then
+  if (( TOTAL_REDFLAGS == 0 )); then
+    SCORE="0.00"
+  else
+    SCORE="1.00"
+  fi
+else
+  # Use awk for floating-point division; bash doesn't do floats.
+  SCORE=$(awk -v n="$TOTAL_REDFLAGS" -v d="$TOTAL_REQS" \
+    'BEGIN { printf "%.2f", n / d }')
+fi
+
+# ── Compare against threshold ────────────────────────────────────────────────
+
+PASS=$(awk -v s="$SCORE" -v t="$THRESHOLD" \
+  'BEGIN { print (s + 0 <= t + 0) ? "true" : "false" }')
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+  cat <<EOF
+{
+  "file": "$FILE",
+  "total_requirements": $TOTAL_REQS,
+  "unverified": $UNVERIFIED,
+  "unresolved": $UNRESOLVED,
+  "conflict": $CONFLICT,
+  "code_refs_advisory": $CODE_REF,
+  "score": $SCORE,
+  "threshold": $THRESHOLD,
+  "pass": $PASS
+}
+EOF
+else
+  verdict="PASS"
+  [[ "$PASS" == "false" ]] && verdict="FAIL"
+  cat <<EOF
+── Spec ambiguity score ─────────────────────────
+  File             : $FILE
+  Requirements     : $TOTAL_REQS
+  Unverified       : $UNVERIFIED
+  Unresolved       : $UNRESOLVED
+  Conflict         : $CONFLICT
+  Code-ref (advisory): $CODE_REF
+  ─────────────────────────────────────────────
+  Score            : $SCORE
+  Threshold        : $THRESHOLD
+  Verdict          : $verdict
+──────────────────────────────────────────────────
+EOF
+  if [[ "$PASS" != "true" ]]; then
+    cat >&2 <<EOF
+Spec is above the readiness threshold. Common paths:
+  - Resolve [UNVERIFIED] claims by reading code or running /research
+  - Resolve [UNRESOLVED]/[CONFLICT] claims via /spec-author pass 2
+  - If any remain, set state: DRAFT and add to open_obligations
+EOF
+  fi
+fi
+
+if [[ "$PASS" == "true" ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/skills/spec-write/SKILL.md
+++ b/skills/spec-write/SKILL.md
@@ -267,6 +267,44 @@ Do not proceed past this step with a failing spec.
 
 ---
 
+## Step 8a — Ambiguity score
+
+Run the quantitative ambiguity gate to confirm the spec is ready for
+downstream consumers:
+
+```bash
+bash .claude/scripts/spec-ambiguity-score.sh "<spec-file-path>"
+```
+
+The script computes `score = ([UNVERIFIED] + [UNRESOLVED] + [CONFLICT]) /
+total_requirements` and reports PASS if `score <= 0.20`.
+
+**Interpretation:**
+
+- **Score 0.00 (PASS):** clean — all requirements are resolvable from the
+  current context. Proceed with `state: "APPROVED"` unless Step 7 state
+  rules already assigned DRAFT for another reason.
+- **Score between 0.01 and 0.20 (PASS):** one or two lingering markers
+  against a well-sized spec. The spec can go APPROVED if the markers are
+  on non-load-bearing requirements; otherwise set DRAFT and use
+  `open_obligations` to track each unresolved claim.
+- **Score above 0.20 (FAIL):** too many unresolved claims for
+  downstream consumption. Set `state: "DRAFT"`, record each marker in
+  `open_obligations`, and surface the score in your completion report so
+  the caller sees it.
+
+The score is a signal, not a hard gate — Step 7 state rules remain
+authoritative for state assignment. The score adds transparency: authors
+see *why* a spec is DRAFT instead of inferring from the absence of
+explicit feedback.
+
+**Do not proceed to registration while the score indicates FAIL and
+the spec is being registered as APPROVED.** These two states are
+inconsistent — resolve them (lower score by resolving markers, or
+acknowledge DRAFT state) before continuing.
+
+---
+
 ## Step 9 — Update shard INDEX.md
 
 Add a row to the Feature Registry table in the domain shard's INDEX.md:

--- a/tests/scenario-spec-ambiguity-score.sh
+++ b/tests/scenario-spec-ambiguity-score.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# Scenario: spec-ambiguity-score.sh computes ambiguity score for specs.
+#
+# Validates:
+# - Clean spec scores 0.00 and PASSes
+# - Mixed spec (1 unverified / 5 reqs) scores 0.20 and PASSes (boundary)
+# - Noisy spec (3 unverified / 5 reqs) scores 0.60 and FAILs
+# - Machine section is the scoring scope (narrative text doesn't count)
+# - --json output format is parseable
+# - --threshold flag overrides default
+# - Empty spec (no requirements) returns deterministic score
+# - Missing file exits with clear error
+#
+# Run from repo root: bash tests/scenario-spec-ambiguity-score.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-spec-ambiguity-score"
+SCRIPT="$REPO_ROOT/scripts/spec-ambiguity-score.sh"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ""
+echo "scenario: spec-ambiguity-score"
+echo "────────────────────────────────────────────────"
+
+cleanup
+mkdir -p "$TEST_BASE"
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+write_clean_spec() {
+    cat > "$TEST_BASE/clean.md" << 'EOF'
+---
+{"id": "domain.clean", "state": "APPROVED", "domains": ["domain"]}
+---
+# domain.clean
+
+R1. Service must accept well-formed requests.
+R2. Service must reject malformed input with 400.
+R3. Service must return 500 on internal failure.
+R4. Service must log every request.
+R5. Service must time out after 30 seconds.
+
+---
+
+## Design Narrative
+
+### Intent
+Clean spec with no markers — every requirement resolvable.
+EOF
+}
+
+write_boundary_spec() {
+    # 1 UNVERIFIED out of 5 reqs = 0.20 — on the boundary of the 0.20 threshold
+    cat > "$TEST_BASE/boundary.md" << 'EOF'
+---
+{"id": "domain.boundary", "state": "DRAFT", "domains": ["domain"]}
+---
+# domain.boundary
+
+R1. Service must accept well-formed requests.
+R2. Service must reject malformed input. [UNVERIFIED: assumes 400 is the canonical reject code — source needed]
+R3. Service must return 500 on internal failure.
+R4. Service must log every request.
+R5. Service must time out after 30 seconds.
+
+---
+
+## Design Narrative
+
+### Intent
+One unverified claim; other five requirements clean.
+EOF
+}
+
+write_noisy_spec() {
+    # 3 markers out of 5 reqs = 0.60 — comfortably above threshold
+    cat > "$TEST_BASE/noisy.md" << 'EOF'
+---
+{"id": "domain.noisy", "state": "DRAFT", "domains": ["domain"]}
+---
+# domain.noisy
+
+R1. Service must accept well-formed requests. [UNVERIFIED: assumes HTTP/1.1]
+R2. Service must reject malformed input. [UNRESOLVED: which codes count as malformed?]
+R3. Service must return 500 on internal failure.
+R4. Service must log every request. [CONFLICT: R4 vs F02.R7 on log format]
+R5. Service must time out after 30 seconds.
+
+---
+
+## Design Narrative
+
+### Intent
+Deliberately noisy for test coverage.
+EOF
+}
+
+write_empty_spec() {
+    cat > "$TEST_BASE/empty.md" << 'EOF'
+---
+{"id": "domain.empty", "state": "DRAFT", "domains": ["domain"]}
+---
+# domain.empty
+
+No requirements yet — placeholder.
+
+---
+
+## Design Narrative
+
+### Intent
+Stub.
+EOF
+}
+
+write_narrative_noise_spec() {
+    # Narrative contains markers but machine section is clean — must not count
+    cat > "$TEST_BASE/narrative-noise.md" << 'EOF'
+---
+{"id": "domain.narrative-noise", "state": "APPROVED", "domains": ["domain"]}
+---
+# domain.narrative-noise
+
+R1. Service must accept well-formed requests.
+R2. Service must reject malformed input with 400.
+R3. Service must return 500 on internal failure.
+
+---
+
+## Design Narrative
+
+### Intent
+Prior notes contained [UNRESOLVED] claims and a [CONFLICT] with F02
+that were addressed during adversarial review. Those markers should
+not count — they are natural English prose in the narrative section.
+EOF
+}
+
+# ── Test 1: Clean spec scores 0.00 and PASSes ───────────────────────────────
+
+echo ""
+echo "  Clean spec"
+echo "  ──────────"
+
+write_clean_spec
+if output="$(bash "$SCRIPT" "$TEST_BASE/clean.md" 2>&1)"; then
+    if echo "$output" | grep -qE "Score[[:space:]]+:[[:space:]]+0\.00"; then
+        pass "clean spec scores 0.00"
+    else
+        fail "clean spec score" "got: $output"
+    fi
+    if echo "$output" | grep -q "Verdict          : PASS"; then
+        pass "clean spec verdict PASS"
+    else
+        fail "clean spec verdict" "got: $output"
+    fi
+else
+    fail "clean spec should exit 0" "got: $output"
+fi
+
+# ── Test 2: Boundary spec (0.20) PASSes at default threshold ────────────────
+
+echo ""
+echo "  Boundary spec (1/5 = 0.20)"
+echo "  ──────────────────────────"
+
+write_boundary_spec
+if output="$(bash "$SCRIPT" "$TEST_BASE/boundary.md" 2>&1)"; then
+    if echo "$output" | grep -qE "Score[[:space:]]+:[[:space:]]+0\.20"; then
+        pass "boundary spec scores 0.20"
+    else
+        fail "boundary spec score" "got: $output"
+    fi
+    if echo "$output" | grep -q "Verdict          : PASS"; then
+        pass "boundary spec passes at default 0.20 threshold"
+    else
+        fail "boundary verdict" "got: $output"
+    fi
+else
+    fail "boundary spec should exit 0 at default threshold" "got: $output"
+fi
+
+# ── Test 3: Noisy spec FAILs ────────────────────────────────────────────────
+
+echo ""
+echo "  Noisy spec (3/5 = 0.60)"
+echo "  ───────────────────────"
+
+write_noisy_spec
+if output="$(bash "$SCRIPT" "$TEST_BASE/noisy.md" 2>&1 || true)"; then
+    :  # ran (exit 0 or 1 captured by || true)
+fi
+
+# Exit code check requires a separate invocation
+if bash "$SCRIPT" "$TEST_BASE/noisy.md" >/dev/null 2>&1; then
+    fail "noisy spec should exit non-zero"
+else
+    pass "noisy spec exits non-zero"
+fi
+
+if echo "$output" | grep -qE "Score[[:space:]]+:[[:space:]]+0\.60"; then
+    pass "noisy spec scores 0.60"
+else
+    fail "noisy spec score" "got: $output"
+fi
+
+if echo "$output" | grep -q "Verdict          : FAIL"; then
+    pass "noisy spec verdict FAIL"
+else
+    fail "noisy verdict" "got: $output"
+fi
+
+if echo "$output" | grep -q "Unverified       : 1" \
+   && echo "$output" | grep -q "Unresolved       : 1" \
+   && echo "$output" | grep -q "Conflict         : 1"; then
+    pass "noisy spec counts all three marker types correctly"
+else
+    fail "marker breakdown" "got: $output"
+fi
+
+# ── Test 4: Narrative section doesn't contaminate score ─────────────────────
+
+echo ""
+echo "  Narrative noise is scored-out"
+echo "  ─────────────────────────────"
+
+write_narrative_noise_spec
+if output="$(bash "$SCRIPT" "$TEST_BASE/narrative-noise.md" 2>&1)"; then
+    if echo "$output" | grep -qE "Score[[:space:]]+:[[:space:]]+0\.00"; then
+        pass "narrative markers ignored (score stays 0.00)"
+    else
+        fail "narrative contamination" "got: $output"
+    fi
+else
+    fail "narrative-noise spec should pass" "got: $output"
+fi
+
+# ── Test 5: --threshold flag overrides default ─────────────────────────────
+
+echo ""
+echo "  Threshold override"
+echo "  ──────────────────"
+
+# Boundary spec (0.20) should FAIL with stricter threshold 0.10
+if bash "$SCRIPT" --threshold 0.10 "$TEST_BASE/boundary.md" >/dev/null 2>&1; then
+    fail "boundary spec should fail at threshold 0.10"
+else
+    pass "threshold 0.10 fails boundary spec"
+fi
+
+# Noisy spec (0.60) should PASS with lax threshold 0.75
+if bash "$SCRIPT" --threshold 0.75 "$TEST_BASE/noisy.md" >/dev/null 2>&1; then
+    pass "threshold 0.75 passes noisy spec"
+else
+    fail "threshold 0.75 should pass noisy spec"
+fi
+
+# ── Test 6: --json output is valid JSON ─────────────────────────────────────
+
+echo ""
+echo "  JSON output"
+echo "  ───────────"
+
+if command -v jq >/dev/null 2>&1; then
+    json_output="$(bash "$SCRIPT" --json "$TEST_BASE/noisy.md" 2>/dev/null || true)"
+    if echo "$json_output" | jq empty 2>/dev/null; then
+        pass "--json produces valid JSON"
+    else
+        fail "JSON invalid" "got: $json_output"
+    fi
+
+    # jq drops trailing zeros ("0.60" -> "0.6") so numeric-compare, not string-compare.
+    score=$(echo "$json_output" | jq -r .score)
+    if awk -v s="$score" 'BEGIN { exit !(s + 0 == 0.60) }'; then
+        pass "JSON score field matches text output"
+    else
+        fail "JSON score field" "got: $score"
+    fi
+
+    pass_field=$(echo "$json_output" | jq -r .pass)
+    if [[ "$pass_field" == "false" ]]; then
+        pass "JSON pass field reports false for noisy spec"
+    else
+        fail "JSON pass field" "got: $pass_field"
+    fi
+else
+    echo "  SKIP  jq not available — JSON validation skipped"
+fi
+
+# ── Test 7: Empty spec (no requirements) deterministic ──────────────────────
+
+echo ""
+echo "  Empty spec"
+echo "  ──────────"
+
+write_empty_spec
+if output="$(bash "$SCRIPT" "$TEST_BASE/empty.md" 2>&1)"; then
+    # No requirements + no markers = score 0.00 + PASS. Avoids crash on
+    # divide-by-zero.
+    if echo "$output" | grep -qE "Score[[:space:]]+:[[:space:]]+0\.00"; then
+        pass "empty spec scores 0.00 (no divide-by-zero)"
+    else
+        fail "empty spec score" "got: $output"
+    fi
+else
+    fail "empty spec should pass (no reqs, no markers)" "got: $output"
+fi
+
+# ── Test 8: Missing file exits with clear error ─────────────────────────────
+
+echo ""
+echo "  Missing file"
+echo "  ────────────"
+
+if err="$(bash "$SCRIPT" "$TEST_BASE/does-not-exist.md" 2>&1)"; then
+    fail "missing file should exit non-zero"
+else
+    if echo "$err" | grep -q "file not found"; then
+        pass "missing file reports 'file not found'"
+    else
+        fail "missing file error text" "got: $err"
+    fi
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+echo ""
+
+exit $failed


### PR DESCRIPTION
## Summary

- Adds a numeric ambiguity score to spec authoring, inspired by GSD's Socratic ambiguity scoring. Unlike GSD's 4-dimension score, this one counts three concrete marker classes already present in vallorcine's spec format: `score = ([UNVERIFIED] + [UNRESOLVED] + [CONFLICT]) / total_requirements`. Threshold defaults to 0.20.
- The existing rule-based state assignment (any `[UNVERIFIED]` marker → DRAFT) stays authoritative. The score adds *transparency*: authors now see *why* a spec is DRAFT (e.g. score 0.33 = 2 markers / 6 reqs) instead of inferring from absence of feedback. Also catches the signal difference between 1/30 and 15/30 that the binary gate hides.
- New skill step 8a in `/spec-write` runs the score between structural validation and registry update.

## Test plan

- [x] `bash tests/scenario-spec-ambiguity-score.sh` — 16/16 passing (clean, boundary, noisy, narrative-isolation, threshold overrides, JSON validity, empty-spec determinism, missing-file error).
- [x] `bash tests/test-install.sh` — 59/59 passing (MANIFEST + install.sh wiring validated).
- [ ] Manual verification against a real jlsm spec to confirm the score matches intuition on a production-authored spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)