### PR TITLE
feat(work-start): --parallel mode for concurrent WD implementation

### DIFF
--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -1,9 +1,9 @@
 ---
 description: "Start implementing a specified work definition — implementation pipeline only"
-argument-hint: "<group-slug> [WD-nn | next]"
+argument-hint: "<group-slug> [WD-nn | next | --parallel [N]]"
 ---
 
-# /work-start "<group-slug>" [WD-nn | next]
+# /work-start "<group-slug>" [WD-nn | next | --parallel [N]]
 
 Bridges a work definition from a work group into the implementation pipeline.
 Creates a `.feature/` directory and hands off to planning, testing, and
@@ -14,6 +14,8 @@ interface contracts), use `/work-plan` instead.
 - `<group-slug>` — the work group to draw from
 - `WD-nn` — start a specific work definition (e.g., WD-01)
 - `next` — auto-select the highest-value READY work definition
+- `--parallel [N]` — start every SPECIFIED WD concurrently (optionally
+  cap at N concurrent sub-agents). See "Parallel mode" section below.
 
 If no WD argument is provided, defaults to `next`.
 
@@ -50,6 +52,12 @@ Display opening header:
 ---
 
 ## Step 3 — Select work definition
+
+### If `--parallel` flag is present:
+
+Skip the single-WD selection logic and go to the **Parallel mode**
+section below. The rest of Step 3's single-WD paths (WD-nn / next) do
+not apply.
 
 ### If specific WD (e.g., WD-01):
 
@@ -239,6 +247,128 @@ Invoke `/feature-plan "<slug>"`.
 
 ---
 
+## Parallel mode
+
+When invoked with `--parallel [N]`, `/work-start` dispatches every
+SPECIFIED work definition in the group as a concurrent sub-agent. Each
+sub-agent runs the full feature pipeline
+(`/feature-plan` → `/feature-test` → `/feature-implement` →
+`/feature-refactor`) in an isolated context.
+
+### When to use parallel mode
+
+Parallel mode is a velocity multiplier when the group has multiple
+WDs that are READY to implement and have no runtime cross-dependencies
+(e.g., they land in separate modules or produce non-overlapping
+artifacts). A wave of five SPECIFIED WDs in a group can complete in
+roughly the time of one WD instead of five sequential runs.
+
+### When NOT to use parallel mode
+
+- **WDs share runtime state** (test DB, ports, cache). Parallel test
+  execution will fight for resources. Sequential is safer.
+- **WDs produce overlapping specs or KB entries.** Concurrent writes
+  to the same spec file or KB entry corrupt the registry.
+- **The user wants to review each step.** Parallel mode is
+  fire-and-wait; individual WD progress is visible in each sub-agent's
+  `.feature/<slug>/status.md` but there is no global pause point
+  between stages.
+
+### Parallel-mode flow
+
+Replace Steps 3–5 with this block when `--parallel` is set.
+
+1. **Enumerate startable WDs.** Parse the `work-resolve.sh` output
+   table and collect every WD whose Status is `SPECIFIED`. If zero,
+   report and stop:
+   ```
+   No SPECIFIED work definitions in '<group-slug>' — run /work-plan
+   first to specify READY WDs, or check work-status for blockers.
+   ```
+
+2. **Cap concurrency.** If the user supplied `--parallel N`, take the
+   first N SPECIFIED WDs (prefer those with more downstream dependents
+   — same "unblocking value" heuristic as `next` mode). If `N` is
+   omitted, dispatch all of them.
+
+3. **Show the plan.** Display:
+   ```
+   ── Parallel start plan ─────────────────────────
+   Group: <group-slug>
+   SPECIFIED WDs: <N>
+   Will dispatch concurrently: <dispatched count>
+
+     WD-<nn> — <title>  (domains: <domains>, unblocks: <list>)
+     WD-<nn> — ...
+   ───────────────────────────────────────────────
+   ```
+   Use AskUserQuestion to confirm — parallel mode spawns multiple
+   long-running pipelines at once and the user should be explicit:
+   - "Dispatch all <N> in parallel"
+   - "Cap at 2" (or a lower number)
+   - "Stop — I'll start them manually"
+
+4. **Create feature directories (all WDs, sequential).** For each
+   dispatched WD, run Step 4 from the single-WD path in full: generate
+   `brief.md`, verify readiness, write `status.md`, update the WD's
+   status to `IMPLEMENTING`. Do this sequentially — these operations
+   touch the `.work/` tree and are fast. Fanning out here adds no
+   measurable benefit and risks racing on `manifest.md` regeneration.
+
+5. **Dispatch sub-agents concurrently.** Spawn one sub-agent per WD in
+   a **single message with multiple Agent tool calls**. Each sub-agent
+   receives this prompt:
+   ```
+   You are the parallel pipeline runner for <feature-slug>.
+   The feature directory exists at .feature/<feature-slug>/.
+   Status.md is initialized at planning/loading-context and the WD is
+   marked IMPLEMENTING.
+
+   Invoke /feature-plan "<feature-slug>" and run the full pipeline
+   through to /feature-refactor. Do not pause for user confirmation;
+   treat automation_mode as autonomous. If any stage escalates (spec
+   conflict, missing tests, test writer escalation), record it in
+   cycle-log.md and continue with the remaining stages where possible;
+   report the escalation in your final one-line summary.
+
+   Return a single summary line of the form:
+     "<feature-slug>: <COMPLETE | STOPPED_AT_<stage> | ERROR> — <detail>"
+   ```
+
+6. **Aggregate results.** When all sub-agents return, summarize:
+   ```
+   ── Parallel run complete · <group-slug> ───────
+   Dispatched: <N>
+   Complete: <n>/<N>
+   Stopped mid-pipeline: <list with stage>
+   Errored: <list with detail>
+   ───────────────────────────────────────────────
+   ```
+   For stopped or errored WDs, the user's next action is usually
+   `/feature-resume "<feature-slug>"` to pick up where each sub-agent
+   left off.
+
+### Concurrency caveats (documented, user-accepted)
+
+- **Shared KB / ADR writes.** If two WDs' `/feature-retro` phases both
+  want to write a new `adversarial-finding` KB entry about the same
+  pattern, both writes succeed but one silently clobbers. Mitigation:
+  run `/curate` after a parallel batch; it detects duplicate KB
+  entries in the cross-reference analysis.
+- **Shared spec writes.** If two WDs produce specs in overlapping
+  domains, both `/spec-write` calls may serialize through the same
+  manifest file. The manifest update uses atomic `jq` + tmp + mv, so
+  the *last writer wins* on the manifest — but individual spec files
+  are per-WD and don't conflict.
+- **Test runner contention.** Parallel test suites can race on shared
+  resources (test DB, network ports, temp files). This is a
+  project-level concern. If the project's tests are isolated per WD,
+  parallel is safe; if not, either cap at 1 or don't use parallel.
+- **Token / cost budget.** N parallel pipelines burn roughly N× the
+  tokens and dollars of a single run. Budget accordingly.
+
+---
+
 ## Notes
 
 - The double-dash convention (`<group>--<wd>`) in the feature slug allows
@@ -248,3 +378,5 @@ Invoke `/feature-plan "<slug>"`.
   have visibility into the broader initiative.
 - Status.md starts at planning/loading-context because specifications
   should already exist from a prior `/work-plan` run or manual authoring.
+- Parallel mode (`--parallel`) is an advanced flow — see the "Parallel
+  mode" section above for when it applies and the concurrency caveats.

--- a/tests/scenario-work-start-parallel.sh
+++ b/tests/scenario-work-start-parallel.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Scenario: /work-start --parallel mode is documented and integrates cleanly.
+#
+# /work-start's parallel mode dispatches multiple sub-agents, which cannot be
+# exercised in a scenario test (sub-agent orchestration requires the Claude
+# runtime). This test validates the contract: that the SKILL.md documents
+# the flag in the header, describes the parallel flow, and wires into
+# work-resolve.sh's existing output so a runtime implementation has an
+# unambiguous spec to follow.
+#
+# Run from repo root: bash tests/scenario-work-start-parallel.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SKILL="$REPO_ROOT/skills/work-start/SKILL.md"
+RESOLVE="$REPO_ROOT/scripts/work-resolve.sh"
+TEST_BASE="/tmp/vallorcine/scenario-work-start-parallel"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ""
+echo "scenario: /work-start --parallel"
+echo "────────────────────────────────────────────────"
+
+# ── SKILL.md argument-hint and usage ────────────────────────────────────────
+
+echo ""
+echo "  Flag declared in skill header"
+echo "  ─────────────────────────────"
+
+if grep -qE '^argument-hint:.*--parallel' "$SKILL"; then
+    pass "argument-hint lists --parallel"
+else
+    fail "argument-hint missing --parallel"
+fi
+
+if grep -qE '# /work-start.*--parallel' "$SKILL"; then
+    pass "usage header lists --parallel"
+else
+    fail "usage header missing --parallel"
+fi
+
+# ── Dedicated 'Parallel mode' section ───────────────────────────────────────
+
+echo ""
+echo "  Parallel-mode section"
+echo "  ─────────────────────"
+
+if grep -q "^## Parallel mode" "$SKILL"; then
+    pass "has ## Parallel mode section"
+else
+    fail "missing ## Parallel mode section"
+fi
+
+for topic in "When to use parallel mode" "When NOT to use parallel mode" "Parallel-mode flow" "Concurrency caveats"; do
+    if grep -qF "$topic" "$SKILL"; then
+        pass "Parallel mode covers '$topic'"
+    else
+        fail "missing topic: '$topic'"
+    fi
+done
+
+# ── Flow sub-steps are present ──────────────────────────────────────────────
+
+echo ""
+echo "  Flow mechanics"
+echo "  ──────────────"
+
+for phrase in \
+    "Enumerate startable WDs" \
+    "Cap concurrency" \
+    "Create feature directories (all WDs, sequential)" \
+    "Dispatch sub-agents concurrently" \
+    "Aggregate results"
+do
+    if grep -qF "$phrase" "$SKILL"; then
+        pass "flow step: '$phrase'"
+    else
+        fail "missing flow step: '$phrase'"
+    fi
+done
+
+# ── Early-exit contract: Step 3 shortcircuits for --parallel ────────────────
+
+echo ""
+echo "  Step 3 shortcircuit"
+echo "  ───────────────────"
+
+if grep -qF 'If `--parallel` flag is present' "$SKILL"; then
+    pass "Step 3 shortcircuits when --parallel set"
+else
+    fail "Step 3 missing --parallel shortcircuit"
+fi
+
+# ── Dispatch contract: sub-agent prompt explicit ────────────────────────────
+
+echo ""
+echo "  Sub-agent prompt contract"
+echo "  ─────────────────────────"
+
+if grep -q "parallel pipeline runner" "$SKILL"; then
+    pass "sub-agent prompt identifies role"
+else
+    fail "sub-agent prompt role missing"
+fi
+
+if grep -q "single message with multiple Agent tool calls" "$SKILL"; then
+    pass "dispatch uses parallel Agent calls in one message"
+else
+    fail "parallel dispatch pattern undocumented"
+fi
+
+if grep -q "Return a single summary line" "$SKILL"; then
+    pass "sub-agent return contract specified"
+else
+    fail "sub-agent return contract missing"
+fi
+
+# ── Concurrency caveats cover real hazards ──────────────────────────────────
+
+echo ""
+echo "  Concurrency caveats"
+echo "  ───────────────────"
+
+for hazard in "Shared KB" "Shared spec writes" "Test runner contention" "Token / cost budget"; do
+    if grep -qF "$hazard" "$SKILL"; then
+        pass "caveat: '$hazard'"
+    else
+        fail "missing caveat: '$hazard'"
+    fi
+done
+
+# ── Parsing contract: work-resolve.sh output has SPECIFIED rows ─────────────
+
+echo ""
+echo "  work-resolve.sh contract"
+echo "  ────────────────────────"
+
+# The parallel flow parses SPECIFIED rows from work-resolve.sh output. That
+# output format must still emit SPECIFIED status in the table. Confirm by
+# running work-resolve on a synthetic group and checking the output shape.
+
+cleanup
+mkdir -p "$TEST_BASE/project/.work/parallel-group"
+cd "$TEST_BASE/project"
+
+cat > ".work/parallel-group/WD-01.md" << 'EOF'
+---
+id: WD-01
+title: First parallel WD
+group: parallel-group
+status: SPECIFIED
+domains: [auth]
+---
+
+## Summary
+Test WD.
+
+## Acceptance Criteria
+Test.
+EOF
+
+cat > ".work/parallel-group/WD-02.md" << 'EOF'
+---
+id: WD-02
+title: Second parallel WD
+group: parallel-group
+status: SPECIFIED
+domains: [auth]
+---
+
+## Summary
+Test WD.
+
+## Acceptance Criteria
+Test.
+EOF
+
+if output="$(bash "$RESOLVE" parallel-group 2>/dev/null)"; then
+    specified_rows=$(echo "$output" | grep -cE '\| SPECIFIED \|' || true)
+    if (( specified_rows == 2 )); then
+        pass "work-resolve emits SPECIFIED rows that parallel mode can parse"
+    else
+        fail "expected 2 SPECIFIED rows from work-resolve" \
+            "got $specified_rows — output: $output"
+    fi
+else
+    fail "work-resolve.sh failed on synthetic group" "got: $output"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+echo ""
+
+exit $failed


### PR DESCRIPTION
## Summary

- GSD's wave-based parallel execution is the highest-leverage capability gap from the 2026-04-21 audit. The dependency model already exists in vallorcine (artifact_deps + `work-resolve.sh` computed readiness); only the concurrent dispatch was missing.
- Adds `--parallel [N]` flag to `/work-start` that dispatches every SPECIFIED WD as a concurrent sub-agent running the full feature pipeline in an isolated 200K context.
- A wave of five SPECIFIED WDs in a group can complete in roughly the time of one WD instead of five sequential runs.

## What changed

- `skills/work-start/SKILL.md`
  - Header: `--parallel [N]` in argument-hint + usage.
  - Step 3: shortcircuits to a new "Parallel mode" section when `--parallel` is set.
  - New "Parallel mode" section with four subsections — When to use, When NOT to use, 6-step flow, and a **Concurrency caveats** block (shared KB writes, shared spec writes, test runner contention, token/cost budget).
  - Sub-agent prompt contract made explicit so the runtime has an unambiguous template.

## Deliberately NOT changed

- No new scripts. `work-resolve.sh` already emits a parseable SPECIFIED-status table; the Agent tool already supports multi-call concurrency in one message. The only missing piece was the flow documentation and sub-agent prompt contract.
- Sequential mode stays the default. Parallel requires an explicit flag AND an AskUserQuestion confirmation step, so no accidental fan-outs.

## Test plan

- [x] `bash tests/scenario-work-start-parallel.sh` — 21/21 passing (flag in argument-hint + usage, Parallel mode section with 4 subsections, 5 flow steps, Step 3 shortcircuit, sub-agent prompt contract, 4 concurrency caveats, `work-resolve.sh` still emits SPECIFIED rows that parallel mode parses).
- [x] `bash tests/test-install.sh` — 59/59 passing.
- [ ] Manual validation: dispatch `/work-start "<group>" --parallel 2` on a jlsm group with 3+ SPECIFIED WDs and confirm sub-agent orchestration works end to end.

Scenario tests cannot exercise sub-agent orchestration (requires the Claude runtime), so this PR ships the spec. Runtime validation is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)