### PR TITLE
feat(audit): route wontfix findings through open_obligations

### DIFF
--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -931,7 +931,9 @@ Ask the user using AskUserQuestion for each RELAX-<N>:
      prove-fix to confirm the fix now lands.
   2. "Accept as wontfix" — the old behavior is authoritative (backward
      compat, external contract). Record the finding in the report as a
-     known-accepted-risk with rationale.
+     known-accepted-risk with rationale, and log a non-blocking
+     `wontfix:` obligation on the most-relevant spec so `/curate`
+     analysis 19 can resurface it if the rationale ever stales.
   3. "Escalate to /spec-author" — the pin test encodes an implicit spec
      requirement that was never written down. Author the spec, then the
      decision becomes a normal spec-conflict.
@@ -950,6 +952,26 @@ contract pins this behavior; cannot change without versioned migration").
 Update the prove-fix output's `fix_detail` to record the user's
 rationale. The finding stays FIX_IMPOSSIBLE in the audit report but is
 now explicitly accepted, not silent drag.
+
+Then, **if `.spec/` exists and a relevant spec can be identified** (same
+heuristic used for option 4 — domain matches the construct under test),
+append a non-blocking obligation to that spec's `open_obligations` array:
+
+```
+"wontfix: <finding ID> — <brief rationale>"
+```
+
+The `wontfix:` prefix lets humans reading `/curate` output distinguish
+accepted-risk entries from deferred work. **Unlike option 4, the spec
+stays APPROVED** — wontfix is a landed design decision, not a gap.
+The obligation is the resurface hook: `/curate` analysis 19 ages it by
+last-commit time and flags it once it exceeds `--obligation-age-days`
+(default 30). A human reviewing the curate report can then decide
+whether the rationale still holds or the wontfix is now fixable.
+
+If `.spec/` is absent or no relevant spec exists, skip the obligation
+write — the audit report entry is the only durable record. Note this in
+the prove-fix output so reviewers know the resurface hook is not wired.
 
 For option 3: invoke `/spec-author` with a brief describing the pinned
 behavior the test encodes. After spec-author returns, re-evaluate the

--- a/tests/scenario-audit-wontfix-obligation.sh
+++ b/tests/scenario-audit-wontfix-obligation.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Scenario: audit wontfix obligations resurface via /curate analysis 19
+#
+# The audit skill's option-2 ("Accept as wontfix") handler logs a
+# `wontfix: <finding-id> — <rationale>` obligation on the most-relevant
+# spec. This scenario pins the contract with curate-scan.sh:
+# - the wontfix: prefix must survive the aging-obligations pipeline
+#   verbatim so /curate output distinguishes accepted-risk entries
+#   from deferred work.
+# - the spec's state stays APPROVED (wontfix is a landed design
+#   decision, not a gap — unlike option-4 defer).
+#
+# Run from repo root: bash tests/scenario-audit-wontfix-obligation.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-audit-wontfix-obligation"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "scenario: audit wontfix obligation"
+    echo "────────────────────────────────────────────────"
+    echo "  SKIP  jq not available"
+    exit 0
+fi
+
+echo ""
+echo "scenario: audit wontfix obligation"
+echo "────────────────────────────────────────────────"
+
+# ── Setup: project with an APPROVED spec carrying an aged wontfix obligation ─
+PROJECT="$TEST_BASE/project"
+mkdir -p "$PROJECT/.claude/scripts"
+mkdir -p "$PROJECT/.spec/registry" "$PROJECT/.spec/domains/widgets"
+
+cp "$REPO_ROOT/scripts/curate-scan.sh" "$PROJECT/.claude/scripts/"
+
+cat > "$PROJECT/.spec/registry/manifest.json" << 'REGEOF'
+{
+  "schema_version": 2,
+  "generated_at": "2026-04-22",
+  "spec_count": 1,
+  "specs": [
+    {"id": "widgets.spec-wontfix", "path": ".spec/domains/widgets/spec-wontfix.md", "state": "APPROVED", "domains": ["widgets"]}
+  ]
+}
+REGEOF
+
+# Spec stays APPROVED. The wontfix: obligation is non-blocking — a resurface hook,
+# not a gap. Exactly what the audit skill's option-2 handler is documented to write.
+cat > "$PROJECT/.spec/domains/widgets/spec-wontfix.md" << 'SPECEOF'
+---
+{
+  "id": "widgets.spec-wontfix",
+  "version": 1,
+  "state": "APPROVED",
+  "domains": ["widgets"],
+  "open_obligations": [
+    "wontfix: F-42 — external API contract pins this behavior; revisit on v2 migration"
+  ]
+}
+---
+
+# widgets.spec-wontfix — Widget with accepted-risk finding
+
+## Requirements
+R1. Widgets must exist.
+SPECEOF
+
+cd "$PROJECT"
+git init -q --initial-branch=main .
+git config user.email "test@test.com"
+git config user.name "Test"
+
+# Commit with an aged timestamp so analysis 19 flags the obligation.
+OLD_DATE="$(date -d '60 days ago' '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date -v-60d '+%Y-%m-%dT%H:%M:%S' 2>/dev/null)"
+git add .spec/registry/manifest.json .spec/domains/widgets/spec-wontfix.md
+GIT_AUTHOR_DATE="$OLD_DATE" GIT_COMMITTER_DATE="$OLD_DATE" git commit -q -m "aged wontfix obligation"
+
+output="$(bash .claude/scripts/curate-scan.sh --init 2>&1)"
+
+# ── Test: Aging Open Obligations section appears ───────────────────────────
+if grep -q "Aging Open Obligations" .curate/scan-summary.md; then
+    pass "aging obligations section present"
+else
+    fail "aging obligations section should appear" "output: $output"
+fi
+
+aging_section="$(sed -n '/## Aging Open Obligations/,/^## /p' .curate/scan-summary.md)"
+
+# ── Test: wontfix prefix preserved verbatim ────────────────────────────────
+if echo "$aging_section" | grep -qF "wontfix: F-42"; then
+    pass "wontfix: prefix and finding ID preserved verbatim"
+else
+    fail "scanner must not strip the wontfix: prefix" "section: $aging_section"
+fi
+
+# ── Test: rationale text preserved ─────────────────────────────────────────
+if echo "$aging_section" | grep -qF "external API contract pins this behavior"; then
+    pass "rationale text preserved"
+else
+    fail "rationale text must pass through untouched" "section: $aging_section"
+fi
+
+# ── Test: aged spec surfaces ───────────────────────────────────────────────
+if echo "$aging_section" | grep -q "widgets.spec-wontfix"; then
+    pass "aged spec ID surfaced"
+else
+    fail "widgets.spec-wontfix should appear in aging obligations" "section: $aging_section"
+fi
+
+# ── Test: spec stays APPROVED (not forced to DRAFT by wontfix) ─────────────
+# Unlike option-4 "Defer to obligation", option-2 wontfix must NOT degrade
+# spec state — the wontfix is a landed design decision, not a gap. The spec
+# file's declared state must still read APPROVED.
+spec_state="$(jq -r '.state' < <(awk '/^---$/{n++; next} n==1 && /^[[:space:]]*\{/{inj=1} n==1 && inj{print} n>=2{exit}' .spec/domains/widgets/spec-wontfix.md) 2>/dev/null || echo "?")"
+if [[ "$spec_state" == "APPROVED" ]]; then
+    pass "spec state remains APPROVED for wontfix (not forced to DRAFT)"
+else
+    fail "wontfix must not force spec to DRAFT" "state was: $spec_state"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+cd "$REPO_ROOT"
+echo ""
+echo "Passed: $passed / $total"
+if [[ "$failed" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Option 2 ("Accept as wontfix") in the FIX_IMPOSSIBLE escalation flow was the only outcome that didn't resurface via /curate — the audit report preserved the rationale in *Removed Tests (Not Fixed)* but nothing aged the decision or flagged it if the rationale later staled.

Now option 2 additionally logs a `wontfix: <finding-id> — <rationale>` obligation on the most-relevant spec (when .spec/ exists). Analysis 19 (aging-obligations) picks it up once past --obligation-age-days (default 30), sorted by age.

The wontfix: prefix lets humans reading /curate output distinguish accepted-risk entries from deferred work without needing scanner-side classification. Unlike option 4 (defer), the spec stays APPROVED — wontfix is a landed design decision, not a gap.

Tests: scenario-audit-wontfix-obligation.sh pins the wontfix: prefix contract between the skill and curate-scan.sh (5 assertions). test-install 59/59, scenario-curate-drift 27/27 green.

Closes the last graveyard path in the FIX_IMPOSSIBLE escalation added in v0.14.2.