### PR TITLE
feat(audit): security lens for adversary-model bug classes

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -47,6 +47,7 @@
 .claude/prompts/audit/assembly.md
 .claude/prompts/audit/card-construction.md
 .claude/prompts/audit/classification.md
+.claude/prompts/audit/lens-security.md
 .claude/prompts/audit/domain-pruning.md
 .claude/prompts/audit/exploration.md
 .claude/prompts/audit/fix.md

--- a/prompts/audit/assembly.md
+++ b/prompts/audit/assembly.md
@@ -175,6 +175,16 @@ failures, check-then-act races."
 fall-through errors, discriminant mismatches between dispatcher and
 handlers, handlers assuming dispatch guarantees that don't hold."
 
+**Security:** "Apply adversary-model analysis, not just defect
+detection. Read `.claude/prompts/audit/lens-security.md` for deep
+attack patterns. Scope is cluster constructs that handle credentials,
+PII, crypto keys/IVs/nonces, authentication/authorization, or
+deserialization of untrusted input. Split findings by verification
+category — TESTABLE (provable via a failing test) vs ADVISORY
+(design issue like timing channels that prove-fix cannot deterministically
+reproduce). Record `security_concern`, `verification`,
+`attack_surface`, and `adversary_model` on each finding."
+
 ## Boundary contracts
 | Construct | File | Guarantees | Assumes |
 |-----------|------|-----------|---------|

--- a/prompts/audit/exploration.md
+++ b/prompts/audit/exploration.md
@@ -128,8 +128,12 @@ domain-conditional concern areas:
 | HTTP handler | Route annotations, handler methods, request/response types | information flow, injection, auth |
 | Thread pool / async | Synchronized blocks, thread pool creation, async/await, futures | concurrency concerns |
 | External service | HTTP client calls, message queue producers/consumers, RPC stubs | distributed consistency |
-| Crypto | Cipher, MessageDigest, hash, key, encrypt/decrypt imports | cryptographic misuse |
+| Crypto | Cipher, MessageDigest, hash, key, encrypt/decrypt, IV, nonce imports | cryptographic misuse |
 | Environment | System.getenv, os.environ, config file reads, property loading | configuration sensitivity |
+| Credential store | Password hashing/verification, token issuance, JWT signing/verification, session management | auth, cryptographic misuse, information flow |
+| PII handling | Field names matching `ssn`, `email`, `phone`, `address`, `dob`; PII-storing tables/collections | information flow, configuration sensitivity |
+| Auth middleware | Authentication check, authorization comparison, role/permission lookup, RBAC enforcement | auth, information flow |
+| Deserialization / parser | `ObjectInputStream`, `pickle.loads`, `vm.runInNew*`, untrusted XML/JSON/YAML parsing | injection, information flow |
 
 Log each signal with the file and line where detected.
 

--- a/prompts/audit/lens-security.md
+++ b/prompts/audit/lens-security.md
@@ -1,0 +1,231 @@
+# Security Lens — Attack Pattern Reference
+
+Deep-dive attack patterns for the security lens. The Suspect subagent
+consults this file when the cluster's active concerns include any of
+`info_flow`, `auth`, `injection`, `crypto`, or `config_sensitivity`
+(concerns 7-11 of the core assertion sweep), or when `assembly.md`
+tagged the cluster's domain as "Security".
+
+Generic concern areas (validation gaps, transformation fidelity,
+contract violations, etc.) miss adversary-model bug classes: attacks
+that exploit what the system *leaks* or what an attacker can *infer*,
+rather than what the code *does wrong* in isolation. This file
+documents the patterns those generic lenses miss.
+
+---
+
+## When to apply this lens
+
+Activated automatically when Exploration's domain-signal detection
+flags any of these (see `exploration.md` Step 5):
+
+| Signal | Typical patterns |
+|---|---|
+| Crypto API | `Cipher`, `MessageDigest`, `encrypt`, `decrypt`, key management, hash, IV, nonce |
+| Credential store | Password hashing/verification, API key storage, session token issuance, JWT signing/verification |
+| PII handling | Fields named `ssn`, `email`, `phone`, `address`, `dob`; tables/collections that store personal data |
+| Auth path | Authentication middleware, authorization checks, permission comparisons, role-based access |
+| Input boundaries | HTTP handlers, RPC endpoints, deserialization entry points, SQL/query builders, path/URL parsers |
+
+If a cluster has none of the signals above, skip this lens. Do not
+apply security attack patterns to generic code — the false-positive
+rate is high and the signal is low.
+
+---
+
+## Testability taxonomy
+
+Not every security finding is fixable via prove-fix. Split findings by
+**verification category** when you record them:
+
+- **TESTABLE** — the attack has a deterministic failure mode that
+  prove-fix can reproduce and the fix can prove. Examples:
+  *key-material-not-zeroed*, *auth-check-missing*, *sql-injection*,
+  *deserialization-without-validation*, *credential-in-logs*.
+  Route normally through prove-fix.
+
+- **ADVISORY** — the attack exploits non-functional properties
+  (timing, cache state, allocation patterns). A prove-fix test would
+  be flaky or platform-dependent, and "the fix" is a design choice
+  (constant-time comparison, padding, rekeying) rather than a bug.
+  Route as an advisory finding in the audit report — the user
+  reviews and decides, but no adversarial test is produced.
+
+Record the category in each finding's `severity_meta` field.
+
+---
+
+## Attack patterns (by concern)
+
+### 7. Information flow / data exposure
+
+**7.1 Credential in logs / errors / metrics**
+- Password, API key, session token, or JWT appearing in any log line,
+  error message body, or observability pipeline.
+- Check every `log.*`, `error.*`, `stderr.write`, metric tag emission
+  along the auth path.
+- TESTABLE: assert log output contains no substring matching the
+  credential value after an authenticated request.
+
+**7.2 Timing channel on credential comparison**
+- Using `==` / `strcmp` / non-constant-time comparison on a secret.
+- An attacker can learn prefix length by measuring response time.
+- ADVISORY: flag and recommend constant-time compare
+  (`hmac.compare_digest` / `subtle.ConstantTimeCompare` / equivalent).
+
+**7.3 Error message distinguishes existence from credentials**
+- "User not found" vs "bad password" lets an attacker enumerate
+  accounts.
+- TESTABLE: assert response bodies are identical for "user exists +
+  wrong password" and "user does not exist".
+
+**7.4 Stack traces in responses**
+- Framework default that returns exception chains (including
+  environment details, file paths, internal type names) to untrusted
+  callers.
+- TESTABLE: error-response body contains no substring matching the
+  exception class name or internal path prefix.
+
+### 8. Auth / authorization logic
+
+**8.1 Missing authorization check between endpoints**
+- Two endpoints with the same permission requirement; only one has
+  the check. Caller discovers the unchecked path.
+- TESTABLE: call unchecked endpoint with token lacking required
+  permission; assert rejected.
+
+**8.2 Role check before ownership check**
+- Admin can always see any record, but a regular user can see their
+  own records. If ownership is checked after role and role fails open,
+  privilege escalation follows.
+- TESTABLE: set up a non-admin user, call resource, assert rejected
+  before any database fetch reaches the record.
+
+**8.3 Authentication on one method of a resource, not all**
+- `GET /profile` checks auth; `HEAD /profile` or `OPTIONS /profile`
+  does not. Some frameworks' auth middleware is method-scoped.
+- TESTABLE: unauthenticated HEAD/OPTIONS returns same status as
+  rejected GET.
+
+**8.4 JWT without signature verification**
+- Decodes JWT payload but skips signature verification (or uses
+  `alg: "none"`).
+- TESTABLE: forged JWT with attacker-chosen claims is accepted.
+
+### 9. Injection / neutralization
+
+**9.1 String-concatenated SQL / query**
+- Any user-influenced string flowing into a query without
+  parameterization.
+- TESTABLE: injected fragment executes (e.g. `'; DROP TABLE` in a
+  test database, or a query-builder assertion that user input never
+  reaches `.raw()` / `.unsafe()`).
+
+**9.2 Deserialization of untrusted data without class whitelist**
+- Java `ObjectInputStream`, Python `pickle`, Node.js `vm.runInNew…`
+  without input validation.
+- TESTABLE: craft a payload that triggers class instantiation or
+  side effect; assert rejected.
+
+**9.3 Path traversal in file access**
+- Constructing a file path from user input without canonicalizing and
+  re-validating against an allowlist.
+- TESTABLE: input `../../../etc/passwd` returns the canonical
+  resolved path's containment check, or is rejected.
+
+**9.4 Command injection**
+- Passing user input to shell / `subprocess` without `shell=False` and
+  argv-form separation.
+- TESTABLE: input `; <payload>` does not execute `<payload>`.
+
+### 10. Cryptographic misuse
+
+**10.1 IV / nonce reuse for stream or AEAD modes**
+- Same IV used across multiple encryptions with the same key
+  (CTR/GCM/CBC-with-PKCS7). Two ciphertexts XORed recover plaintext
+  XOR of the originals.
+- TESTABLE: two calls encrypting distinct plaintext produce distinct
+  IVs (assert IV is random or counter-increments).
+
+**10.2 Key material not zeroed after use**
+- Key bytes linger in memory longer than necessary. Heap dumps or
+  swap leaks expose the key.
+- TESTABLE: after the key-using call returns, the byte array
+  referenced by the key holder is zeroed. (JVM: track the byte[],
+  assert all zero bytes after the operation.)
+
+**10.3 Weak RNG for secret material**
+- `java.util.Random` / `Math.random()` / Python `random` used for
+  key, salt, token, IV generation.
+- TESTABLE: assert the secret generator is a cryptographic RNG
+  (SecureRandom / secrets module / `crypto.randomBytes`).
+
+**10.4 MAC-before-encrypt or no MAC**
+- Authenticity decided by decrypt-and-check-plaintext instead of
+  MAC-before-decrypt, enabling padding oracles; or encryption without
+  any authenticity (CBC without MAC).
+- ADVISORY: recommend AEAD (GCM, ChaCha20-Poly1305) and flag the
+  pattern.
+
+**10.5 Ciphertext without integrity tag**
+- Ciphertext stored or transmitted without MAC/AEAD tag. Attacker
+  can tamper without detection.
+- TESTABLE: flip a bit in ciphertext; assert decrypt rejects.
+
+**10.6 Hash-then-cache for credential check**
+- Bcrypt/argon2 result cached in a fast-lookup map keyed by the
+  plaintext password. Cache hit skips the bcrypt verify.
+- TESTABLE: two different plaintext passwords with colliding cache
+  keys both succeed.
+
+### 11. Configuration / environment sensitivity
+
+**11.1 Secure defaults absent**
+- A configuration flag controls whether TLS / signature verification
+  is enforced. Default is "off" (or unset treated as off).
+- TESTABLE: unset the flag, assert secure behavior still applies.
+
+**11.2 Secret embedded in config loaded into logs**
+- Loading config and logging the parsed config object. Secrets in
+  config appear in logs.
+- TESTABLE: seed config with a recognizable secret; assert it does
+  not appear in any log sink after config load.
+
+**11.3 Environment-variable fallback reveals secret source**
+- Code falls back to `ENV["SECRET"]` and logs "loaded secret from
+  environment" without noting the fallback is used for local dev
+  only.
+- ADVISORY: recommend explicit "insecure-dev-mode" gate that rejects
+  at startup in production.
+
+---
+
+## Output format
+
+Record security findings with these additional fields:
+
+```yaml
+security_concern: info_flow | auth | injection | crypto | config_sensitivity
+verification: TESTABLE | ADVISORY
+attack_surface: <specific trigger — input, sequence, or adversary capability>
+adversary_model: <who can exploit this — remote unauthenticated user,
+  authenticated low-privilege user, local attacker, etc.>
+```
+
+The standard `severity` field still applies (high / medium / low),
+but note that an ADVISORY finding can be high severity even without a
+prove-fix path — the audit report surfaces it for user decision.
+
+---
+
+## What this lens must NOT do
+
+- Generic input-validation findings that the `contract_boundaries`
+  lens already covers. Only flag input validation when the adversary
+  can *weaponize* the gap (not just trigger a crash).
+- Architectural security reviews (threat model, trust boundary
+  validation). Those are `/spec-author` territory, not prove-fix
+  audit.
+- Speculative advisories without a concrete attack path. "Log aggregation
+  might someday leak this" is not a finding; "this log line contains a
+  bcrypt hash that appears in the response body" is.

--- a/prompts/audit/suspect.md
+++ b/prompts/audit/suspect.md
@@ -71,6 +71,16 @@ domain.
 12. **Configuration / environment sensitivity** — implicit environmental
     dependencies.
 
+**Security lens deep dive:** When any of concerns 7, 8, 10, 11 are in
+your packet, OR when the packet's `Domain-specific analysis guidance`
+names the "Security" lens, read
+`.claude/prompts/audit/lens-security.md` before sweeping. It lists
+concrete adversary-model attack patterns (IV/nonce reuse, credential
+timing channels, deserialization class whitelist gaps, etc.) that
+generic concerns don't surface. Record security findings with the
+extra fields the lens specifies: `security_concern`, `verification`
+(TESTABLE | ADVISORY), `attack_surface`, `adversary_model`.
+
 ## Using construct cards
 
 Your packet includes full reconciled construct cards. Use them as

--- a/tests/scenario-audit-lens-security.sh
+++ b/tests/scenario-audit-lens-security.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Scenario: security lens is wired into the audit pipeline.
+#
+# Validates:
+# - prompts/audit/lens-security.md exists in the kit
+# - MANIFEST lists it
+# - install.sh installs it (via existing prompts/audit/*.md glob)
+# - assembly.md's Domain-specific analysis guidance references it
+# - suspect.md tells the subagent to read it when security concerns apply
+# - exploration.md's domain-signal table covers the new signals
+#   (credential store, PII, auth middleware, deserialization/parser)
+# - lens-security.md has the expected structure (testability taxonomy,
+#   attack patterns grouped by concern number, output format)
+#
+# Run from repo root: bash tests/scenario-audit-lens-security.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-audit-lens-security"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ""
+echo "scenario: audit security lens"
+echo "────────────────────────────────────────────────"
+
+# ── Existence + MANIFEST ────────────────────────────────────────────────────
+
+echo ""
+echo "  Existence and MANIFEST"
+echo "  ──────────────────────"
+
+lens_file="$REPO_ROOT/prompts/audit/lens-security.md"
+if [[ -f "$lens_file" ]]; then
+    pass "lens-security.md exists"
+else
+    fail "lens-security.md is missing"
+fi
+
+if grep -qF ".claude/prompts/audit/lens-security.md" "$REPO_ROOT/MANIFEST"; then
+    pass "MANIFEST lists lens-security.md"
+else
+    fail "MANIFEST missing lens-security.md entry"
+fi
+
+# ── Structural sections of the lens file ────────────────────────────────────
+
+echo ""
+echo "  Lens file structure"
+echo "  ───────────────────"
+
+if grep -q "^## Testability taxonomy" "$lens_file"; then
+    pass "has Testability taxonomy section"
+else
+    fail "missing Testability taxonomy section"
+fi
+
+if grep -q "TESTABLE" "$lens_file" && grep -q "ADVISORY" "$lens_file"; then
+    pass "distinguishes TESTABLE vs ADVISORY findings"
+else
+    fail "missing TESTABLE/ADVISORY distinction"
+fi
+
+for concern in "Information flow" "Auth / authorization" "Injection" "Cryptographic misuse" "Configuration / environment"; do
+    if grep -qF "$concern" "$lens_file"; then
+        pass "attack patterns cover '$concern'"
+    else
+        fail "missing attack patterns for '$concern'"
+    fi
+done
+
+# Specific security patterns that generic lenses miss
+for pattern in "IV / nonce reuse" "Timing channel" "Key material not zeroed" "JWT without signature" "class whitelist"; do
+    if grep -qF "$pattern" "$lens_file"; then
+        pass "covers specific pattern: '$pattern'"
+    else
+        fail "missing pattern: '$pattern'"
+    fi
+done
+
+# Output format guidance
+if grep -q "security_concern" "$lens_file" \
+   && grep -q "attack_surface" "$lens_file" \
+   && grep -q "adversary_model" "$lens_file"; then
+    pass "output format spec includes structured fields"
+else
+    fail "output format fields missing"
+fi
+
+# ── Integration: assembly.md references the lens ────────────────────────────
+
+echo ""
+echo "  Integration"
+echo "  ───────────"
+
+if grep -qF "lens-security.md" "$REPO_ROOT/prompts/audit/assembly.md"; then
+    pass "assembly.md references lens-security.md"
+else
+    fail "assembly.md missing lens-security.md reference"
+fi
+
+if grep -q "\*\*Security:\*\*" "$REPO_ROOT/prompts/audit/assembly.md"; then
+    pass "assembly.md has 'Security' domain-specific guidance"
+else
+    fail "assembly.md missing Security lens guidance block"
+fi
+
+if grep -qF "lens-security.md" "$REPO_ROOT/prompts/audit/suspect.md"; then
+    pass "suspect.md references lens-security.md"
+else
+    fail "suspect.md missing lens-security.md reference"
+fi
+
+# ── Integration: exploration.md covers new signals ──────────────────────────
+
+echo ""
+echo "  New domain signals in exploration.md"
+echo "  ────────────────────────────────────"
+
+for signal in "Credential store" "PII handling" "Auth middleware" "Deserialization"; do
+    if grep -qF "$signal" "$REPO_ROOT/prompts/audit/exploration.md"; then
+        pass "exploration.md covers signal: '$signal'"
+    else
+        fail "exploration.md missing signal: '$signal'"
+    fi
+done
+
+# ── Install-path coverage: fresh install includes the lens ──────────────────
+
+echo ""
+echo "  Install wiring"
+echo "  ──────────────"
+
+cleanup
+mkdir -p "$TEST_BASE/project"
+cd "$TEST_BASE/project"
+git init -q 2>&1 >/dev/null
+
+if bash "$REPO_ROOT/install.sh" "$TEST_BASE/project" >/dev/null 2>&1; then
+    if [[ -f "$TEST_BASE/project/.claude/prompts/audit/lens-security.md" ]]; then
+        pass "install.sh installs lens-security.md"
+    else
+        fail "install.sh did not install lens-security.md"
+    fi
+else
+    fail "install.sh failed for test project"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+echo ""
+
+exit $failed


### PR DESCRIPTION
## Summary

- /audit's generic lenses catch defects but miss adversary-model bug classes (timing channels, IV reuse, key residue, credential leaks). The jlsm encryption audit found 10 key-lifecycle bugs via the generic `resource_lifecycle` lens but missed these — they need "what can an attacker extract?" reasoning, not "is the resource cleaned up?" reasoning.
- Targeted MVP for Tier 2 item 4 in the priority stack. The lens activates only when exploration detects security-sensitive constructs (crypto APIs, credential stores, PII fields, auth middleware, deserialization entry points). Not a blanket security audit — a targeted adversary-model supplement to existing concerns.

## What changed

- `prompts/audit/lens-security.md` (new) — attack patterns grouped by concern: credential leaks, timing channels, auth-check gaps, JWT misuse, injection, IV/nonce reuse, key residue, weak RNG, ciphertext integrity, secure defaults, etc. Each pattern tagged **TESTABLE** (prove-fix can reproduce) or **ADVISORY** (design findings that prove-fix can't reliably test — surfaced for user decision).
- `prompts/audit/exploration.md` — Step 5 signal table gains 4 new triggers (credential store, PII handling, auth middleware, deserialization/parser) that activate domain-conditional concerns 7-11.
- `prompts/audit/assembly.md` — Domain-specific analysis guidance gains a "Security" entry pointing Suspect subagents at `lens-security.md`.
- `prompts/audit/suspect.md` — core sweep instructs subagents to read `lens-security.md` when security concerns are in the packet, and to record extra fields (`security_concern`, `verification`, `attack_surface`, `adversary_model`).
- `MANIFEST` lists the new prompt; `install.sh` picks it up via the existing `prompts/audit/*.md` glob.

## Scope note

Deliberately MVP. The lens activates via existing domain-conditional concerns plus 4 new exploration signals. Full integration (active-lenses.md "security" candidate, domain pruning with security evidence, card-level security trigger detection) is the architect-deliberation part of Tier 2 item 4 and is deferred.

## Test plan

- [x] `bash tests/scenario-audit-lens-security.sh` — 23/23 passing (lens file exists, MANIFEST entry, key patterns covered, structured output fields, integration references in assembly/suspect/exploration, fresh-install pickup).
- [x] `bash tests/test-install.sh` — 59/59 passing.
- [ ] Manual validation against a real audit run on jlsm encryption module (should surface the 3 previously-missed bug classes: timing channels, IV reuse, ciphertext integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)