### PR TITLE
v0.14.3 bundle: manifest-v2 compat + hang prevention + doc refresh + getting-started guides

### DIFF
--- a/.claude/rules/kit-development.md
+++ b/.claude/rules/kit-development.md
@@ -55,12 +55,12 @@ and are NOT in the MANIFEST.
 
 **User-facing commands** — installed to developer projects:
   /feature, /feature-quick, /feature-domains, /feature-plan, /feature-test,
-  /feature-implement, /feature-refactor, /audit, /feature-pr,
-  /feature-retro, /feature-complete, /feature-cleanup, /feature-resume,
-  /feature-coordinate,
+  /feature-harden, /feature-implement, /feature-refactor, /audit,
+  /feature-pr, /feature-retro, /feature-complete, /feature-cleanup,
+  /feature-resume, /feature-coordinate,
   /work, /work-decompose, /work-plan, /work-start, /work-status,
   /spec, /spec-author, /spec-write, /spec-verify, /spec-init, /spec-resolve,
-  /kb, /research, /architect, /decisions, /curate,
+  /kb, /research, /architect, /decisions, /capabilities, /curate,
   /project-context, /vallorcine-help, /setup-vallorcine, /upgrade-vallorcine,
   /uninstall-vallorcine
 

--- a/COMPETITIVE.md
+++ b/COMPETITIVE.md
@@ -937,9 +937,20 @@ research over session summaries.
 
 **Multi-model support** — we're a Claude Code plugin. This is our platform.
 
-**Security-specific scanning** — Claude Code Security and Codex Security own
-this space with platform-level resources. Compete on general bug-finding quality
-and knowledge compounding, not on security vulnerability databases.
+**Security-specific scanning as a standalone product** — Claude Code Security
+and Codex Security own this space with platform-level resources (CVE databases,
+SAST rule libraries, vulnerability triage dashboards). We compete on general
+bug-finding quality and knowledge compounding, not on security vulnerability
+databases.
+
+*Clarification (v0.14.2):* shipping the `/audit` security lens
+(`prompts/audit/lens-security.md`) does NOT put us in this category — the
+lens is adversary-model reasoning (timing channels, IV/nonce reuse,
+key-lifecycle bugs, ciphertext integrity) within the existing audit
+pipeline, not a CVE scanner or a standalone security product. The lens
+triggers only when code handles sensitive data (credential stores, PII,
+auth middleware, deserialization). We remain out of the standalone-security
+category; the lens is audit depth, not a new product line.
 
 ---
 
@@ -963,6 +974,32 @@ Interop, not replacement.
 
 ## Closed gaps (previously listed)
 
+**v0.14.2 — GSD capability closures (from 2026-04-21 audit):**
+- ~~Wave-based multi-feature parallelism~~ — shipped as
+  `/work-start --parallel [N]`. Our primitive is stronger than GSD's:
+  declared `artifact_deps` + `produces` with computed readiness
+  (`work-resolve.sh`), vs GSD's dependency inference from file
+  reads/writes. Different correctness guarantees — ours catches missing
+  dependencies at WD-validate time, theirs catches them at runtime.
+- ~~Quantitative spec ambiguity scoring~~ — shipped as
+  `scripts/spec-ambiguity-score.sh`. Computes
+  `([UNVERIFIED]+[UNRESOLVED]+[CONFLICT]) / total_requirements` and
+  surfaces the score at DRAFT → APPROVED promotion. Different technique
+  from GSD's Socratic 6-round scoring but adjacent effect: quantitative
+  gate on ambiguity before spec promotion. Combines with our
+  two-pass adversarial authoring rather than replacing it.
+- ~~Adversary-model bug classes in audit (security lens)~~ — shipped as
+  `prompts/audit/lens-security.md` with TESTABLE vs ADVISORY finding
+  taxonomy. Addresses the encryption-audit gap (10 bugs found via
+  generic lens, 3 classes missed: timing channels, IV reuse, ciphertext
+  integrity). Does NOT make us a standalone security product — see
+  "Not worth building" for that boundary.
+- ~~Audit → obligation graveyard path~~ — shipped via FIX_IMPOSSIBLE
+  escalation flow (PR #51) + wontfix findings routing to
+  `open_obligations` (PR #56) that resurface via `/curate` aging logic.
+  Closes the last path where audit findings could silently vanish.
+
+**Earlier closures:**
 - ~~/decisions list/filter~~ — shipped v0.2.4
 - ~~Hooks integration~~ — dropped, violates principle 1
 - ~~Coverage gating~~ — dropped, violates principle 1

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,8 +22,10 @@ state of the project — what's happening now and what's next.
 
 *Last updated: 2026-04-23*
 
-**v0.14.2 shipped. GSD-gap capabilities landed. Two fix branches held for
-PR review. Doc refresh + getting-started docs in progress this session.**
+**v0.14.2 shipped. GSD-gap capabilities landed. Post-v0.14.2 bundle
+(manifest-v2 compat + parallel-subagent hang prevention + doc refresh +
+getting-started guides) collapsed into a single PR on
+`chore/v0.14.3-bundle`.**
 
 ### What's shipped since 2026-04-21
 
@@ -57,50 +59,64 @@ PR review. Doc refresh + getting-started docs in progress this session.**
   `/curate` analysis 19 aging logic once past the threshold. Closes the
   last graveyard path for FIX_IMPOSSIBLE outcomes.
 
-### Two branches held for PR review
+### The v0.14.3 bundle (this PR on `chore/v0.14.3-bundle`)
 
-- **`fix/manifest-v2-schema-compat`** (commits `98f2e35` + `5570e9e`) —
-  dual-schema (v1 + v2) manifest compat across `spec-resolve.sh`,
-  `work-lib.sh`, `work-finalize.sh`, `curate-scan.sh`, `spec-stats.sh`.
-  Root cause: the 2026-04-20 spec migration flipped the manifest from
+Three workstreams collapsed into one PR for reviewability. Six commits:
+
+**Fixes:**
+- **`fix(spec): v2 manifest schema compatibility`** — dual-schema (v1 +
+  v2) manifest compat across `spec-resolve.sh`, `work-lib.sh`,
+  `work-finalize.sh`, `curate-scan.sh`, `spec-stats.sh`. Root cause:
+  the 2026-04-20 spec migration flipped the manifest from
   `{features: {FXX: ...}}` (v1) to `{schema_version: 2, specs: [...]}`
   (v2), and several read-path scripts were still hardcoded against v1
   keys — they silently failed under `set -euo pipefail` or fell through
   to `NEEDS_DOMAIN_INFERENCE=true` for every call, blocking
   `/work-start`, `/spec-write`, `/feature-plan`, `/feature-test`,
   `/spec-author`, and `/audit` on v2 repos. Added four dual-schema
-  manifest query helpers to `spec-lib.sh`. Second commit closes four
-  pre-existing scenario-test failures found during the same sweep.
-- **`fix/parallel-subagent-hang-prevention`** (commit `e1dc37a`) —
-  mode-gates every unconditional `AskUserQuestion` in the three
-  pipeline skills (`/feature-test`, `/feature-implement`,
-  `/feature-refactor`) so they bypass to `cycle-log.md` +
-  `escalated-<reason>` substage + `ESCALATED` return in parallel mode
-  instead of hanging on a missing human. Strengthens
-  `/feature-refactor`'s parallel-mode exit with an explicit
+  manifest query helpers to `spec-lib.sh`.
+- **`fix(tests): close four pre-existing scenario-test failures`** —
+  found during the manifest-v2 sweep, closed here per the
+  fix-now-not-defer rule: `scenario-index-verify` arithmetic bug,
+  `scenario-narrative` stale exit-code assertions, `scenario-version-skew`
+  legacy install-layout reference, `scenario-work-pipeline` v1-manifest
+  fixture paired with v2-style WD deps.
+- **`fix(pipeline): prevent parallel-subagent hangs`** — mode-gates
+  every unconditional `AskUserQuestion` in the three pipeline skills
+  (`/feature-test`, `/feature-implement`, `/feature-refactor`) so they
+  bypass to `cycle-log.md` + `escalated-<reason>` substage + `ESCALATED`
+  return in parallel mode instead of hanging on a missing human.
+  Strengthens `/feature-refactor`'s parallel-mode exit with an explicit
   termination contract ("your very next message MUST be the summary
   line — no more tools"). Adds Step 1a to `/feature-coordinate`
   documenting the subagent dispatch contract every coordinator must
-  embed. Root-caused from the 2026-04-23 jlsm WU-3 hang (subagent
-  wrote `status.md = COMPLETE` at 10:41:32, then kept running ~2 min
-  before the user had to Ctrl+C to unblock the coordinator).
-  Regression: `scenario-parallel-subagent-hang-prevention.sh` (10
-  structural invariants).
+  embed. Root-caused from the 2026-04-23 jlsm WU-3 hang (subagent wrote
+  `status.md = COMPLETE` at 10:41:32, then kept running ~2 min before
+  the user had to Ctrl+C). Regression:
+  `scenario-parallel-subagent-hang-prevention.sh` (10 structural
+  invariants).
 
-### This session — doc refresh + getting-started docs
-
-On branch `docs/getting-started-and-refresh`:
-1. **Doc freshness pass** — this edit and CONTEXT / SETTLED / DEFERRED
-   refresh to reflect state through v0.14.2 + the two held branches.
-2. **`GETTING-STARTED.md`** (new repo file, not shipped to user
-   projects) — for people landing on the GitHub repo: how the four
-   knowledge layers (KB / ADR / spec / code) relate, the feature
-   pipeline at a glance, work groups, decision tree for what to run.
-3. **`GETTING-STARTED-EXISTING.md`** (new repo file) — slow-adoption
-   path for existing codebases. Day 1 / week 1 / month 1 / month 3
-   progression anchored on `/setup-vallorcine` + `/curate --init`.
-4. `/vallorcine-help` gains a hint pointing new users at the
-   GitHub-hosted getting-started docs.
+**Documentation:**
+- **`docs: freshness pass through v0.14.2 + held branches`** — CONTEXT
+  refresh, 7 decisions graduated to SETTLED.md, DEFERRED marked
+  security-aware lens as done.
+- **`docs: add GETTING-STARTED + GETTING-STARTED-EXISTING guides`** —
+  two new repo-only onboarding docs (316 + 333 lines) for people
+  landing on the GitHub page. Not shipped via MANIFEST. README gains a
+  "New here?" link section; `/vallorcine-help` gains URL hints for
+  conceptual questions.
+- **`docs: spot-check fixes for EXAMPLES + COMPETITIVE + GETTING-STARTED`**
+  — corrected the `.spec/` bug I introduced in GETTING-STARTED (`.spec/`
+  is `/spec-init`-gated, not created by `/setup-vallorcine`); added
+  `/feature-harden` to the EXAMPLES.md walkthrough (was missing);
+  reconciled the split threshold in EXAMPLES to match SETTLED (~15K
+  tokens / 5+ constructs); added four new walkthrough sections to
+  EXAMPLES (parallel execution via `/feature-coordinate`, spec workflow,
+  standalone `/audit`, `/capabilities`); refreshed COMPETITIVE's "Closed
+  gaps" with the four v0.14.2 GSD-parity shipments and sharpened the
+  standalone-security-scanner boundary; added `/feature-harden` and
+  `/capabilities` to the `.claude/rules/kit-development.md` user-facing
+  command list.
 
 ---
 
@@ -139,7 +155,7 @@ snapshot-WD-DRAFT-status. See SETTLED.md.*
   substage, returning `ESCALATED`. Pairs with an explicit termination
   contract at `/feature-refactor`'s parallel-mode exit — the single-line
   summary *is* the return, no more tools after `status.md = complete`.
-  Shipped as `fix/parallel-subagent-hang-prevention` (held for PR).
+  Bundled in `chore/v0.14.3-bundle` (this PR).
 
 - **Dual-schema manifest compatibility is permanent, not transitional**
   (2026-04-23) — v1 manifests (`{features: {FXX: ...}}`) remain valid for
@@ -150,7 +166,7 @@ snapshot-WD-DRAFT-status. See SETTLED.md.*
   writes use v1 shape. Decision implication: we do NOT plan a forced
   migration window or auto-upgrade tool — v1 stays working indefinitely
   so projects can migrate (or not) at their own pace. Shipped as
-  `fix/manifest-v2-schema-compat` (held for PR).
+  bundled in `chore/v0.14.3-bundle` (this PR).
 
 *Live list — resolve into SETTLED.md or drop when addressed.*
 *Prioritised: do next → do soon → do when needed → do when scale demands it.*
@@ -159,20 +175,10 @@ exists, not yet coded. No tag = needs both design and implementation.*
 
 ### Do next
 
-**v0.14.3 bundle is accumulating.** Two branches held for PR review:
-`fix/manifest-v2-schema-compat` (dual-schema compat + 4 test fixes) and
-`fix/parallel-subagent-hang-prevention` (mode-gated AskUserQuestion +
-termination contract). After they merge, cut v0.14.3.
-
-**This session — documentation hardening** (branch
-`docs/getting-started-and-refresh`):
-1. Doc freshness (CONTEXT + SETTLED + DEFERRED) — in progress.
-2. `GETTING-STARTED.md` for repo visitors — explains knowledge layers,
-   feature pipeline, work groups, what to run when.
-3. `GETTING-STARTED-EXISTING.md` — slow-adoption path for brownfield
-   projects anchored on `/curate --init`.
-4. `/vallorcine-help` hint pointing to the repo docs for tutorial-style
-   onboarding.
+**Merge `chore/v0.14.3-bundle` (this PR), then cut v0.14.3.** The
+`.changelog-staging.md` entries for both fix commits are already in
+place; the doc changes are additive. After merge, `/release` will pick
+up the staged notes and bundle them.
 
 **Positioning shift to encode across user-facing docs** (README,
 EXAMPLES.md, landing content, the new getting-started docs): emphasize

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,95 +20,87 @@ state of the project — what's happening now and what's next.
 
 ## Current focus
 
-*Last updated: 2026-04-21*
+*Last updated: 2026-04-23*
 
-**v0.14.0 released. jlsm on v0.14.0 kit with 15-WD planning snapshot landed.
-`/curate` drift detection shipped.**
+**v0.14.2 shipped. GSD-gap capabilities landed. Two fix branches held for
+PR review. Doc refresh + getting-started docs in progress this session.**
 
-**What happened (2026-04-21):**
+### What's shipped since 2026-04-21
 
-Single day, three lanes cleanly closed.
+**v0.14.1 → v0.14.2 release sequence:**
+- v0.14.1 (2026-04-21 evening, commit `35e8e31`) — bundled the `/curate`
+  drift detection analyses (18 + 19) that were staged at the end of the
+  spec migration day.
+- v0.14.2 (commit `7fc33dd`) — four GSD-gap capabilities from the
+  2026-04-21 competitive audit:
+  - **PR #51** — `/audit` FIX_IMPOSSIBLE escalation flow (relax-test /
+    wontfix / spec-author / defer), closing the graveyard path for
+    audit findings blocked by pin tests.
+  - **PR #52** — `/spec-write` quantitative ambiguity gate (GSD
+    capability #3): `spec-ambiguity-score.sh` computes
+    `([UNVERIFIED]+[UNRESOLVED]+[CONFLICT]) / total_requirements` and
+    surfaces the score at DRAFT → APPROVED promotion time.
+  - **PR #53** — `/audit` security lens (GSD capability #1):
+    `prompts/audit/lens-security.md` with TESTABLE vs ADVISORY finding
+    taxonomy, 4 new exploration signals (credential store, PII, auth
+    middleware, deserialization). Addresses the encryption-audit gap
+    (10 bugs found via generic lens, 3 classes missed: timing channels,
+    IV reuse, ciphertext integrity).
+  - **PR #54** — `/work-start --parallel [N]` (GSD capability #2):
+    wave-based multi-WD dispatch using the existing readiness model.
 
-### vallorcine — v0.14.0 released
+**Also merged post-v0.14.2:**
+- **PR #55** — docs: DESIGN manifest sync + `/feature` pipeline audit
+  surfacing.
+- **PR #56** — `/audit` wontfix findings now route through
+  `open_obligations` on the most-relevant spec, resurfacing via
+  `/curate` analysis 19 aging logic once past the threshold. Closes the
+  last graveyard path for FIX_IMPOSSIBLE outcomes.
 
-`/release` cut v0.14.0 from main at commit `d09bc33`. Release notes bundle
-the spec-verify verify-and-repair loop, the `.work/` layer and its 5
-commands, `@spec` annotation standard + `spec-trace.sh`, interface contracts,
-pipeline modes, obligation lifecycle, and manifest schema v2. GitHub Release
-created with zip attached; retention policy left all 4 releases intact.
+### Two branches held for PR review
 
-### vallorcine#46 — `/curate` drift detection (merged)
+- **`fix/manifest-v2-schema-compat`** (commits `98f2e35` + `5570e9e`) —
+  dual-schema (v1 + v2) manifest compat across `spec-resolve.sh`,
+  `work-lib.sh`, `work-finalize.sh`, `curate-scan.sh`, `spec-stats.sh`.
+  Root cause: the 2026-04-20 spec migration flipped the manifest from
+  `{features: {FXX: ...}}` (v1) to `{schema_version: 2, specs: [...]}`
+  (v2), and several read-path scripts were still hardcoded against v1
+  keys — they silently failed under `set -euo pipefail` or fell through
+  to `NEEDS_DOMAIN_INFERENCE=true` for every call, blocking
+  `/work-start`, `/spec-write`, `/feature-plan`, `/feature-test`,
+  `/spec-author`, and `/audit` on v2 repos. Added four dual-schema
+  manifest query helpers to `spec-lib.sh`. Second commit closes four
+  pre-existing scenario-test failures found during the same sweep.
+- **`fix/parallel-subagent-hang-prevention`** (commit `e1dc37a`) —
+  mode-gates every unconditional `AskUserQuestion` in the three
+  pipeline skills (`/feature-test`, `/feature-implement`,
+  `/feature-refactor`) so they bypass to `cycle-log.md` +
+  `escalated-<reason>` substage + `ESCALATED` return in parallel mode
+  instead of hanging on a missing human. Strengthens
+  `/feature-refactor`'s parallel-mode exit with an explicit
+  termination contract ("your very next message MUST be the summary
+  line — no more tools"). Adds Step 1a to `/feature-coordinate`
+  documenting the subagent dispatch contract every coordinator must
+  embed. Root-caused from the 2026-04-23 jlsm WU-3 hang (subagent
+  wrote `status.md = COMPLETE` at 10:41:32, then kept running ~2 min
+  before the user had to Ctrl+C to unblock the coordinator).
+  Regression: `scenario-parallel-subagent-hang-prevention.sh` (10
+  structural invariants).
 
-Two new analyses in `curate-scan.sh`:
-- **Analysis 18** — enumerate APPROVED specs via manifest (dual-schema v1/v2
-  aware), call `spec-trace.sh` for each, flag reqs missing impl / test / both
-  annotations. Routes to `/spec-verify`.
-- **Analysis 19** — enumerate specs with non-empty `open_obligations`,
-  compute age from last commit touching the spec, flag obligations older
-  than `--obligation-age-days` (default 30). Routes to `/spec-author` or
-  `/spec-resolve`.
+### This session — doc refresh + getting-started docs
 
-New CLI flags: `--obligation-age-days`, `--max-specs-traced` (caps
-`spec-trace` fan-out for large repos). `.changelog-staging.md` seeded for
-next release.
-
-### jlsm — PR #41 + #42 both merged
-
-**#41** — 6 query specs promoted DRAFT → APPROVED with direct-coverage
-annotations on 86/86 reqs (closed a claimed-but-false "100% coverage" hedge
-by adding 8 new tests for R1, R2, R6, R8, R26 that previously relied on
-sibling-subtype transitive coverage).
-
-**#42** — three-commit landing:
-1. Kit upgrade v0.13.8 → v0.14.0 in jlsm (`.claude/upgrade.sh`, 131/131
-   MANIFEST parity). Cosmetic `upgrade.sh` bug filed as
-   telefrek/vallorcine#45.
-2. Planning snapshot: 5 work groups / 15 WDs in `.work/` for the 13 still-
-   DRAFT specs: `close-coverage-gaps` (2 WDs, both READY),
-   `implement-transport` (3 WDs, 1/2), `implement-membership` (2 WDs, 1/1,
-   cross-group blocks on transport), `implement-sstable-enhancements`
-   (3 WDs, all READY), `implement-encryption-lifecycle` (5 WDs, 1/4, F41
-   decomposed by section). All WDs at `status: DRAFT` because specs are
-   DRAFT — WDs will promote them through `/work-plan` → `/work-start` when
-   scheduled. Validated with `work-validate.sh` (15/15 ok) and
-   `work-resolve.sh` (readiness matches graph).
-3. `.spec/MIGRATION.md` + `_migration_f03_followup/` moved into
-   `_archive/migration-2026-04-20/`; 25 spec Design Narratives had their
-   cross-reference updated.
-
-**Where things stand:**
-jlsm main now has everything needed to start picking up the planning
-snapshot WDs. Nine are READY, six are BLOCKED on within-group predecessors.
-vallorcine main has the `/curate` drift entries staged for the next
-release (likely v0.14.1 — additive, backwards-compatible).
-
-### Later in the session — competitive refresh + GSD audit
-
-PRs #48 and #49 landed a two-step competitive analysis pass: the refresh
-brought COMPETITIVE.md to current data (Superpowers 42K→163K, feature-dev
-89K→176K, Qodo 2.1 Rules System, Cursor 3, Google Antigravity, claude-mem
-as a category signal, academic commoditization via GitHub Code Security
-instead of standalone AutoFL/LLMAO), and the GSD audit (55,791 stars)
-corrected the pre-audit framing of GSD as a shallow lookalike.
-
-**Strategic finding from the GSD audit:** GSD is a real direct-lane
-competitor with substantial feature depth — falsifiable specs (Socratic
-ambiguity scoring), audit pipeline, project knowledge graph, security
-verification, retrospectives, wave-based multi-feature parallelism, 83
-commands across 14 runtime platforms. Our defensible moat is narrower
-than the pre-audit framing implied and is now architectural, not
-feature-label: **spec lifecycle (DRAFT/APPROVED/INVALIDATED) +
-displacement detection + specs driving audit passes + declared
-artifact-dependency readiness + multi-pass knowledge-compounding audit**.
-Positioning should shift from the "spec-driven" label (GSD owns that
-mindshare at 55K+ stars) to depth-of-spec-rigor.
-
-### Active plan on pause
-
-WIP.md carries a 9-item priority stack for `/ideate continue` to resume.
-Next action: item 2 — v0.14.1 release (`.changelog-staging.md` already has
-the `/curate` drift entry seeded). After that: security-aware analysis
-lens + four critical spec-layer gaps exposed by jlsm dogfood.
+On branch `docs/getting-started-and-refresh`:
+1. **Doc freshness pass** — this edit and CONTEXT / SETTLED / DEFERRED
+   refresh to reflect state through v0.14.2 + the two held branches.
+2. **`GETTING-STARTED.md`** (new repo file, not shipped to user
+   projects) — for people landing on the GitHub repo: how the four
+   knowledge layers (KB / ADR / spec / code) relate, the feature
+   pipeline at a glance, work groups, decision tree for what to run.
+3. **`GETTING-STARTED-EXISTING.md`** (new repo file) — slow-adoption
+   path for existing codebases. Day 1 / week 1 / month 1 / month 3
+   progression anchored on `/setup-vallorcine` + `/curate --init`.
+4. `/vallorcine-help` gains a hint pointing new users at the
+   GitHub-hosted getting-started docs.
 
 ---
 
@@ -116,72 +108,49 @@ lens + four critical spec-layer gaps exposed by jlsm dogfood.
 
 *Rolling window — graduate oldest entries to SETTLED.md when this exceeds ~10 items*
 
-*4 decisions graduated to SETTLED.md (2026-04-19): WD validity, spec promotion,
-health model, work-decompose spec state. See SETTLED.md.*
+*7 decisions graduated to SETTLED.md (2026-04-23): spec-reorg-behavioral-domains
+(executed), manifest-schema-v2, primitives-vs-applications, correctness-over-
+context-cost, fix-now-not-defer, @spec-annotations-as-traceability, planning-
+snapshot-WD-DRAFT-status. See SETTLED.md.*
 
 - **Spec violations are contracts, not backlog** (2026-04-16) — spec-verify
   repairs violations inline (fix code or amend spec). Obligations created only
   on explicit user deferral, never as default path.
 
-- **@spec annotations as primary traceability** (2026-04-16) — `@spec FXX.RN`
-  comments in code link requirements to enforcement points. spec-verify
-  annotates during discovery. spec-trace.sh provides the reverse index.
-
-- **Correctness over context cost** (2026-04-17) — never drop correctness-relevant
-  context to save tokens. Solve context problems via phase splitting and condensed
-  handoffs instead of skipping information agents need.
-
-- **Spec reorganization: behavioral domains** (2026-04-17) — specs will migrate
-  from feature-centric (F13-jlsm-schema.md) to behavioral-domain
-  (schema/construction.md). 12 domains, ~60 files. Annotation format changes
-  to `@spec domain.slug.RN`. Execute after verification pass.
-
 - **Partial implementation state needed** (2026-04-19) — current model is binary
   (APPROVED or DRAFT). Need a clean representation for "90% implemented, 10%
   explicitly deferred." Domain reorg may solve naturally (implemented parts in
-  one spec, stubs in another).
-
-- **Primitives vs applications — encryption pattern** (2026-04-20) — encryption
-  spec content splits cleanly by abstraction level. Primitives (keys, rotation,
-  algorithms, variants) live in `encryption/`. Applications (how WAL/query/
-  indices use encryption) live in their functional domain with a multi-domain
-  tag for discovery from encryption. Codified as MIGRATION.md P6 and applied
-  to F42/F46/F47/F03 during jlsm migration. Same principle generalizes to any
-  cross-cutting primitive (compression, serialization would follow same pattern).
-
-- **Manifest schema v2** (2026-04-20) — post-migration manifest uses
-  `{schema_version: 2, specs: [{id, path, ...}]}` (array of specs with id
-  field) instead of legacy `{features: {FXX: {...}}}` (object keyed by ID).
-  Kit's `spec_file_for_id` detects both and adapts. Schema v2 handles
-  `domain.slug` spec IDs naturally; v1 is retained for backwards compat
-  with legacy projects.
-
-- **Fix now, not defer — positive justification required** (2026-04-21) —
-  generalises the existing kit-failures and spec-violations rules: when a
-  problem surfaces mid-session, default to fixing it in the current PR.
-  Phrases like "not X's problem", "separate concern", "covered transitively
-  by Y" are red flags that need positive justification before they're
-  acceptable. No transitive / side-effect coverage for claimed behaviour —
-  test what is claimed, directly. Memory: `feedback_fix_now_not_defer.md`.
-
-- **Planning-snapshot work groups: DRAFT status** (2026-04-21) — WDs that
-  point at specs still in DRAFT should use `status: DRAFT`, not SPECIFIED.
-  SPECIFIED implies the spec is APPROVED and ready for implementation;
-  DRAFT matches the actual state where the WD will promote the spec via
-  `/work-plan` before implementation can proceed. Applied to the 5 jlsm
-  work groups shipped in #42.
+  one spec, stubs in another). Still open — revisit once 2-3 jlsm WDs have
+  completed so the data on real "90% done" shapes is available.
 
 - **GSD is a real direct-lane competitor, not a shallow lookalike**
-  (2026-04-21). Hands-on audit (55,791 GitHub stars, 83 commands, 14
-  runtime platforms) found falsifiable specs via Socratic ambiguity
-  scoring, autonomous audit-to-fix, a project knowledge graph,
-  retrospectives, security verification, and wave-based multi-feature
-  parallelism. Confirmed still uniquely vallorcine: spec lifecycle states,
-  displacement detection, specs driving audit, declared artifact-dep
-  readiness + pipeline modes, multi-pass knowledge-compounding audit.
-  Positioning must emphasize the depth-of-spec-rigor axis, not the
-  "spec-driven" label (GSD owns that mindshare at 55K+ stars). See
-  PR #49 for full head-to-head.
+  (2026-04-21). See COMPETITIVE.md for the full head-to-head. Positioning
+  emphasizes depth-of-spec-rigor (lifecycle, displacement, audit integration,
+  computed readiness), not the "spec-driven" label (GSD owns that mindshare
+  at 55K+ stars). Called out here because it shapes ongoing positioning work.
+
+- **Mode-gated AskUserQuestion + subagent termination contract** (2026-04-23)
+  — pipeline skills (`/feature-test`, `/feature-implement`,
+  `/feature-refactor`) must never call `AskUserQuestion` in a subagent
+  context: there is no human attached, and the `Agent` tool call blocks the
+  coordinator until the subagent emits a final message. Every site that
+  previously used "pause regardless of automation_mode" now has a
+  `balanced | speed` bypass recording `escalated-<reason>` to cycle-log +
+  substage, returning `ESCALATED`. Pairs with an explicit termination
+  contract at `/feature-refactor`'s parallel-mode exit — the single-line
+  summary *is* the return, no more tools after `status.md = complete`.
+  Shipped as `fix/parallel-subagent-hang-prevention` (held for PR).
+
+- **Dual-schema manifest compatibility is permanent, not transitional**
+  (2026-04-23) — v1 manifests (`{features: {FXX: ...}}`) remain valid for
+  legacy projects that haven't migrated. All read-path scripts use
+  `spec-lib.sh` helpers (`spec_file_for_id`, `spec_manifest_ids`,
+  `spec_manifest_state`, `spec_manifest_domains_for`) that detect the
+  schema at read time and adapt. Writes to v2 manifests use v2 shape; v1
+  writes use v1 shape. Decision implication: we do NOT plan a forced
+  migration window or auto-upgrade tool — v1 stays working indefinitely
+  so projects can migrate (or not) at their own pace. Shipped as
+  `fix/manifest-v2-schema-compat` (held for PR).
 
 *Live list — resolve into SETTLED.md or drop when addressed.*
 *Prioritised: do next → do soon → do when needed → do when scale demands it.*
@@ -190,52 +159,54 @@ exists, not yet coded. No tag = needs both design and implementation.*
 
 ### Do next
 
-*vallorcine#43, #44, #46, #47, #48, #49 merged 2026-04-21. v0.14.0
-released.*
-*jlsm#40, #41, #42 merged 2026-04-21. Kit at v0.14.0; 15-WD planning
-snapshot on main. Nathan working through WDs on the jlsm side.*
+**v0.14.3 bundle is accumulating.** Two branches held for PR review:
+`fix/manifest-v2-schema-compat` (dual-schema compat + 4 test fixes) and
+`fix/parallel-subagent-hang-prevention` (mode-gated AskUserQuestion +
+termination contract). After they merge, cut v0.14.3.
 
-**Active plan on pause — see WIP.md for full 9-item stack.**
-The session ended after item 1 (GSD audit) with PR #49 merged. `/ideate
-continue` resumes from item 2. Summary of the stack in priority order:
-
-1. ~~GSD feature audit~~ — **done 2026-04-21** (PR #49)
-2. **v0.14.1 release** — next action. `.changelog-staging.md` already has
-   the `/curate` drift entry seeded. Trivial `/release` invocation.
-3. Marketplace submission currency check — user-driven; Nathan to confirm
-   whether the pending submission is pinned to v0.13.x.
-4. **Security-aware analysis lens** — targeted `/audit` lens for
-   adversary-model bug classes (timing channels, IV reuse, ciphertext
-   integrity) that generic lenses miss. Triggered by the jlsm encryption
-   audit empirical data.
-5. **Fix 4 critical spec-layer gaps** — feature-implement spec awareness,
-   feature-refactor spec awareness, spec-write two-file invalidation,
-   work-decompose spec state validation.
-6. Partial implementation state model (depends on data from jlsm WDs in
-   progress; revisit once 2-3 have run).
-7. Fix 6 pipeline failure patterns.
-8. Distributed work layer (deferred — team-mode feature).
-9. #45 cosmetic `upgrade.sh` output bug (low priority).
+**This session — documentation hardening** (branch
+`docs/getting-started-and-refresh`):
+1. Doc freshness (CONTEXT + SETTLED + DEFERRED) — in progress.
+2. `GETTING-STARTED.md` for repo visitors — explains knowledge layers,
+   feature pipeline, work groups, what to run when.
+3. `GETTING-STARTED-EXISTING.md` — slow-adoption path for brownfield
+   projects anchored on `/curate --init`.
+4. `/vallorcine-help` hint pointing to the repo docs for tutorial-style
+   onboarding.
 
 **Positioning shift to encode across user-facing docs** (README,
-EXAMPLES.md, landing content) when time permits: emphasize the
-depth-of-spec-rigor axis (lifecycle, displacement, audit integration,
-computed readiness) over the "spec-driven" label. GSD owns the
-spec-driven label at 55K+ stars.
+EXAMPLES.md, landing content, the new getting-started docs): emphasize
+the depth-of-spec-rigor axis (lifecycle, displacement, audit
+integration, computed readiness) over the "spec-driven" label. GSD owns
+the spec-driven label at 55K+ stars. The GETTING-STARTED docs are the
+first place to seed this framing.
 
 ### Do soon (medium effort, clear designs)
 
 - **Fix spec-layer gaps (11 identified)** — 4 critical: feature-implement spec
   awareness, feature-refactor spec awareness, spec-write two-file invalidation,
   work-decompose spec state validation. Full gap analysis in session memory.
+  Status: not started since 2026-04-21. Check first whether any are already
+  covered by the manifest-v2 dual-schema work before scoping.
 
 - **Fix 6 pipeline failure patterns** — one-sided invalidation, audit outpacing
   specs, assert-only guards, dead code wiring, spec asymmetry, feature-centric
-  organization. Each has root cause and fix task documented.
+  organization. Each has root cause and fix task documented. Status:
+  feature-centric organization resolved by the 2026-04-20 spec migration
+  (behavioral domains). The others still stand.
 
 - **Partial implementation state model** — binary APPROVED/DRAFT insufficient for
   specs that are 90% implemented. Need either per-requirement states, split specs,
   or APPROVED-with-obligations. Data from verification pass will inform design.
+  Revisit once 2-3 jlsm WDs have completed implementation and we can read
+  their emergent patterns.
+
+- **Flaky-test surfacing in `/feature-retro`** — scan cycle-log.md for
+  flakiness signals (timeouts on first run + passed-on-rerun, "flaky",
+  "retry" keywords) and emit a dedicated retro section. Triggered by the
+  2026-04-23 jlsm WU-3 run which noted a pre-existing
+  `SharedStateAdversarialTest` timeout-then-pass that would otherwise be
+  buried. See `DEFERRED.md`.
 
 ### Do when needed (useful but workarounds exist)
 
@@ -245,11 +216,17 @@ spec-driven label at 55K+ stars.
 - **spec-trace.sh sub-lettered IDs** — R39a-h pattern not matched by numeric-only
   regex. Annotations exist in code but uncounted. Fix when reorg drops FXX IDs.
 
+- **#45 cosmetic `upgrade.sh` output bug** — low priority; originally on the
+  v0.14.1 stack, still open.
+
 ### Do when scale demands it (team/scale features)
 
 - **Team KB commands** — `/kb sync`, `/kb consolidate`, `/kb status`.
 
 - **Pipeline observability** — velocity metrics, KB utilization tracking.
+
+- **Distributed work layer** — multi-party decomposition and merge
+  (deferred — team-mode feature).
 
 ---
 

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -167,6 +167,19 @@ CONTEXT.md when you're ready to act on them, or drop them if no longer relevant.
 - **KB cross-referencing** — reverse mapping from decisions to KB entries. One-way
   (KB → decisions) exists in `/kb query`. Low urgency until KB is large enough.
 
+- **Flaky-test surfacing in `/feature-retro`** (2026-04-23) — retro phase
+  scans per-unit and feature-level `cycle-log.md` for flakiness signals
+  ("timed out on first run", "passed on rerun", "flaky", "retry") and
+  emits a dedicated "Flaky tests observed" section in the retro summary
+  so the user can triage rather than discover them by reading the full
+  log. Motivated by the 2026-04-23 WU-3 run, which noted a pre-existing
+  `SharedStateAdversarialTest` timeout-then-pass in jlsm that would
+  otherwise be buried. Open shape questions: how to distinguish "flaky
+  in this feature's test surface" from "pre-existing flaky that the run
+  happened to touch" — probably a frontmatter field on the surfaced
+  entry rather than a guess. Pairs well with (but is not blocked by)
+  retro's existing stage summary structure.
+
 - **Internal research KB for vallorcine development** — ~~structure and capture
   mechanism~~ **done** (2026-03-26): `.claude/research/` directory + /save-work
   Step 3.5 learnings capture. Remaining: bootstrap by scanning recent session

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -96,21 +96,16 @@ CONTEXT.md when you're ready to act on them, or drop them if no longer relevant.
   now handles everything: KB, decisions, feature pipeline, project profile, and
   .gitignore. `/feature-init` removed.
 
-- **Security-aware analysis lens** — add a security domain lens to the audit
-  pipeline, scoped to code handling keys, credentials, PII, or sensitive data.
-  NOT a full security audit — targeted checks within the existing prove-fix
-  model. Examples: key material not zeroed after use, IV/nonce reuse potential,
-  plaintext leaking into logs/exceptions, non-constant-time secret comparison,
-  credentials in memory longer than necessary. Triggers only when constructs
-  handle sensitive data (encryption APIs, credential stores, PII fields).
-  Evidence: encryption audit found 10 critical key-lifecycle bugs through
-  generic resource_lifecycle lens, but missed timing channels, IV reuse, and
-  ciphertext integrity — bugs that require adversary-model reasoning. The
-  security lens would ask "what can an attacker extract?" not just "is this
-  resource cleaned up?" Verification model: same prove-fix for testable
-  findings (key not zeroed = testable), advisory output for untestable ones
-  (timing channel = needs manual review). Promote to Open questions when
-  ready to design the lens prompt and advisory output format.
+- ~~**Security-aware analysis lens**~~ — **done** (v0.14.2, PR #53). Shipped as
+  `prompts/audit/lens-security.md` with attack-pattern-by-concern coverage and
+  TESTABLE vs ADVISORY finding taxonomy. Four new exploration signals
+  (credential store, PII, auth middleware, deserialization) activate the lens
+  when sensitive-data handling is detected. Assembly + suspect wired to consult
+  the lens. Motivated by jlsm encryption-audit evidence (10 key-lifecycle bugs
+  found via generic lens; 3 adversary-model classes missed: timing channels,
+  IV reuse, ciphertext integrity). Scope shipped was MVP — full integration
+  (active-lenses.md "security" candidate, domain pruning with security
+  evidence) remains deferred as architect-deliberation work.
 
 - ~~`/decisions roadmap`~~ — **done** (v0.13.3). Bulk planning pass with clustering,
   effort classification, dependency analysis. Now includes "Create work group" option

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -36,15 +36,35 @@ you exactly what to run before continuing.
 ```
 
 The Work Planner writes contracts and stubs into your source tree. If the
-feature is large enough (6+ constructs with clean dependency boundaries),
-it proposes splitting into work units that each run their own TDD cycle.
+feature's estimated session size exceeds ~15K tokens (roughly 5+ constructs
+at the ~3K-per-construct heuristic) and there are clean dependency
+boundaries, it proposes splitting into work units that each run their own
+TDD cycle. Step 4 also picks an `execution_strategy` — `cost` (sequential,
+default), `balanced` (batched parallel), or `speed` (max parallelism). The
+first two run sequentially via Step 5 below; the `balanced` / `speed`
+strategies are covered in the parallel-coordinator section later in this
+document.
 
-**4. Write tests, then implement**
+**4. Write tests, then (optionally) harden, then implement**
 
 ```
 /feature-test "rate-limiting-middleware"
+/feature-harden "rate-limiting-middleware"     # optional — see below
 /feature-implement "rate-limiting-middleware"
 ```
+
+`/feature-harden` sits between test writing and implementation. It adds
+an adversarial test pass against domain-lens behavioral attacks on the
+contracts (concurrency races, boundary conditions, resource-lifecycle
+edges — which lens runs depends on the feature's domains). The command
+auto-selects `skip` / `lite` / `full` based on the feature's risk
+profile, so you can usually leave it in the flow and let it decide. If
+you want the pipeline to skip it entirely, `/feature-harden "<slug>"
+--skip` marks it done without running.
+
+In autonomous mode, hardening chains automatically between test and
+implement. In manual mode, invoke it yourself between the two — or
+skip it.
 
 On first `/feature-implement`, you'll be asked to choose a TDD loop mode:
 
@@ -181,6 +201,55 @@ The pipeline picks up cleanly from where it stopped.
 
 ---
 
+## Parallel execution with the feature coordinator
+
+When a feature was planned with `execution_strategy: balanced` or `speed`
+and has multiple work units with a dependency graph, the TDD loop runs
+under `/feature-coordinate` instead of the usual sequential
+test → implement → refactor chain. The coordinator dispatches work units
+as concurrent sub-agents, waits for them, then launches the next batch.
+
+Entry point, invoked automatically by the pipeline at the end of planning
+when strategy is `balanced`/`speed`:
+
+```
+/feature-coordinate "rate-limiting-middleware"
+```
+
+Behavior depends on the strategy:
+
+- **`balanced`** — grouped batches. All units with satisfied dependencies
+  launch together, coordinator waits for the batch to finish, then
+  launches the next batch. Predictable checkpoints between batches.
+- **`speed`** — completion-driven. As each unit finishes, any newly
+  unblocked units launch immediately — a unit deep in the dependency
+  chain starts the moment its last predecessor finishes, without waiting
+  for an unrelated batch to complete.
+
+Each sub-agent runs the full `/feature-test` → `/feature-implement` →
+`/feature-refactor` pipeline against its assigned work unit in an
+isolated context. Progress is tracked in a single TodoWrite list owned
+by the coordinator (sub-agents don't write to TodoWrite — it's a shared
+surface). Per-unit progress is also visible in each unit's
+`.feature/<slug>/units/WU-N/status.md`.
+
+### Multi-feature parallel dispatch
+
+At the work-group level, `/work-start --parallel [N]` dispatches every
+SPECIFIED work definition in a group as a concurrent sub-agent,
+optionally capped at N simultaneous runs:
+
+```
+/work-start "implement-transport-layer" --parallel 3
+```
+
+The coordinator shows the dispatch plan, asks you to confirm (parallel
+mode burns N× the tokens of a sequential run), then fans out. Concurrency
+caveats — shared KB writes, test contention, cost budget — are surfaced
+before you confirm.
+
+---
+
 ## Crash recovery
 
 Session crash, timeout, or context overflow? Resume cleanly:
@@ -311,6 +380,140 @@ Review all deferred items:
 
 ---
 
+## Writing and maintaining specs
+
+Specs are opt-in — not every project uses them, and within a project
+you add them lazily as features introduce behavior worth specifying
+(see [GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md) for the
+adoption rationale). The spec layer has its own small pipeline.
+
+**1. Initialize the spec corpus** (once per project, when you're ready
+to start writing specs):
+
+```
+/spec-init
+```
+
+This creates `.spec/registry/manifest.json`, the domain taxonomy seed,
+and shard indexes. Safe to run even if other layers are already set
+up — it's a no-op if the spec corpus already exists.
+
+**2. Author a hardened spec** through two-pass adversarial review:
+
+```
+/spec-author "F12" "token bucket rate limiter"
+```
+
+The Spec Author Agent runs a structured-draft pass, then a falsification
+pass that adversarially challenges the draft — trying to break each
+requirement with edge cases, boundary conditions, and contradictory
+scenarios. You confirm the final requirement set before it lands in
+`.spec/` with DRAFT state.
+
+**3. Register and promote.** `/spec-author` calls `/spec-write` under
+the hood to land the file, but you can also register a hand-authored
+spec:
+
+```
+/spec-write "F12" "token bucket rate limiter"
+```
+
+`/spec-write` checks for conflicts and displacement (new specs that
+contradict existing APPROVED specs) before registering. If displacement
+is detected, you choose how to resolve (accept replacement, narrow
+scope, or defer). Quantitative ambiguity is gated at this step — specs
+with score >0.20 (`[UNVERIFIED]+[UNRESOLVED]+[CONFLICT]` fraction) stay
+DRAFT until clarified.
+
+**4. Verify against implementation** after the feature lands:
+
+```
+/spec-verify "F12"
+```
+
+`/spec-verify` traces each requirement to its enforcement point in
+code (via `@spec FXX.RN` annotations), flags drift, and repairs inline
+— either updating the code to match the spec or amending the spec to
+match the reality. It's a repair loop, not a gap report.
+
+**5. Query specs** when you need them:
+
+```
+/spec "what guarantees do we make about rate limit windows?"
+```
+
+`/spec` searches requirements across all specs, surfaces gaps (domains
+with no spec coverage), and traces change impact ("if I change R5, what
+else breaks?"). Useful during feature scoping to see what's already
+promised.
+
+---
+
+## Running the audit pipeline standalone
+
+`/audit` runs at the end of every `/feature` flow via `/feature-refactor`,
+but it's also a standalone command for adversarial analysis of existing
+code — either to revisit shipped features, validate a refactor, or
+respond to a bug report with a systematic search.
+
+Standalone entry points:
+
+```
+/audit "auth-middleware-rewrite"      # feature slug — audits that feature's constructs
+/audit "src/crypto/wrap.rs"           # file path — audits all constructs in that file
+/audit "encryption/primitives-lifecycle"  # spec id — audits against that spec's requirements
+/audit "reports/2026-03-15-vector-index.md"  # prior audit report — resumes from it
+```
+
+The audit pipeline runs a multi-pass analysis (inventory → triage →
+construct clustering → per-cluster deep analysis → reconciliation)
+with pre-prove gates that filter findings before the expensive
+prove-fix cycle. Every finding gets either proved with a failing test
++ fix, recorded as a spec obligation (wontfix cases, per PR #56), or
+surfaced as advisory (non-testable — timing channels, for instance).
+
+Domain-conditional lenses activate based on what the code does. The
+security lens (v0.14.2+) triggers on credential stores, PII, auth
+middleware, and deserialization — it adds adversary-model reasoning
+(key lifecycle, IV/nonce reuse, ciphertext integrity, constant-time
+comparisons) on top of the generic audit passes.
+
+Budget caps are respected: Phase 0 detects already-fixed findings from
+prior runs to avoid re-proving them. If a finding can't be fixed
+because an existing test pins the current behavior, the FIX_IMPOSSIBLE
+escalation flow gives you four routes (relax the pin test, wontfix
+with obligation, spec-author to resolve the conflict, or defer).
+
+---
+
+## Capability tracking
+
+`/capabilities` is a lightweight index of what the project can do —
+useful for product questions ("do we support X?"), onboarding, and as
+input to feature scoping.
+
+```
+/capabilities "do we support rate limiting per tenant?"   # natural-language search
+/capabilities list                                         # browse by domain
+/capabilities add "tenant-scoped rate limiting"            # create a new entry
+/capabilities update "rate-limiting"                       # refine an existing entry
+/capabilities backfill                                     # bootstrap from existing
+                                                           # features, specs, ADRs
+```
+
+On a brownfield project, `/capabilities backfill` is the fastest way to
+populate `.capabilities/` without manual entry — it reads existing
+features, APPROVED specs, and accepted ADRs and proposes capability
+entries for your review. Nothing lands without confirmation.
+
+Capability entries are kept small and natural-language-searchable. They
+are not specs — specs describe *guarantees*, capabilities describe
+*what's available*. A spec tells you "if you call `rateLimit(tenant,
+n)`, the system enforces the limit within 100ms"; a capability tells
+you "rate limiting exists and is tenant-scoped."
+
+---
+
 ## Quick tasks
 
 For small changes that don't need the full pipeline — a single construct,
@@ -334,9 +537,15 @@ After installing vallorcine into a project:
 /setup-vallorcine
 ```
 
-`/setup-vallorcine` is a one-time command that initialises everything:
-`.kb/`, `.decisions/`, `.feature/`, project profile (language, framework,
-test runner, conventions), and `.gitignore` entries.
+`/setup-vallorcine` is a one-time command that initialises the core
+layers: `.kb/`, `.decisions/`, `.capabilities/`, `.feature/`, a project
+profile (language, framework, test runner, conventions), and
+`.gitignore` entries.
+
+The spec layer (`.spec/`) is deliberately *not* created here — run
+`/spec-init` separately when you're ready to start writing specs. This
+matches the lazy-spec adoption path: specs have real ergonomic cost and
+are opt-in per feature area.
 
 Not sure where to start?
 

--- a/GETTING-STARTED-EXISTING.md
+++ b/GETTING-STARTED-EXISTING.md
@@ -1,0 +1,333 @@
+# Getting Started on an Existing Codebase
+
+This document is for teams that want to bring vallorcine into a codebase
+that already has real history — maybe thousands of commits, dozens of
+contributors, existing tests, existing docs, existing architectural
+decisions that were made but never written down. The path in
+[GETTING-STARTED.md](GETTING-STARTED.md) assumes you're starting fresh.
+This one assumes you're not.
+
+The short version: **don't try to retro-spec your whole codebase on day
+one.** The value of specs/KB/ADRs accrues where features touch them.
+Seed the directories, capture what's obvious, and then let each new
+feature pull the right context into the right place. Six months in,
+you'll have a rich, curated knowledge base — and you won't have spent
+a quarter "documenting" instead of shipping.
+
+---
+
+## The slow-adoption premise
+
+Vallorcine's value compounds: your 5th feature is faster than your 1st
+because the 1st wrote usable KB entries, usable ADRs, and usable specs
+that the 5th consumes. That compounding only works if the durable
+assets *are real* — research you actually did, decisions you actually
+made, specs that actually describe the system.
+
+If you retro-spec a 50K-line codebase in a three-week sprint, most of
+those specs will be fiction. They'll describe what the code *seems* to
+do from the outside, not what it's actually guaranteeing. Tests won't
+link to them. The audit pipeline will produce false positives. Worst
+case: you'll throw the whole system away because "vallorcine didn't
+work for us" — when the real problem is that the inputs were never
+real.
+
+The alternative: grow the knowledge layers alongside real work, anchored
+by `/curate`. Every commit you make touches some subset of the codebase.
+Let vallorcine capture what's happening in *that subset*, not the rest.
+Six months in, the parts of the codebase that got touched are
+well-specified; the parts that didn't are unchanged. That's fine. You
+weren't changing them anyway.
+
+---
+
+## Day 1 — install and scan
+
+```
+bash install.sh .
+/setup-vallorcine
+/curate --init
+```
+
+### What `/setup-vallorcine` does
+
+Creates the four layer directories (`.kb/`, `.decisions/`, `.spec/`,
+`.feature/`), writes seed index files, adds a minimal block to your
+project's root `CLAUDE.md`, and generates a project config
+(`.feature/project-config.md`) with build/test commands, language hints,
+and team conventions if you tell it about them.
+
+This is idempotent. If you've already done this, running it again
+doesn't hurt anything — it just notices the directories exist.
+
+### What `/curate --init` does (the important part)
+
+Scans git history and the current tree for signals that should become
+durable assets but aren't captured yet:
+
+- **Backfill-candidate decisions** — commits whose messages imply a
+  decision was made ("chose X over Y", "migrate from A to B",
+  "decided to use ..."). Surfaces them as candidates you can promote to
+  real ADRs via `/architect` — capturing the rationale *while the
+  context is still fresh* in someone's head.
+- **Research topics worth capturing** — code that references a specific
+  algorithm, protocol, or library in a non-trivial way but has no KB
+  entry explaining the design choice. Candidates for `/research`.
+- **Implicit dependencies** — files that consistently co-change but
+  aren't linked by imports or explicit contracts. Signal for missing
+  interface documentation.
+- **Orphaned areas** — modules with no tests, no docs, no ADRs, and
+  significant churn. High-risk regions.
+
+`/curate --init` is the *only* curate run that does a deep historical
+scan. Every subsequent `/curate` is incremental — runs in minutes,
+surfaces only new signals since the last scan. That makes it cheap to
+run weekly.
+
+**Crucial:** `/curate --init` surfaces *candidates*. It doesn't write
+ADRs, KB entries, or specs. You pick items by number, and each picked
+item routes to the right follow-up command. Many candidates you'll
+skip — they weren't worth capturing. That's fine. The goal isn't 100%
+capture; it's to surface the ones that *are* worth capturing.
+
+---
+
+## Week 1 — capture what's obvious
+
+Work through the `/curate --init` findings. Typical items:
+
+- **3-5 backfill decisions** that are genuinely load-bearing — the
+  choice of HTTP client, the serialization format, the auth strategy.
+  Promote via `/architect` or `/decisions backfill`. Don't try to
+  document every minor decision.
+- **1-3 research topics** that the team regularly re-explains when
+  someone joins — "why we use HNSW not IVF-Flat", "how the CRDT
+  reconciliation works". Capture via `/research`.
+- **Skip the spec layer entirely this week.** Specs take real effort
+  to write well, and the best signal for "is this spec worth writing"
+  comes from a feature that needs the spec — which you don't have yet.
+
+By end of week 1, you want:
+
+- `.kb/` has 2-5 real entries covering the highest-value
+  recurring-explanation topics.
+- `.decisions/` has 3-8 ADRs backfilled for the most load-bearing
+  architectural choices.
+- `.spec/` is still empty. That's intentional.
+
+This is enough to make the next feature's domain analysis non-trivially
+better than it would have been without any of this.
+
+---
+
+## Month 1 — first new feature uses the full pipeline
+
+Now a real feature lands. Use `/feature "<description>"` for it, even
+though the rest of the codebase doesn't have specs or structured
+context.
+
+What you'll notice:
+
+- **`/feature-domains`** finds the 2-3 ADRs and 1-2 KB entries you
+  backfilled in week 1 that apply. They go into the feature brief's
+  context section.
+- **`/feature-plan`** writes its plan without a spec to consume (because
+  you don't have one for this area yet). The plan references your
+  existing code as context.
+- **`/feature-test`** generates tests from the brief + domain patterns
+  (no spec requirements to operationalize — yet).
+- **If the feature touches sensitive logic**, this is the moment to
+  write a spec. Run `/spec-author "<feature-id>" "<title>"` on the
+  behavior the feature introduces — a two-pass adversarial authoring
+  run that produces an APPROVED spec in a single session.
+- **Audit runs against the new code,** not the whole codebase.
+  Findings either get fixed or get recorded as obligations. KB entries
+  get created for any adversarial patterns the audit discovered.
+- **Retrospective writes back.** A KB entry or two. Maybe an ADR if
+  an architectural choice got made during the feature. A narrative
+  article about the arc of the work.
+
+By end of month 1 you've shipped 1-3 features and the knowledge layers
+have grown *in exactly the places the features touched*. The rest of
+the codebase is unchanged. That's fine — you weren't working on the
+rest of the codebase.
+
+### The lazy-spec rule
+
+Only write specs for behavior a feature is *introducing* or
+*significantly changing*. Don't write specs for:
+
+- Code that's been stable for 18 months and no one's planning to touch.
+- "Completeness" — trying to cover every public interface.
+- CRUD plumbing that's self-describing.
+
+Do write specs for:
+
+- New public APIs.
+- Cross-cutting guarantees (encryption, consistency, auth).
+- Anything where a failure mode would matter in production.
+- Code you're about to significantly refactor — write the spec first,
+  then the refactor is "make the tests pass" with the old code as
+  reference rather than ground truth.
+
+---
+
+## Month 3 — work groups and `/spec-verify`
+
+Three months in, you have:
+- 15-30 KB entries covering the areas features have touched.
+- 8-15 ADRs covering load-bearing decisions.
+- 5-20 specs covering the behavior features have shipped.
+- A `/curate` habit — incremental runs every 1-2 weeks.
+
+Now the advanced workflows become useful.
+
+### Use `/work` for multi-feature initiatives
+
+When a planned initiative will span 3+ features over 2+ weeks — auth
+migration, new storage backend, major refactor — use `/work` instead of
+a series of one-off `/feature` runs. Work groups capture the
+dependencies between features, let you plan specs before implementation
+starts, and (optionally) let you run parallel WDs concurrently.
+
+### Use `/spec-verify` when you touch specified code
+
+If a feature touches code under an existing spec, run `/spec-verify
+<spec-id>` after the implementation lands. It checks that the code
+still matches what the spec claims — finds drift early, repairs either
+the code or the spec based on which is correct.
+
+This is different from the audit pass, which finds *bugs*. `/spec-verify`
+finds *violations of documented behavior* — changes that broke a
+contract without updating the contract.
+
+### Run `/curate` regularly
+
+Every 1-2 weeks. It surfaces:
+- ADRs that don't match current code (drift).
+- KB entries past their `last_researched` threshold.
+- Specs with aging `open_obligations` (debt that's been deferred too
+  long).
+- Work groups that haven't moved in weeks.
+
+Each finding routes to the right fix-up command. Don't accept every
+finding — curation surfaces, humans decide.
+
+---
+
+## Common pitfalls
+
+### "Let me spec the whole codebase first"
+
+This fails. Specs written without a feature that needs them are
+fiction. You'll spend a quarter writing specs that no tests reference
+and no code verifies, then abandon the system because "it didn't
+work."
+
+Grow specs alongside features. The codebase doesn't need to be 100%
+specified for vallorcine to be valuable — it needs the *touched* parts
+specified, and the touched parts grow naturally.
+
+### "Research is taking too long — we'll skip the KB"
+
+KB entries compound. A single entry researched once and used in 5
+features saved 4 re-researches. If `/research` is taking too long, the
+symptoms are:
+
+- You're researching things you didn't need (trust the domain analysis
+  output — if it didn't commission research, it probably wasn't needed).
+- Your `last_researched` threshold is too tight and entries are being
+  re-researched that haven't actually gone stale.
+
+Tune rather than skip. The compounding effect is real and measurable
+on projects with 20+ entries.
+
+### "Decisions are obvious — we don't need ADRs"
+
+They're obvious *now, to the person who made them*. Six months later,
+the new team member asks "why do we use X?" and you've lost the
+context. ADRs are notes-to-future-self-and-teammates, not
+ceremony.
+
+Rule of thumb: if the decision shaped a public API, crossed module
+boundaries, or involved rejecting alternatives, write the ADR.
+`/decisions backfill` can pull candidates out of git history if you
+haven't been doing this.
+
+### "Every feature needs a spec"
+
+No. `/feature` works without specs — the domain analysis pulls in
+whatever context exists, and the test plan is generated from the
+brief. Specs add value when:
+
+- Multiple features will share the behavior.
+- The behavior has adversarial failure modes worth enumerating.
+- You want the audit pipeline to have concrete requirements to check
+  against.
+
+For a one-off internal change, `/feature` without a spec is the right
+call.
+
+### "I installed vallorcine but nothing seems different"
+
+You probably skipped `/setup-vallorcine` and `/curate --init`. Without
+those, the knowledge layers are empty and the commands have nothing to
+pull context from. Run them.
+
+If you've done both and still feel nothing's happening: try a full
+`/feature` run on a real piece of work. The value shows up in the
+domain analysis stage, when you see the agent actually pulling the
+backfilled ADRs and KB entries into context. If it's still empty,
+your `/curate --init` probably didn't surface much — either the
+codebase is genuinely young (in which case start with
+[GETTING-STARTED.md](GETTING-STARTED.md)) or the git history is shallow
+(e.g., fresh monorepo cut from a larger tree) and `/curate --deeper`
+is worth a shot.
+
+---
+
+## What exists → what to do
+
+| You already have | vallorcine workflow |
+|------------------|---------------------|
+| Existing tests (unit, integration) | Keep them. `/feature` reuses them as a safety net; the pipeline adds new tests rather than replacing old ones. |
+| Existing docs (README, ARCHITECTURE.md) | Keep them. Capture the decisions as ADRs via `/architect` or `/decisions backfill`; docs stay as narrative. |
+| Existing ADRs (other systems — MADR, nygard format) | Keep them in their current location; treat `.decisions/` as the vallorcine-managed set going forward. Don't bulk-migrate. |
+| Existing wiki or internal docs | Source material for `/research`. Each time you reference wiki content in a feature, capture the relevant slice as a KB entry with the wiki as the source. |
+| Existing specs (OpenAPI, protobuf, types) | Orthogonal to vallorcine specs — those are *interface* specs (structural), vallorcine specs are *behavioral* (what the system guarantees). Both are useful; neither replaces the other. |
+| Existing test coverage gaps | `/curate` will flag "orphaned areas" — use them as candidates for adversarial work, not guilt. |
+| Existing technical debt | `/decisions backfill` captures *why* the debt exists; `/architect` deliberates *how* to pay it down. Don't pretend the debt isn't there. |
+| CI/CD pipeline | Keep it. `/feature-pr` produces PRs that flow through the existing pipeline unchanged. The kit doesn't replace your CI. |
+
+---
+
+## Realistic timeline
+
+| Phase | Elapsed | State |
+|-------|---------|-------|
+| Day 1 | 30-60 min | Installed, scanned, `/curate --init` results in hand. |
+| Week 1 | 3-5 hours | 3-8 ADRs backfilled, 2-5 KB entries, no specs yet. |
+| Month 1 | 1-3 features shipped | Knowledge grows in touched areas; everywhere else unchanged. |
+| Month 3 | ~8-15 features | `/spec-verify` becoming useful; `/work` used for 1-2 larger initiatives. |
+| Month 6 | Compounding visible | 20+ KB entries, 10+ ADRs, 10+ specs. Domain analysis pulls real context on every feature. `/curate` runs catch drift before it becomes a problem. New team members orient in hours instead of weeks. |
+
+The timeline above assumes a team of 2-4 developers shipping regularly.
+Faster teams compound faster; slower teams compound slower. The shape is
+the same either way.
+
+---
+
+## Where to go next
+
+- **[GETTING-STARTED.md](GETTING-STARTED.md)** — the mental model
+  overview: how KB, ADRs, specs, and features relate, and the decision
+  tree for what to run when.
+- **[README.md](README.md)** — full command reference.
+- **[DESIGN.md](DESIGN.md)** — the architecture and the ten core
+  principles that shaped the kit's design.
+- **[EXAMPLES.md](EXAMPLES.md)** — end-to-end walkthroughs of real
+  features.
+
+If you get stuck: run `/vallorcine-help "<what you're trying to do>"`.
+It's a router — it reads your current project context, asks you one
+question, and hands you the right command.

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -1,0 +1,316 @@
+# Getting Started with vallorcine
+
+Vallorcine is a Claude Code kit for shipping real features on real codebases
+without losing the context you build up along the way. It turns research,
+architecture decisions, specifications, tests, and code into connected
+assets that feed each other — so your 5th feature is faster than your 1st
+instead of slower.
+
+This document is the new-user overview. It explains:
+- The four knowledge layers and how they relate
+- The feature pipeline in plain language
+- When you need work groups (multi-feature coordination)
+- Curation — how the system catches drift
+- A decision tree for "what do I run when?"
+
+If you already have vallorcine installed and just want the command
+reference, read [README.md](README.md). For the architecture and the ten
+core design principles, read [DESIGN.md](DESIGN.md).
+
+---
+
+## The mental model: four knowledge layers
+
+Vallorcine keeps four kinds of information separate, each with its own
+directory and its own lifecycle.
+
+```
+.kb/         — research findings (how things work)
+.decisions/  — architecture decisions (why we chose X over Y)
+.spec/       — behavioral contracts (what the system guarantees)
+.feature/    — active feature work (what we're building right now)
+```
+
+Think of them as the four questions a mature project has to answer:
+
+| Layer | Answers | Written by | Read by |
+|-------|---------|-----------|---------|
+| **Knowledge** (`.kb/`) | *How does X work?* Research on algorithms, libraries, protocols. | `/research`, `/feature-retro` | `/architect`, `/feature-domains`, `/feature-test` |
+| **Decisions** (`.decisions/`) | *Why did we choose X over Y?* ADRs with full deliberation. | `/architect`, `/decisions backfill` | `/feature-domains`, `/feature-plan`, `/spec-author` |
+| **Specifications** (`.spec/`) | *What does the system guarantee?* Behavioral contracts with requirement IDs. | `/spec-author`, `/spec-write` | `/feature-plan`, `/feature-test`, `/audit`, `/spec-verify` |
+| **Features** (`.feature/`) | *What are we building right now?* Session state + test plan + implementation context. | `/feature` and its pipeline stages | The pipeline itself (crash recovery, resume) |
+
+### How they feed each other
+
+The layers aren't independent — they form a flow:
+
+```
+Research (KB)  ──feeds──▶  Architecture decisions (ADRs)
+     │                              │
+     │                              ▼
+     │                         Specifications
+     │                              │
+     ├────────────────┬─────────────┤
+     ▼                ▼             ▼
+Domain analysis ──▶  Test plan  ──▶  Implementation
+                     (tests)         (code)
+     │                ▲               │
+     │                │               │
+     │         Audit finds bugs ──────┘
+     │         (patterns go back to KB)
+     ▼
+Feature retrospective
+     │
+     └──▶ writes back to KB (new patterns learned)
+           writes back to decisions (drift noted)
+```
+
+Concrete example:
+
+1. You run `/research "HNSW graph construction"` — an agent investigates,
+   writes findings to `.kb/algorithms/vector-indexing/hnsw.md` with a
+   `last_researched` date.
+2. Later, when choosing an ANN algorithm, `/architect` pulls that KB
+   entry into deliberation — you don't re-research HNSW, you build on
+   what's there. The resulting ADR lands in `.decisions/ann-algorithm/`.
+3. When you write a spec for the indexing behavior, `/spec-author` reads
+   both the KB entry and the ADR as input — the spec codifies what the
+   system will guarantee, using the algorithm choice the ADR settled.
+4. `/feature-plan` reads the spec as its primary context. Tests are
+   generated from the spec's requirements (R1, R2, ...). Implementation
+   makes those tests pass.
+5. `/audit` runs adversarial analysis against the implementation,
+   looking for the spec's requirements being violated under edge
+   conditions. Bugs found here become KB entries (adversarial patterns)
+   that `/feature-test` uses on the *next* feature — so the same class
+   of bug gets prevented before it's written.
+6. `/feature-retro` at the end of the feature writes back: new KB
+   entries from what you learned, updates to ADRs if assumptions
+   shifted, and a narrative that captures the arc.
+
+The writing directions are strictly partitioned. Each agent can only
+write to its designated layer — `/research` cannot write ADRs, `/audit`
+cannot modify specs, etc. This is what keeps the layers from turning
+into a single mess of mixed-concern files.
+
+---
+
+## The feature pipeline
+
+`/feature "<description>"` walks a single feature from an idea to a PR
+through a structured TDD pipeline. Each stage has a clear input
+(previous stage's output on disk) and a clear output (next stage's
+input). If a session crashes, you resume where you stopped — the state
+lives in `.feature/<slug>/status.md`, not in conversation memory.
+
+The stages, in order:
+
+1. **Scoping** — 3-4 question interview to nail down the brief. Produces
+   `.feature/<slug>/brief.md`.
+2. **Domains** — identifies which domains the feature touches, pulls in
+   relevant KB, ADRs, and specs. Commissions new research/ADRs if gaps
+   are found. Routes to `/spec-author` if the project uses specs and
+   the feature needs a new one.
+3. **Planning** — produces `.feature/<slug>/work-plan.md` with every
+   construct (class, function, type, file) the feature will add or
+   change. Picks an execution strategy: `cost` (sequential, one unit at
+   a time), `balanced` (batched parallel), `speed` (max parallelism).
+4. **Testing** — Test Writer Agent generates a test plan from spec
+   requirements (if specs exist) or from the brief + domain patterns.
+   Every test fails first (red phase confirmed).
+5. **Hardening** (optional) — adversarial test pass against domain-lens
+   behavioral attacks on the contracts, before implementation.
+6. **Implementation** — Code Writer Agent makes the tests pass, never
+   modifies the tests. If a test seems wrong, it escalates rather than
+   editing.
+7. **Refactor** — quality review (8-item checklist), then delegates to
+   `/audit` for adversarial bug finding. Audit findings either get
+   fixed inline or escalate for triage (never silently ignored).
+8. **PR draft** — `/feature-pr` assembles title, description, checklist
+   from the feature's artifacts. Human reviews, edits, and submits.
+9. **Retrospective** — `/feature-retro` writes back learnings to KB,
+   updates to decisions, and optionally generates a narrative article.
+
+### When to use `/feature` vs `/feature-quick`
+
+- **`/feature`** for substantial work: multi-file changes, anything
+  touching business logic, anything requiring tests. Full pipeline with
+  spec analysis, planning, TDD, audit.
+- **`/feature-quick`** for single-session trivial changes: add a field,
+  rename a method, add a helper. No planning document, no multi-session
+  state. If you type `/feature-quick` and it detects complexity signals
+  (cross-cutting changes, multiple files, "refactor", new dependencies),
+  it will suggest escalating to `/feature` instead.
+
+When in doubt, run `/vallorcine-help "<what you're about to do>"` — it
+routes you to the right entry point.
+
+---
+
+## Work groups — multi-feature coordination
+
+A single `/feature` run is great for self-contained changes. Real
+projects have larger initiatives: "migrate auth from session tokens to
+JWT", "add encryption to the storage layer", "replace the query planner".
+These span multiple features, have real cross-feature dependencies, and
+benefit from being planned as a coordinated batch.
+
+Work groups (`.work/<group-slug>/`) are how vallorcine represents this.
+
+### The work-group flow
+
+```
+/work "<goal>"                — create the work group, capture the goal
+/work-decompose "<slug>"      — break the goal into work definitions
+                                (WDs) with explicit dependencies
+/work-status "<slug>"         — show readiness: what's READY, BLOCKED,
+                                IN_PROGRESS, COMPLETE
+/work-plan "<slug>" next      — specify a WD (produce specs/ADRs for it)
+/work-start "<slug>" next     — implement a specified WD
+                                (runs the full feature pipeline)
+```
+
+### What makes work groups powerful
+
+**Artifact-based dependencies.** A WD declares what it produces (a spec,
+an interface contract, an ADR) and what it depends on (produced by
+another WD). Readiness is computed mechanically — when a dependency's
+artifact lands, the consuming WD automatically moves from BLOCKED to
+READY. No manual tracking.
+
+**Two pipeline modes per WD:**
+- **Specification-only** (`/work-plan`) — for WDs whose job is to
+  produce a spec or an ADR, not code. Ends when the artifact is
+  APPROVED.
+- **Implementation-only** (`/work-start`) — for WDs whose spec already
+  exists. Skips domain analysis and spec authoring, goes straight to
+  planning → tests → code.
+
+**Parallel dispatch** (`/work-start <group> --parallel [N]`) runs every
+SPECIFIED WD as a concurrent sub-agent in isolated contexts. A wave of
+five WDs can finish in roughly the time of one instead of five. The
+concurrency caveats (shared KB writes, test contention, cost budget)
+are documented inline in the skill.
+
+### When you don't need work groups
+
+If your whole change fits in a single feature, skip work groups entirely.
+`/feature "<description>"` handles it directly — work groups are for
+initiatives that genuinely span multiple coordinated features.
+
+---
+
+## Curation — catching drift
+
+The four layers accumulate assets. Over time, they drift:
+
+- An ADR says "we chose approach X" but the code actually implements Y.
+- A KB entry was researched 6 months ago; the library has changed.
+- A spec claims R5 is enforced by `UserService`, but the annotation is
+  gone and nothing verifies the requirement anymore.
+- A work group has 3 WDs still open with no updates for weeks.
+
+`/curate` is the command that scans for these signals periodically.
+
+- **`/curate --init`** — first-time scan on an existing codebase. Pulls
+  candidate decisions and research topics out of git history, surfacing
+  things that *should* have been captured. Good starting point on
+  brownfield projects — see [GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md).
+- **`/curate`** — incremental scan. Runs in minutes. Reviews quality
+  signals since the last run: stale decisions, knowledge gaps, spec
+  drift, aging obligations.
+- **`/curate --deeper`** — 6-month scan instead of the default 3, for
+  periodic deep reviews.
+
+Findings are presented as a numbered list. You pick by number; curate
+routes each one to the right follow-up command (`/spec-verify`,
+`/research`, `/architect`, `/decisions revisit`, etc.). Nothing is
+auto-fixed — curation surfaces, humans decide.
+
+---
+
+## What to run when — decision tree
+
+```
+Are you starting something new?
+│
+├─ Small, single-file, no tests needed
+│  → /feature-quick "<description>"
+│
+├─ Normal feature (tests, multi-file, business logic)
+│  → /feature "<description>"
+│
+└─ Multi-feature initiative (e.g., "migrate auth to JWT")
+   → /work "<goal>"
+     → /work-decompose "<slug>"
+     → /work-plan "<slug>" next    (specify each WD)
+     → /work-start "<slug>" next   (implement each specified WD)
+
+Are you looking for existing knowledge?
+│
+├─ General question about how something works
+│  → /kb "<question>"             (queries research)
+│
+├─ Looking for a past decision
+│  → /decisions "<question>"       (queries ADRs)
+│  → /decisions list                (browse all)
+│
+├─ Looking for behavioral guarantees
+│  → /spec "<question>"            (queries specs)
+│
+└─ Just want to know what's going on
+   → /project-context              (all active team-shared context)
+
+Do you need to research or decide something?
+│
+├─ Research a topic into the KB
+│  → /research "<subject>"
+│
+├─ Make an architecture decision
+│  → /architect "<problem>"
+│
+└─ Revisit a past decision that might be wrong now
+   → /decisions revisit "<slug or topic>"
+
+Are you onboarding an existing codebase?
+│
+└─ → /setup-vallorcine             (one-time kit setup)
+     → /curate --init              (pull candidates from git history)
+     → See GETTING-STARTED-EXISTING.md for the full path
+
+Not sure?
+│
+└─ → /vallorcine-help              (the router — asks you one question,
+                                     hands you the right command)
+```
+
+---
+
+## Where to go next
+
+- **[README.md](README.md)** — full command reference and install guide.
+- **[GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md)** — how to
+  onboard an existing codebase gradually instead of trying to spec
+  everything upfront.
+- **[DESIGN.md](DESIGN.md)** — the architecture: ten core principles,
+  write-authority partitioning, crash recovery, token budgets.
+- **[COMPETITIVE.md](COMPETITIVE.md)** — how vallorcine fits into the
+  Claude Code plugin ecosystem and what it does that other kits don't.
+- **[EXAMPLES.md](EXAMPLES.md)** — end-to-end walkthroughs: building a
+  feature, querying the KB, crash recovery, the autonomous TDD loop.
+
+### First 30 minutes with vallorcine
+
+If you just installed vallorcine on a fresh project:
+
+1. Run `/setup-vallorcine` — creates `.kb/`, `.decisions/`, `.spec/`,
+   `.feature/`, and the project config.
+2. Run `/vallorcine-help` — get a guided tour of what each concern does.
+3. Pick a small first feature and run `/feature-quick "<description>"`
+   — learn the rhythm before you commit to the full pipeline.
+4. Once you have one feature under your belt, run `/feature` on a
+   normal-sized change and watch how specs/tests/code connect.
+
+If you installed on an existing codebase that already has significant
+history, read [GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md)
+next — the recommended path is different.

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -31,6 +31,25 @@ directory and its own lifecycle.
 .feature/    — active feature work (what we're building right now)
 ```
 
+A fifth directory, `.capabilities/`, is a lightweight index of what the
+project can do — searchable by natural language, useful for "do we
+support X?" questions and as input to future feature scoping. It's
+created alongside the four layers but isn't part of the core mental
+model.
+
+### When each layer gets created
+
+`/setup-vallorcine` bootstraps `.kb/`, `.decisions/`, `.capabilities/`,
+and `.feature/` in one shot on first install. `.spec/` is deliberately
+*not* created by `/setup-vallorcine` — specs are opt-in. When you're
+ready to start writing specs for a feature area, run `/spec-init` once
+to initialize the spec registry, then use `/spec-author` per feature.
+This matches the lazy-spec philosophy: the spec layer has real
+ergonomic cost, and you don't want it active until you have behavior
+worth specifying. See
+[GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md) for the
+incremental-adoption path on brownfield projects.
+
 Think of them as the four questions a mature project has to answer:
 
 | Layer | Answers | Written by | Read by |
@@ -303,13 +322,17 @@ Not sure?
 
 If you just installed vallorcine on a fresh project:
 
-1. Run `/setup-vallorcine` — creates `.kb/`, `.decisions/`, `.spec/`,
-   `.feature/`, and the project config.
+1. Run `/setup-vallorcine` — creates `.kb/`, `.decisions/`,
+   `.capabilities/`, `.feature/`, and the project config. `.spec/` is
+   not created yet; run `/spec-init` separately when you're ready to
+   start writing specs.
 2. Run `/vallorcine-help` — get a guided tour of what each concern does.
 3. Pick a small first feature and run `/feature-quick "<description>"`
    — learn the rhythm before you commit to the full pipeline.
 4. Once you have one feature under your belt, run `/feature` on a
-   normal-sized change and watch how specs/tests/code connect.
+   normal-sized change and watch how domain analysis, tests, and code
+   connect — and run `/spec-init` when that feature introduces
+   behavior worth specifying.
 
 If you installed on an existing codebase that already has significant
 history, read [GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md)

--- a/README.md
+++ b/README.md
@@ -345,6 +345,19 @@ bash install.sh --diff /path/to/your/project
 
 ---
 
+## New here? Read this first
+
+- **[GETTING-STARTED.md](GETTING-STARTED.md)** — the mental model: how
+  KB / ADRs / specs / features relate, the feature pipeline in plain
+  language, when work groups apply, and a "what to run when" decision
+  tree.
+- **[GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md)** — how
+  to bring vallorcine into a codebase that already has real history.
+  `/curate --init`, the lazy-spec rule, realistic Day 1 / Week 1 /
+  Month 1 / Month 3 progression, and common pitfalls.
+
+---
+
 ## Usage
 
 **New feature (full pipeline):**

--- a/SETTLED.md
+++ b/SETTLED.md
@@ -713,3 +713,103 @@ jlsm anchor audit of 8 specs (5 Tier A, 1 Tier B, 2 Tier C).
 Decomposition without visibility into `.spec/` produces WDs disconnected from
 reality. The algorithm must read spec registry as part of its analysis. Found
 when work-decompose created 13 WDs that completely missed 26 existing DRAFT specs.
+
+## @spec annotations as primary traceability (2026-04-16)
+
+`@spec FXX.RN` (and after the 2026-04-20 migration, `@spec domain.slug.RN`)
+comments in code link requirements to enforcement points. `spec-verify`
+annotates during discovery; `spec-trace.sh` provides the reverse index.
+Together they make spec→code traceability queryable in both directions
+without a separate registry. `/curate` analysis 18 enumerates APPROVED
+specs and calls `spec-trace.sh` for each to flag reqs missing impl/test
+annotations.
+
+## Correctness over context cost (2026-04-17)
+
+Never drop correctness-relevant context from an agent prompt to save tokens.
+When prompts grow past budget, the fix is phase splitting + condensed
+handoff files (analysis-phase writes a structured finding doc, next-phase
+reads that instead of inheriting the conversation), not cutting information
+the agent needs to make decisions. Codified in
+`.claude/rules/context-efficiency.md`.
+
+## Spec reorganization to behavioral domains (2026-04-17, executed 2026-04-20)
+
+Specs migrated from feature-centric layout (`F13-jlsm-schema.md`) to
+behavioral-domain layout (`domains/schema/construction.md`). 12 domains,
+~60-75 files depending on how cross-cutting concerns split. Annotation
+format changed from `@spec FXX.RN` to `@spec domain.slug.RN`. Executed in
+jlsm PR #40 + vallorcine PR #43 (2026-04-20) — 75 specs reshaped
+domain-first. The kit stays backwards-compatible with feature-ID specs
+via the dual-schema manifest detection (see next entry).
+
+## Primitives vs applications spec pattern (2026-04-20)
+
+When a concern is cross-cutting (encryption, compression, serialization),
+split the spec content by abstraction level: primitives (keys, rotation,
+algorithms, variants) live in their own domain directory; applications
+(how WAL/query/indices *use* encryption) live in their functional domain
+with a multi-domain tag for cross-discovery. Codified as MIGRATION.md P6
+and applied to jlsm F42/F46/F47/F03 during migration. Same rule
+generalizes to any cross-cutting primitive.
+
+## Manifest schema v2 + dual-schema read path (2026-04-20, hardened 2026-04-23)
+
+Post-migration manifests use `{schema_version: 2, specs: [{id, path, ...}]}`
+(array of specs with domain-slug IDs) instead of legacy
+`{features: {FXX: {...}}}`. Schema v2 handles `domain.slug` IDs natively;
+v1 is retained for projects that haven't migrated. Every read-path
+script uses `spec-lib.sh` helpers (`spec_file_for_id`,
+`spec_manifest_ids`, `spec_manifest_state`, `spec_manifest_domains_for`)
+that detect the schema at read time. Writes to v2 manifests use v2 shape;
+v1 writes use v1 shape. No forced migration window — v1 stays working
+indefinitely. The 2026-04-23 `fix/manifest-v2-schema-compat` branch
+closed the remaining silent-failure paths in `spec-resolve.sh`,
+`work-lib.sh`, `work-finalize.sh`, `curate-scan.sh`, and `spec-stats.sh`.
+
+## Fix now, not defer — positive justification required (2026-04-21)
+
+Generalises the existing kit-failures and spec-violations rules: when a
+problem surfaces mid-session, default to fixing it in the current PR.
+Phrases like "not X's problem", "separate concern", "covered
+transitively by Y" are red flags that need positive justification before
+they're acceptable. No transitive / side-effect coverage for claimed
+behaviour — test what is claimed, directly. Memory:
+`feedback_fix_now_not_defer.md`.
+
+## Planning-snapshot work groups use DRAFT status (2026-04-21)
+
+WDs that point at specs still in DRAFT use `status: DRAFT`, not
+SPECIFIED. SPECIFIED implies the spec is APPROVED and ready for
+implementation; DRAFT matches the actual state where the WD will promote
+the spec via `/work-plan` before implementation can proceed. Applied to
+the 5 jlsm work groups shipped in PR #42 (15 WDs, 13 still-DRAFT specs).
+
+## Parallel-subagent hang prevention — mode-gated prompts + termination contract (2026-04-23)
+
+When `/feature-coordinate` dispatches work units as concurrent
+sub-agents, the coordinator's `Agent` tool calls block until each child
+emits its final assistant message. Two failure modes had to be closed:
+
+1. **Unconditional AskUserQuestion sites** in the three pipeline skills
+   (`/feature-test`, `/feature-implement`, `/feature-refactor`) —
+   including several explicitly marked "regardless of automation_mode"
+   — would hang forever in a subagent with no human attached. Every site
+   now has a `balanced | speed` bypass that records
+   `escalated-<reason>` to `cycle-log.md` + substage and returns
+   `ESCALATED`, letting the coordinator surface it via its existing
+   escalation flow.
+
+2. **Weak termination signal** at `/feature-refactor`'s parallel-mode
+   exit — saying "STOP" as prose is not a forcing function at the LLM
+   level. The skill now carries an explicit subagent termination
+   contract: "your very next message MUST be the single-line summary —
+   no more Read, Bash, Grep, Edit." `/feature-coordinate` gained a
+   Step 1a documenting the dispatch contract every coordinator must
+   embed in Agent prompts.
+
+Root cause came from a 2026-04-23 jlsm WU-3 run: status.md flipped to
+COMPLETE at 10:41:32, but the subagent kept running ~2 min before the
+user had to Ctrl+C to unblock the coordinator. Regression:
+`tests/scenario-parallel-subagent-hang-prevention.sh` (10 structural
+invariants; grep-based so it's durable against future skill edits).

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -19,6 +19,13 @@
 
 set -euo pipefail
 
+# Load spec-lib for v1/v2 manifest-aware enumeration + file resolution.
+_CURATE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$_CURATE_SCRIPT_DIR/spec-lib.sh" ]]; then
+    # shellcheck source=spec-lib.sh
+    source "$_CURATE_SCRIPT_DIR/spec-lib.sh"
+fi
+
 # ── Defaults ─────────────────────────────────────────────────────────────────
 
 INIT_MODE=0
@@ -988,13 +995,14 @@ if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
 
     while IFS= read -r fid; do
         [[ -z "$fid" ]] && continue
-        spec_state=$(jq -r --arg id "$fid" '.features[$id].state // ""' "$MANIFEST")
+        spec_state=$(spec_manifest_state "$MANIFEST" "$fid")
         [[ "$spec_state" != "APPROVED" ]] && continue
 
-        spec_rel=$(jq -r --arg id "$fid" '.features[$id].latest_file // ""' "$MANIFEST")
-        [[ -z "$spec_rel" ]] && continue
-        spec_file=".spec/$spec_rel"
-        [[ ! -f "$spec_file" ]] && continue
+        # spec_file_for_id handles v1/v2 path normalization.
+        spec_file=$(spec_file_for_id "$MANIFEST" "$fid")
+        [[ -z "$spec_file" || ! -f "$spec_file" ]] && continue
+        # Re-derive a repo-relative form for downstream diagnostics/output.
+        spec_rel="${spec_file#"$PWD"/.spec/}"
 
         # Extract subject tokens from requirements (CamelCase + snake_case, 4+ chars)
         subject_tokens=$(awk '/^---$/{n++; next} n==2{print} n>=3{exit}' "$spec_file" \
@@ -1021,11 +1029,11 @@ if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
         done
 
         if [[ "$found" == "false" ]]; then
-            spec_domains=$(jq -r --arg id "$fid" '.features[$id].domains // [] | join(",")' "$MANIFEST")
+            spec_domains=$(spec_manifest_domains_for "$MANIFEST" "$fid" | tr '\n' ',' | sed 's/,$//')
             token_list=$(echo "$subject_tokens" | tr '\n' ',' | sed 's/,$//')
             echo "ORPHANED|$fid|$spec_domains|$token_list" >> "$TMPDIR_SCAN/spec-orphaned.txt"
         fi
-    done < <(jq -r '.features | keys[]' "$MANIFEST" 2>/dev/null)
+    done < <(spec_manifest_ids "$MANIFEST")
 fi
 
 # ── Analysis 15: Cross-WD displacement (specs displaced that WDs depend on) ──
@@ -1038,16 +1046,19 @@ fi
 if [[ -d ".work" && -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
     MANIFEST=".spec/registry/manifest.json"
 
-    # Collect all INVALIDATED spec paths
+    # Collect all INVALIDATED spec paths (v1/v2 manifest-aware).
     invalidated_paths=()
     while IFS= read -r fid; do
         [[ -z "$fid" ]] && continue
-        state=$(jq -r --arg id "$fid" '.features[$id].state // ""' "$MANIFEST")
+        state=$(spec_manifest_state "$MANIFEST" "$fid")
         [[ "$state" != "INVALIDATED" ]] && continue
-        rel=$(jq -r --arg id "$fid" '.features[$id].latest_file // ""' "$MANIFEST")
-        [[ -z "$rel" ]] && continue
+        absfile=$(spec_file_for_id "$MANIFEST" "$fid")
+        [[ -z "$absfile" ]] && continue
+        # Downstream compares against WD artifact_deps which store paths
+        # relative to .spec/. Re-derive that form.
+        rel="${absfile#"$PWD"/.spec/}"
         invalidated_paths+=("$rel")
-    done < <(jq -r '.features | keys[]' "$MANIFEST" 2>/dev/null)
+    done < <(spec_manifest_ids "$MANIFEST")
 
     # Check each WD's artifact_deps against invalidated specs
     # Write invalidated paths to a temp file to avoid subshell array issues

--- a/scripts/index-verify.sh
+++ b/scripts/index-verify.sh
@@ -88,7 +88,10 @@ if [[ "$CHECK_KB" == "1" && -d ".kb" && -f ".kb/CLAUDE.md" ]]; then
 
     # Check Recently Added has entries if subject files exist
     subject_count="$(find .kb -name '*.md' ! -name 'CLAUDE.md' ! -path '*/_refs/*' ! -path '*/_archive*' 2>/dev/null | wc -l)"
-    recently_added_count="$(sed -n '/## Recently Added/,/^## /p' ".kb/CLAUDE.md" 2>/dev/null | grep -v 'Date' | grep -c '^|[^-]' || echo 0)"
+    # grep -c prints "0" and exits 1 when there are no matches; swallow the
+    # nonzero exit with `|| true` — do NOT use `|| echo 0`, which would emit
+    # a second "0" and break the subsequent [[ $var -gt 0 ]] arithmetic test.
+    recently_added_count="$(sed -n '/## Recently Added/,/^## /p' ".kb/CLAUDE.md" 2>/dev/null | grep -v 'Date' | grep -c '^|[^-]' || true)"
 
     if [[ "$subject_count" -gt 0 && "$recently_added_count" -le 1 ]]; then
         # Recently Added is empty but subjects exist — rebuild from file dates

--- a/scripts/spec-lib.sh
+++ b/scripts/spec-lib.sh
@@ -108,17 +108,100 @@ spec_file_for_id() {
   fi
 }
 
+# ── Manifest query helpers (v1/v2 schema-agnostic) ───────────────────────────
+# v1 schema: {"features": {"F01": {...}}, "domains": {"compression": {...}}}
+# v2 schema: {"schema_version": 2, "specs": [{"id": "...", "domains": [...]}]}
+# Every helper below detects the schema by probing for the `.specs` array.
+
+# Emit every spec ID in the manifest, one per line.
+spec_manifest_ids() {
+  local manifest="$1"
+  jq -r '
+    if .specs then .specs[].id
+    else (.features // {}) | keys[]
+    end
+  ' "$manifest" 2>/dev/null
+}
+
+# Emit the state for a single spec ID.
+spec_manifest_state() {
+  local manifest="$1" fid="$2"
+  jq -r --arg id "$fid" '
+    if .specs then ((.specs[] | select(.id == $id) | .state) // "")
+    else (.features[$id].state // "")
+    end
+  ' "$manifest" 2>/dev/null
+}
+
+# Emit the domains for a single spec ID, one per line.
+spec_manifest_domains_for() {
+  local manifest="$1" fid="$2"
+  jq -r --arg id "$fid" '
+    if .specs then ((.specs[] | select(.id == $id) | .domains // []) | .[])
+    else (.features[$id].domains // [] | .[])
+    end
+  ' "$manifest" 2>/dev/null
+}
+
+# Emit the unique set of all domains across the manifest, one per line.
+spec_manifest_all_domains() {
+  local manifest="$1"
+  jq -r '
+    if .specs then ([.specs[].domains[]] | unique | .[])
+    else ((.domains // {}) | keys[])
+    end
+  ' "$manifest" 2>/dev/null
+}
+
+# Report whether this is a v2 manifest. Returns 0 (v2) or 1 (v1/unknown).
+spec_manifest_is_v2() {
+  local manifest="$1"
+  [[ "$(jq -r 'has("specs")' "$manifest" 2>/dev/null)" == "true" ]]
+}
+
 # ── Update manifest registry entry atomically via temp file ──────────────────
-# latest_file is relative to .spec/ directory.
+# v1: latest_file relative to .spec/; schema is {"features": {fid: {...}}}.
+# v2: path relative to repo root (".spec/domains/..."); schema is
+#     {"schema_version": 2, "specs": [{"id": ..., "path": ..., ...}]}.
+# Callers pass the v1-style latest_file; this function normalizes for v2.
 spec_registry_update() {
   local manifest="$1" fid="$2" latest_file="$3" state="$4"
   local domains_json="${5:-[]}"
   local tmp
   tmp=$(mktemp)
-  jq --arg id "$fid" --arg lf "$latest_file" --arg st "$state" \
-    --argjson doms "$domains_json" \
-    '.features[$id] = {"latest_file": $lf, "state": $st, "domains": $doms}' \
-    "$manifest" > "$tmp" && mv "$tmp" "$manifest"
+  if spec_manifest_is_v2 "$manifest"; then
+    # v2 stores paths relative to the repo root. Prepend .spec/ only if the
+    # caller hasn't already included it (callers historically pass paths like
+    # "domains/foo/F01-x.md").
+    local v2_path="$latest_file"
+    [[ "$v2_path" != .spec/* ]] && v2_path=".spec/$v2_path"
+    jq --arg id "$fid" --arg p "$v2_path" --arg st "$state" \
+      --argjson doms "$domains_json" \
+      '
+        .specs = (
+          (.specs // [])
+          | map(select(.id != $id))
+          | . + [{
+              "id": $id,
+              "path": $p,
+              "state": $st,
+              "version": 1,
+              "domains": $doms,
+              "requires": [],
+              "invalidates": [],
+              "decision_refs": [],
+              "kb_refs": []
+            }]
+        )
+        | .spec_count = (.specs | length)
+        | .generated_at = (now | todate)
+      ' "$manifest" > "$tmp" && mv "$tmp" "$manifest"
+  else
+    jq --arg id "$fid" --arg lf "$latest_file" --arg st "$state" \
+      --argjson doms "$domains_json" \
+      '.features[$id] = {"latest_file": $lf, "state": $st, "domains": $doms}' \
+      "$manifest" > "$tmp" && mv "$tmp" "$manifest"
+  fi
   echo "[registry] $fid -> $latest_file ($state)" >&2
 }
 

--- a/scripts/spec-resolve.sh
+++ b/scripts/spec-resolve.sh
@@ -65,12 +65,21 @@ elif [[ -n "${OVERRIDE_DOMAINS:-}" ]]; then
   IFS=',' read -ra MATCHED_DOMAINS <<< "$OVERRIDE_DOMAINS"
   echo "[resolve] Domain override: ${MATCHED_DOMAINS[*]}" >&2
 else
-  mapfile -t ALL_DOMAINS < <(jq -r '.domains | keys[]' "$MANIFEST")
+  mapfile -t ALL_DOMAINS < <(spec_manifest_all_domains "$MANIFEST")
   desc_lower=$(echo "$FEATURE_DESC" | tr '[:upper:]' '[:lower:]')
   MATCHED_DOMAINS=()
+  # v2 manifests carry no domain descriptions; description-keyword matching
+  # degrades to name-only matching, which is correct behavior — ambiguous
+  # cases fall through to NEEDS_DOMAIN_INFERENCE.
+  v2_manifest=false
+  spec_manifest_is_v2 "$MANIFEST" && v2_manifest=true
   for domain in "${ALL_DOMAINS[@]}"; do
-    domain_desc=$(jq -r --arg d "$domain" '.domains[$d].description // ""' "$MANIFEST" \
-      | tr '[:upper:]' '[:lower:]')
+    if [[ "$v2_manifest" == "true" ]]; then
+      domain_desc=""
+    else
+      domain_desc=$(jq -r --arg d "$domain" '.domains[$d].description // ""' "$MANIFEST" \
+        | tr '[:upper:]' '[:lower:]')
+    fi
     # Match if feature desc contains domain name OR any keyword in domain desc
     if echo "$desc_lower" | grep -qw "$domain"; then
       MATCHED_DOMAINS+=("$domain")
@@ -92,7 +101,13 @@ if [[ ${#MATCHED_DOMAINS[@]} -eq 0 ]]; then
   echo "Feature request: $FEATURE_DESC"
   echo ""
   echo "## Available Domains"
-  jq -r '.domains | to_entries[] | "- \(.key): \(.value.description)"' "$MANIFEST"
+  jq -r '
+    if .specs then
+      ([.specs[].domains[]] | unique | .[] | "- \(.)")
+    else
+      (.domains | to_entries[] | "- \(.key): \(.value.description)")
+    end
+  ' "$MANIFEST"
   exit 0
 fi
 
@@ -100,14 +115,14 @@ echo "[resolve] Domains matched: ${MATCHED_DOMAINS[*]}" >&2
 
 # ── Step 2: Collect candidate spec files via registry ────────────────────────
 # Skipped when EXPLICIT_SPEC_IDS populated CANDIDATE_FILES above.
-mapfile -t ALL_FEATURE_IDS < <(jq -r '.features | keys[]' "$MANIFEST")
+mapfile -t ALL_FEATURE_IDS < <(spec_manifest_ids "$MANIFEST")
 
 if [[ "$EXPLICIT_ID_MODE" == "true" ]]; then
   : # CANDIDATE_FILES already populated from explicit IDs; skip domain filter loop
 else
 for fid in "${ALL_FEATURE_IDS[@]}"; do
   # Check if this feature belongs to any matched domain
-  feature_domains=$(jq -r --arg id "$fid" '.features[$id].domains // [] | .[]' "$MANIFEST")
+  feature_domains=$(spec_manifest_domains_for "$MANIFEST" "$fid")
   matched=false
   for fd in $feature_domains; do
     for md in "${MATCHED_DOMAINS[@]}"; do
@@ -162,7 +177,7 @@ fi  # end: if EXPLICIT_ID_MODE else
 INVALIDATED_FILES=()
 if [[ "${INCLUDE_INVALIDATED:-}" == "true" ]]; then
   for fid in "${ALL_FEATURE_IDS[@]}"; do
-    feature_domains=$(jq -r --arg id "$fid" '.features[$id].domains // [] | .[]' "$MANIFEST")
+    feature_domains=$(spec_manifest_domains_for "$MANIFEST" "$fid")
     matched=false
     for fd in $feature_domains; do
       for md in "${MATCHED_DOMAINS[@]}"; do

--- a/scripts/spec-stats.sh
+++ b/scripts/spec-stats.sh
@@ -33,8 +33,7 @@ done < <(find "$SPEC_DIR/domains" -name "*.md" ! -name "INDEX.md" -print0 2>/dev
 
 OPEN_OBLIGATIONS=$(jq '[.obligations[] | select(.status=="open")] | length' \
   "$OBLIGATIONS" 2>/dev/null || echo 0)
-DOMAINS=$(jq '.domains | keys | length' \
-  "$MANIFEST" 2>/dev/null || echo 0)
+DOMAINS=$(spec_manifest_all_domains "$MANIFEST" 2>/dev/null | grep -c . || echo 0)
 
 cat <<EOF
 # Spec Corpus Health

--- a/scripts/work-finalize.sh
+++ b/scripts/work-finalize.sh
@@ -11,6 +11,11 @@
 
 set -euo pipefail
 
+# Load spec-lib for v1/v2 manifest-aware file resolution.
+_WF_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=spec-lib.sh
+source "$_WF_SCRIPT_DIR/spec-lib.sh"
+
 SLUG="${1:-}"
 [[ -z "$SLUG" ]] && { echo "Usage: work-finalize.sh <feature-slug>" >&2; exit 0; }
 
@@ -149,11 +154,14 @@ SPEC_IDS=($(printf '%s\n' "${SPEC_IDS[@]}" 2>/dev/null | sort -u))
 
 MANIFEST=".spec/registry/manifest.json"
 for spec_id in "${SPEC_IDS[@]}"; do
-    # Find the spec file via manifest
+    # Find the spec file via manifest (v1 + v2 schema-aware lookup).
     spec_file=""
     if [[ -f "$MANIFEST" ]]; then
-        rel_path="$(jq -r --arg id "$spec_id" '.features[$id].latest_file // ""' "$MANIFEST" 2>/dev/null || true)"
-        [[ -n "$rel_path" ]] && spec_file=".spec/$rel_path"
+        resolved="$(spec_file_for_id "$MANIFEST" "$spec_id" 2>/dev/null || true)"
+        if [[ -n "$resolved" && -f "$resolved" ]]; then
+            # Convert to repo-relative path for downstream grep/sed operations.
+            spec_file="${resolved#"$PWD"/}"
+        fi
     fi
 
     # Fallback: search .spec/domains/

--- a/scripts/work-lib.sh
+++ b/scripts/work-lib.sh
@@ -4,6 +4,15 @@
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   source "$SCRIPT_DIR/work-lib.sh"
 
+# spec-lib.sh provides manifest query helpers used below. Sourcing is
+# idempotent — the wrapper guard prevents double-definition warnings.
+if [[ -z "${VALLORCINE_SPEC_LIB_LOADED:-}" ]]; then
+  _WORK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck source=spec-lib.sh
+  source "$_WORK_LIB_DIR/spec-lib.sh"
+  VALLORCINE_SPEC_LIB_LOADED=1
+fi
+
 # ── Dependency preflight ─────────────────────────────────────────────────────
 work_require_deps() {
   local missing=()
@@ -234,9 +243,14 @@ work_check_spec_dep() {
   local spec_name="${spec_path##*/}"
 
   while IFS= read -r fid; do
-    local latest
-    latest=$(jq -r --arg id "$fid" '.features[$id].latest_file // ""' "$manifest")
-    [[ -z "$latest" ]] && continue
+    # spec_file_for_id resolves the absolute path for both v1 and v2 manifests.
+    local absfile
+    absfile=$(spec_file_for_id "$manifest" "$fid")
+    [[ -z "$absfile" ]] && continue
+    # Re-derive the path relative to .spec/ for substring matching. Callers
+    # pass spec_path as "<domain>/<name>", so we match against the tail of the
+    # resolved path.
+    local latest="${absfile#"$project_root"/.spec/}"
 
     local match=false
 
@@ -262,14 +276,14 @@ work_check_spec_dep() {
     fi
 
     if [[ "$match" == "true" ]]; then
-      found_file="$project_root/.spec/$latest"
+      found_file="$absfile"
       if [[ -f "$found_file" ]]; then
         found_state=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$found_file" \
           | jq -r '.state // ""' 2>/dev/null || true)
       fi
       break
     fi
-  done < <(jq -r '.features | keys[]' "$manifest" 2>/dev/null)
+  done < <(spec_manifest_ids "$manifest")
 
   if [[ -z "$found_file" || ! -f "$found_file" ]]; then
     echo "spec not found: $spec_path"

--- a/skills/feature-coordinate/SKILL.md
+++ b/skills/feature-coordinate/SKILL.md
@@ -117,6 +117,73 @@ sub-agents.
 
 ---
 
+## Step 1a — Subagent dispatch contract
+
+Every Agent call the coordinator issues to run a work unit MUST include the
+following termination contract in the prompt. The pipeline skills
+(`/feature-test`, `/feature-implement`, `/feature-refactor`) already
+mode-gate their AskUserQuestion sites against
+`execution_strategy: balanced | speed`, so subagents will chain autonomously
+between stages. The contract below closes the remaining hang vector:
+subagents that finish their work but keep taking actions instead of
+returning.
+
+Hang root-cause (2026-04-23): WU-3 wrote status.md = COMPLETE and all tests
+green, then the subagent continued running ~2 min with no further
+meaningful work before the user had to Ctrl+C to unblock the coordinator.
+The Agent tool blocks the parent until the child emits its final assistant
+message; there is no timeout, no polling, no "you're clearly done" signal.
+
+### Required prompt fragments
+
+Include these verbatim (or paraphrased keeping the semantics) in every
+subagent prompt:
+
+```
+## Termination contract (MANDATORY)
+
+The Agent tool call that launched you returns to the coordinator only when
+you emit your final assistant message. The coordinator has no timeout and
+cannot poll you.
+
+You MUST return to the coordinator IMMEDIATELY after:
+- writing units/WU-<n>/status.md with Substage = `complete`, OR
+- writing an escalation entry to cycle-log.md and setting substage to
+  `escalated-<reason>`.
+
+Your final message MUST be the single-line summary below — nothing else.
+Do NOT run any more tools, re-verify, re-read cycle-log.md, or polish.
+If you catch yourself about to call another tool after marking complete,
+STOP and emit the summary instead.
+
+## Return format (exactly one line)
+
+WU-<n>: <COMPLETE | ESCALATED | STOPPED_AT_<stage> | ERROR> — <n tests>, <n constructs>, <brief detail>
+```
+
+### Automation mode
+
+Every dispatched subagent prompt must explicitly set the expectation:
+
+```
+Treat automation_mode as autonomous. Do NOT pause between pipeline stages.
+All AskUserQuestion sites in /feature-test, /feature-implement,
+/feature-refactor are mode-gated against execution_strategy = balanced/speed
+— you will not encounter an interactive prompt. If a pipeline skill would
+still try to open AskUserQuestion (new site added without gating), treat
+that as a bug: record it to cycle-log.md and return ESCALATED.
+```
+
+### Coordinator-side verification
+
+After each subagent returns, in addition to checking status.md for
+`complete` vs escalation substage, the coordinator should sanity-check:
+- Status.md Stage/Substage matches the summary line verb (COMPLETE →
+  `complete`; ESCALATED → `escalated-<reason>`).
+- If they disagree, trust status.md — the canonical state is on disk.
+
+---
+
 ## Step 2 — Launch and monitor (speed mode)
 
 The coordinator runs a **completion-driven loop** instead of batch-wait:

--- a/skills/feature-implement/SKILL.md
+++ b/skills/feature-implement/SKILL.md
@@ -85,6 +85,11 @@ All tests were passing as of: <date from status.md>
 
 ```
 
+**In parallel mode (`execution_strategy: balanced | speed`):** do NOT call
+AskUserQuestion — chain to `/feature-refactor "<slug>" --unit WU-<n>`
+immediately.
+
+**Sequential/cost mode:**
 Use AskUserQuestion with two options:
 - "Proceed to refactor"
 - "Stop"

--- a/skills/feature-refactor/SKILL.md
+++ b/skills/feature-refactor/SKILL.md
@@ -60,6 +60,15 @@ Count completed `refactor-complete` entries in cycle-log.md to get cycle number.
 Stop and display: "We've completed 5 refactor cycles and you approved continuation.
 Continue with cycle 6?"
 
+**In parallel mode (`execution_strategy: balanced | speed`):** do NOT call
+AskUserQuestion. Append a `cycle-cap-escalation` entry to
+`units/WU-<n>/cycle-log.md`, set substage → `escalated-cycle-cap`, return:
+```
+WU-<n>: ESCALATED — cycle-cap reached at cycle <n>
+```
+STOP. Coordinator triages whether to approve another cycle.
+
+**Sequential/cost mode:**
 Use AskUserQuestion with options:
   - "Proceed"
   - "Stop here"
@@ -214,9 +223,24 @@ Run tests after changes.
 - No micro-optimisation — only obvious, high-impact fixes
 Run tests after changes.
 
-**Structural escalation (both modes):** If 2c or 2d reveals an issue requiring
-interface changes, new dependencies, or contract renegotiation — pause and
-surface it regardless of automation_mode:
+**Structural escalation:** If 2c or 2d reveals an issue requiring interface
+changes, new dependencies, or contract renegotiation — surface it.
+
+**In parallel mode (`execution_strategy: balanced | speed`):** do NOT call
+AskUserQuestion — the Agent tool call would hang forever with no human to
+answer. Instead:
+1. Append a `structural-escalation` entry to `units/WU-<n>/cycle-log.md`
+   describing the issue and why it can't be self-contained.
+2. Set `units/WU-<n>/status.md` substage → `escalated-structural`.
+3. Return the summary line with ESCALATED status:
+   ```
+   WU-<n>: ESCALATED — structural issue at <stage>: <one-line description>
+   ```
+4. STOP. The coordinator reads the per-unit status and surfaces the
+   escalation to the user via its own escalation flow.
+
+**Sequential/cost mode (`execution_strategy: cost | not-set`):** pause and
+surface via AskUserQuestion, regardless of automation_mode:
 ```
 ── Refactor paused — structural issue found ─────
 This issue may affect other units or require interface changes:
@@ -413,7 +437,21 @@ Continue to Step 4.
   1. [HIGH] <description> — <file:line>
   2. [MEDIUM] <description> — <file:line>
   3. [LOW/INFO] <description>
+```
 
+**In parallel mode (`execution_strategy: balanced | speed`):** do NOT call
+AskUserQuestion. Instead:
+1. Append a `security-escalation` entry to `units/WU-<n>/cycle-log.md`
+   listing every finding with severity.
+2. Set `units/WU-<n>/status.md` substage → `escalated-security`.
+3. Return the summary line:
+   ```
+   WU-<n>: ESCALATED — security review: <n> issues (<severity breakdown>)
+   ```
+4. STOP. Coordinator handles triage.
+
+**Sequential/cost mode:**
+```
 Use AskUserQuestion with options:
   - "Fix now"
   - "Stop to review"
@@ -615,7 +653,19 @@ We've completed 5 refactor cycles. Before starting another:
 
 Remaining concerns: <list or "none">
 Missing tests added this cycle: <n>
+```
 
+**In parallel mode (`execution_strategy: balanced | speed`):** do NOT call
+AskUserQuestion. Append a `cycle-5-checkpoint` escalation to
+`units/WU-<n>/cycle-log.md` with the remaining concerns, set substage →
+`escalated-cycle-5`, return:
+```
+WU-<n>: ESCALATED — cycle-5 checkpoint: <n remaining concerns>
+```
+STOP.
+
+**Sequential/cost mode:**
+```
 Use AskUserQuestion with options:
   - "Continue (approve cycle 6)"
   - "Stop (mark complete with noted limitations)"
@@ -682,18 +732,40 @@ Read `automation_mode` from status.md.
 
 **If `execution_strategy` is `balanced` or `speed` (parallel mode):**
 
-Mark unit complete in per-unit `unit_status`.
+Mark unit complete in per-unit `unit_status` (Stage = `refactor`, Substage =
+`complete`, Last checkpoint = `<N> tests passing`).
 Mark unit complete in feature-level Work Units table.
 Do NOT chain to next unit or PR — the coordinator handles that.
+
+**Subagent termination contract (read this carefully).**
+The Agent tool call that launched you returns to the coordinator only when
+you emit your final assistant message. Coordinators have no timeout and
+cannot poll you — if you keep taking actions after the work is done, the
+coordinator stays blocked while the rest of the batch finishes. That is
+the hang failure mode from 2026-04-23 (WU-3: status.md wrote COMPLETE,
+then the subagent kept working for ~2 more minutes without returning, and
+the user had to Ctrl+C to unblock the coordinator).
+
+Therefore, after writing status.md = complete and the Work Units table
+entry, **your very next message MUST be the single-line summary below —
+nothing else.** Do NOT:
+- run any more tools (no more Read, Bash, Grep, Edit, etc.)
+- re-verify test results you already verified
+- polish or re-read cycle-log.md
+- check "just one more thing"
+
+The block below IS the return:
 
 ```
 ───────────────────────────────────────────────
 ✨ REFACTOR AGENT complete · <slug> · WU-<n>
   Tokens : <TOKEN_USAGE>
 ───────────────────────────────────────────────
-Unit complete. Returning to coordinator.
+WU-<n>: COMPLETE — <n> tests, <n> constructs, <brief detail>
 ```
-STOP. (Coordinator launched this as subagent; returning is sufficient.)
+
+Emit that block as your final message and stop. If you catch yourself
+about to call another tool, stop and emit the summary instead.
 
 **If more work units remain (not the final unit) — sequential/cost mode only:**
 
@@ -770,8 +842,20 @@ Use AskUserQuestion with options:
 If "Proceed": invoke `/feature-pr "<slug>"`.
 If "Stop": display manual commands and stop.
 
-**If missing tests escalation triggered (either mode):**
+**If missing tests escalation triggered:**
 
+**In parallel mode (`execution_strategy: balanced | speed`):** the parallel
+exit block above already fired and you returned — if you're here, you are
+NOT in parallel mode. But just in case: do NOT call AskUserQuestion. Append
+a `missing-tests-escalation` entry to `units/WU-<n>/cycle-log.md` listing
+the missing test categories, set substage → `escalated-missing-tests`,
+return:
+```
+WU-<n>: ESCALATED — missing tests: <n categories>
+```
+STOP.
+
+**Sequential/cost mode:**
 ```
 ───────────────────────────────────────────────
 ✨ REFACTOR AGENT complete · <slug> · Cycle <n>
@@ -784,5 +868,6 @@ Use AskUserQuestion with options:
   - "Stop"
 ```
 Wait for input regardless of automation_mode — missing tests are always a
-human checkpoint. If "Proceed": invoke `/feature-test "<slug>" --add-missing`.
-If "Stop": display the manual sequence and stop.
+human checkpoint (in sequential mode). If "Proceed": invoke
+`/feature-test "<slug>" --add-missing`. If "Stop": display the manual
+sequence and stop.

--- a/skills/feature-test/SKILL.md
+++ b/skills/feature-test/SKILL.md
@@ -131,6 +131,11 @@ All tests verified failing.
 
 ```
 
+**In parallel mode (`execution_strategy: balanced | speed`):** do NOT call
+AskUserQuestion — chain to `/feature-implement "<slug>" --unit WU-<n>`
+immediately. No human is attached to this subagent.
+
+**Sequential/cost mode:**
 Use AskUserQuestion with two options:
 - "Proceed to implementation"
 - "Stop"
@@ -286,6 +291,18 @@ break downstream verification. Resolve this before proceeding:
   3. Or rewrite the brief title to match the domain's vocabulary.
 ```
 
+**In parallel mode (`execution_strategy: balanced | speed`):** do NOT call
+AskUserQuestion. Append a `spec-resolution-escalation` entry to
+`units/WU-<n>/cycle-log.md` (or feature-level cycle-log.md if not in a work
+unit) listing the brief title and the unmatched domains, set per-unit
+status.md substage → `escalated-spec-resolution` (or feature status.md in
+non-unit mode), return:
+```
+<slug>: ESCALATED — spec-resolution: no specs matched brief "<title>"
+```
+STOP. The coordinator (or user) triages spec selection.
+
+**Sequential/cost mode:**
 Use AskUserQuestion to offer:
 - "I'll re-invoke with --specs" — stop; user re-invokes
 - "Proceed without specs" — override: set SPEC_BUNDLE empty and continue

--- a/skills/vallorcine-help/SKILL.md
+++ b/skills/vallorcine-help/SKILL.md
@@ -113,8 +113,26 @@ command to run, then explain what it does and what the user can expect.
 <1-2 sentences of context: what it does, what to expect>
 ```
 
-If the question doesn't match any command, say so and suggest `/vallorcine-help`
-with no arguments to get routed interactively.
+If the question is conceptual or "how does this whole thing fit
+together?" rather than about a specific command — for example, "what's
+the difference between KB and ADRs?", "when do I use work groups?",
+"how do I get started on an existing codebase?" — point them at the
+repo-hosted onboarding guides instead of trying to answer inline:
+
+```
+That question is covered by the vallorcine onboarding guides on GitHub:
+
+  Overview + mental model:
+    https://github.com/telefrek/vallorcine/blob/main/GETTING-STARTED.md
+
+  Existing codebase adoption path:
+    https://github.com/telefrek/vallorcine/blob/main/GETTING-STARTED-EXISTING.md
+
+<1-2 sentences pointing at the specific section that answers their question>
+```
+
+If the question doesn't match any command or guide topic, say so and
+suggest `/vallorcine-help` with no arguments to get routed interactively.
 
 After answering, stop. Do not continue to the routing flow.
 
@@ -150,6 +168,13 @@ and configures everything automatically:
   /setup-vallorcine
 
 Then come back and run /vallorcine-help again.
+
+New to vallorcine? The GitHub repo has two onboarding guides that
+explain the mental model before you dive in:
+  - https://github.com/telefrek/vallorcine/blob/main/GETTING-STARTED.md
+    (overview of knowledge layers, feature pipeline, work groups)
+  - https://github.com/telefrek/vallorcine/blob/main/GETTING-STARTED-EXISTING.md
+    (for bringing vallorcine into a codebase with existing history)
 ```
 
 Stop.

--- a/tests/scenario-curate-drift.sh
+++ b/tests/scenario-curate-drift.sh
@@ -60,6 +60,7 @@ mkdir -p "$PROJECT/.claude/scripts" "$PROJECT/src/schema" "$PROJECT/tests/schema
 mkdir -p "$PROJECT/.spec/registry" "$PROJECT/.spec/domains/schema"
 
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$PROJECT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$PROJECT/.claude/scripts/"
 cp "$REPO_ROOT/scripts/spec-trace.sh" "$PROJECT/.claude/scripts/"
 chmod +x "$PROJECT/.claude/scripts/spec-trace.sh"
 
@@ -285,6 +286,7 @@ mkdir -p "$OB_PROJECT/.claude/scripts"
 mkdir -p "$OB_PROJECT/.spec/registry" "$OB_PROJECT/.spec/domains/widgets"
 
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$OB_PROJECT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$OB_PROJECT/.claude/scripts/"
 
 cat > "$OB_PROJECT/.spec/registry/manifest.json" << 'REGEOF'
 {
@@ -465,6 +467,7 @@ mkdir -p "$V1_PROJECT/.claude/scripts" "$V1_PROJECT/src"
 mkdir -p "$V1_PROJECT/.spec/registry" "$V1_PROJECT/.spec/domains/legacy"
 
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$V1_PROJECT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$V1_PROJECT/.claude/scripts/"
 cp "$REPO_ROOT/scripts/spec-trace.sh" "$V1_PROJECT/.claude/scripts/"
 chmod +x "$V1_PROJECT/.claude/scripts/spec-trace.sh"
 
@@ -529,6 +532,7 @@ cd "$REPO_ROOT"
 NO_SPEC="$TEST_BASE/project-no-spec"
 mkdir -p "$NO_SPEC/.claude/scripts"
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$NO_SPEC/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$NO_SPEC/.claude/scripts/"
 
 cd "$NO_SPEC"
 git init -q --initial-branch=main .

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -70,6 +70,7 @@ git -C "$PROJECT" config user.name "Test"
 # Install the scan script
 mkdir -p "$PROJECT/.claude/scripts"
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$PROJECT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$PROJECT/.claude/scripts/"
 
 # Create initial files
 mkdir -p "$PROJECT/src/auth" "$PROJECT/src/billing" "$PROJECT/src/utils" "$PROJECT/lib"
@@ -364,6 +365,7 @@ echo "── Test 12: Non-git directory"
 NO_GIT="$TEST_BASE/no-git"
 mkdir -p "$NO_GIT/.claude/scripts"
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$NO_GIT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$NO_GIT/.claude/scripts/"
 
 output="$(cd "$NO_GIT" && bash .claude/scripts/curate-scan.sh --init 2>&1)" || true
 if echo "$output" | grep -q "not a git repository"; then
@@ -595,6 +597,7 @@ git -C "$FRESH" commit -m "init" >/dev/null 2>&1
 
 mkdir -p "$FRESH/.claude/scripts"
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$FRESH/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$FRESH/.claude/scripts/"
 
 cd "$FRESH" && bash .claude/scripts/curate-scan.sh --init >/dev/null 2>&1
 
@@ -799,6 +802,7 @@ git -C "$ORPHAN_PROJECT" config user.name "Test"
 
 mkdir -p "$ORPHAN_PROJECT/.claude/scripts"
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$ORPHAN_PROJECT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$ORPHAN_PROJECT/.claude/scripts/"
 
 # Create source files first
 mkdir -p "$ORPHAN_PROJECT/src/auth"
@@ -979,6 +983,7 @@ mkdir -p "$OB_TEST_DIR/.spec/domains/engine"
 mkdir -p "$OB_TEST_DIR/.claude/scripts"
 
 cp "$REPO_ROOT/scripts/curate-scan.sh" "$OB_TEST_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$OB_TEST_DIR/.claude/scripts/"
 
 cd "$OB_TEST_DIR"
 git init -q .

--- a/tests/scenario-narrative.sh
+++ b/tests/scenario-narrative.sh
@@ -226,14 +226,22 @@ else
 fi
 
 # ── Test: generate.py graceful failure ───────────────────────────────────────
+#
+# Per commit 48d073c (2026-04-12), generate.{py,js} exit 1 on failure so the
+# wrapper can detect it, retry, and fall back. The contract is diagnostic on
+# stderr + exit 1 (not crash/exit 0). Capture via if/else to keep `set -e`
+# from killing the test on the expected nonzero exit.
 
 if [[ "$HAS_PYTHON" -eq 1 ]]; then
-    stderr=$(python3 "$NARRATIVE_DIR/generate.py" "nonexistent" "/tmp/vallorcine/no-such-dir" 2>&1)
-    exit_code=$?
-    if [[ "$exit_code" -eq 0 ]]; then
-        pass "generate.py exits 0 on missing dir"
+    if stderr=$(python3 "$NARRATIVE_DIR/generate.py" "nonexistent" "/tmp/vallorcine/no-such-dir" 2>&1); then
+        exit_code=0
     else
-        fail "generate.py exits 0 on missing dir" "exit code: $exit_code"
+        exit_code=$?
+    fi
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "generate.py exits 1 on missing dir"
+    else
+        fail "generate.py exits 1 on missing dir" "exit code: $exit_code"
     fi
     if [[ "$stderr" == *"not found"* ]]; then
         pass "generate.py logs diagnostic on missing dir"
@@ -247,12 +255,15 @@ fi
 # ── Test: generate.js graceful failure ───────────────────────────────────────
 
 if [[ "$HAS_NODE" -eq 1 ]]; then
-    stderr=$(node "$NARRATIVE_DIR/generate.js" "nonexistent" "/tmp/vallorcine/no-such-dir" 2>&1)
-    exit_code=$?
-    if [[ "$exit_code" -eq 0 ]]; then
-        pass "generate.js exits 0 on missing dir"
+    if stderr=$(node "$NARRATIVE_DIR/generate.js" "nonexistent" "/tmp/vallorcine/no-such-dir" 2>&1); then
+        exit_code=0
     else
-        fail "generate.js exits 0 on missing dir" "exit code: $exit_code"
+        exit_code=$?
+    fi
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "generate.js exits 1 on missing dir"
+    else
+        fail "generate.js exits 1 on missing dir" "exit code: $exit_code"
     fi
     if [[ "$stderr" == *"not found"* ]]; then
         pass "generate.js logs diagnostic on missing dir"
@@ -263,14 +274,20 @@ else
     skip "generate.js graceful failure (node not available)"
 fi
 
-# ── Test: wrapper exits 0 with no args ───────────────────────────────────────
+# ── Test: wrapper exits 3 with no args ───────────────────────────────────────
+#
+# narrative-wrapper.sh documents exit code 3 = missing arguments. See the
+# script's header comment for the full exit-code contract.
 
-bash "$REPO_ROOT/scripts/narrative-wrapper.sh" 2>/dev/null
-exit_code=$?
-if [[ "$exit_code" -eq 0 ]]; then
-    pass "narrative-wrapper.sh exits 0 with no args"
+if bash "$REPO_ROOT/scripts/narrative-wrapper.sh" 2>/dev/null; then
+    exit_code=0
 else
-    fail "narrative-wrapper.sh exits 0 with no args" "exit code: $exit_code"
+    exit_code=$?
+fi
+if [[ "$exit_code" -eq 3 ]]; then
+    pass "narrative-wrapper.sh exits 3 with no args (missing arguments)"
+else
+    fail "narrative-wrapper.sh exits 3 with no args" "exit code: $exit_code"
 fi
 
 # ── Test: Format guard on bad JSONL ──────────────────────────────────────────

--- a/tests/scenario-parallel-subagent-hang-prevention.sh
+++ b/tests/scenario-parallel-subagent-hang-prevention.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Scenario: pipeline skills must not hang in parallel-mode subagents.
+#
+# Two structural invariants defend against the 2026-04-23 WU-3 hang
+# (subagent completed its work but never emitted its final summary, so
+# the coordinator stayed blocked on the Agent tool call):
+#
+# 1. Every AskUserQuestion site in the skills a coordinator dispatches
+#    (/feature-test, /feature-implement, /feature-refactor) must either
+#    live under an `automation_mode: manual` branch (doesn't fire in
+#    parallel mode — coordinator always sets autonomous), or be preceded
+#    by a `balanced | speed` bypass that records to cycle-log + returns
+#    ESCALATED instead of waiting for input.
+#
+# 2. /feature-refactor's parallel-mode exit block must contain an
+#    explicit termination contract ("your next message MUST be the
+#    summary — no more tools"), and /feature-coordinate must document
+#    the subagent dispatch contract so coordinators embed it verbatim.
+#
+# This is a grep-based structural test: it doesn't exercise the runtime
+# coordinator, it validates that the SKILL.md files still contain the
+# mode-gating prose. If someone adds a new AskUserQuestion without
+# gating, this test fails fast.
+#
+# Run from repo root: bash tests/scenario-parallel-subagent-hang-prevention.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# ── Test helpers ─────────────────────────────────────────────────────────────
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: parallel subagent hang prevention"
+echo "────────────────────────────────────────────────"
+
+# ── Invariant 1: /feature-coordinate carries the dispatch contract ───────────
+
+echo ""
+echo "── Invariant 1: /feature-coordinate dispatch contract"
+
+coord_skill="$REPO_ROOT/skills/feature-coordinate/SKILL.md"
+
+if grep -q "Subagent dispatch contract" "$coord_skill" && \
+   grep -q "Termination contract" "$coord_skill" && \
+   grep -q "Return format" "$coord_skill"; then
+    pass "/feature-coordinate documents Subagent dispatch + Termination + Return format"
+else
+    fail "/feature-coordinate missing dispatch contract sections" \
+         "expected: 'Subagent dispatch contract' + 'Termination contract' + 'Return format'"
+fi
+
+if grep -q "2026-04-23" "$coord_skill"; then
+    pass "/feature-coordinate references the 2026-04-23 hang root-cause"
+else
+    fail "/feature-coordinate should document the hang root-cause date"
+fi
+
+# ── Invariant 2: /feature-refactor parallel-mode exit is strict ──────────────
+
+echo ""
+echo "── Invariant 2: /feature-refactor parallel-mode termination contract"
+
+refactor_skill="$REPO_ROOT/skills/feature-refactor/SKILL.md"
+
+# The parallel-mode exit block must tell the subagent to emit the summary
+# IMMEDIATELY after marking status.md complete — no more tools.
+parallel_block="$(sed -n '/Subagent termination contract/,/Emit that block as your final message/p' "$refactor_skill")"
+
+if [[ -n "$parallel_block" ]]; then
+    pass "refactor parallel-mode exit has termination contract block"
+else
+    fail "refactor parallel-mode exit missing termination contract" \
+         "expected 'Subagent termination contract' + 'Emit that block as your final message'"
+fi
+
+if echo "$parallel_block" | grep -q "no more Read, Bash, Grep, Edit"; then
+    pass "termination contract explicitly lists forbidden post-completion tools"
+else
+    fail "termination contract should enumerate forbidden tools"
+fi
+
+if echo "$parallel_block" | grep -q "WU-3"; then
+    pass "termination contract cites WU-3 hang evidence"
+else
+    fail "termination contract should cite the WU-3 concrete case"
+fi
+
+# ── Invariant 3: AskUserQuestion sites are mode-gated or manual-only ─────────
+
+echo ""
+echo "── Invariant 3: AskUserQuestion sites gated for parallel mode"
+
+# For each AskUserQuestion line in the 3 pipeline skills, check that it is
+# EITHER:
+#   (a) preceded (within 30 lines above) by a `balanced | speed` bypass
+#   (b) under an `automation_mode: manual` block (within 20 lines above)
+# Otherwise it's a potential hang point in a parallel subagent.
+
+check_aukq_gated() {
+    local file="$1"
+    local name="$2"
+    local ungated=0
+    local ungated_lines=""
+
+    while IFS= read -r ln; do
+        local above_start=$((ln - 30))
+        (( above_start < 1 )) && above_start=1
+        local context
+        context="$(sed -n "${above_start},${ln}p" "$file")"
+
+        # (a) parallel-mode bypass within 30 lines above
+        if echo "$context" | grep -qE 'balanced.*speed|speed.*balanced|execution_strategy.*balanced'; then
+            continue
+        fi
+        # (b) manual-mode-only branch within 20 lines above.
+        #     Authoritative markers: explicit automation_mode text, a
+        #     "Sequential/cost mode:" bypass header, or the prose
+        #     "— Manual:" subheading used within already-mode-gated
+        #     sections like "sequential/cost mode only".
+        local manual_start=$((ln - 20))
+        (( manual_start < 1 )) && manual_start=1
+        local manual_ctx
+        manual_ctx="$(sed -n "${manual_start},${ln}p" "$file")"
+        if echo "$manual_ctx" | grep -qE 'automation_mode.*manual|Sequential/cost mode|`manual` \(or not set\)|^— Manual:|^\*\*If `automation_mode: manual`'; then
+            continue
+        fi
+
+        ungated=$((ungated + 1))
+        ungated_lines="${ungated_lines}${ln} "
+    done < <(grep -n "^Use AskUserQuestion\|^[[:space:]]*Use AskUserQuestion" "$file" | cut -d: -f1)
+
+    if (( ungated == 0 )); then
+        pass "$name: all AskUserQuestion sites are mode-gated"
+    else
+        fail "$name: $ungated ungated AskUserQuestion site(s)" \
+             "lines: $ungated_lines — each must be preceded by a parallel-mode bypass or live under a manual-only branch"
+    fi
+}
+
+check_aukq_gated "$REPO_ROOT/skills/feature-test/SKILL.md" "/feature-test"
+check_aukq_gated "$REPO_ROOT/skills/feature-implement/SKILL.md" "/feature-implement"
+check_aukq_gated "$REPO_ROOT/skills/feature-refactor/SKILL.md" "/feature-refactor"
+
+# ── Invariant 4: Mode-gate clauses include escalation semantics ──────────────
+
+echo ""
+echo "── Invariant 4: parallel-mode bypasses write to cycle-log + return ESCALATED"
+
+# Each skill that has parallel-mode bypass blocks should consistently
+# record an escalation entry and mark substage `escalated-*` before
+# returning. Check that the pattern appears in each file that has a
+# bypass.
+
+check_escalation_pattern() {
+    local file="$1"
+    local name="$2"
+    if ! grep -q "balanced.*speed\|speed.*balanced" "$file"; then
+        pass "$name: no parallel-mode bypasses (skill not used via coordinator)"
+        return
+    fi
+    if grep -q "escalated-" "$file" && grep -q "ESCALATED" "$file"; then
+        pass "$name: parallel bypasses set substage 'escalated-*' and return ESCALATED"
+    else
+        fail "$name: parallel bypasses missing escalation markers" \
+             "expected both 'escalated-<kind>' substage writes and 'ESCALATED' return text"
+    fi
+}
+
+check_escalation_pattern "$REPO_ROOT/skills/feature-test/SKILL.md" "/feature-test"
+check_escalation_pattern "$REPO_ROOT/skills/feature-refactor/SKILL.md" "/feature-refactor"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+    exit 0
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+    exit 1
+fi

--- a/tests/scenario-pipeline-modes.sh
+++ b/tests/scenario-pipeline-modes.sh
@@ -64,6 +64,7 @@ mkdir -p "$TEST_BASE/project/.claude/scripts"
 
 # Copy scripts
 cp "$REPO_ROOT/scripts/work-lib.sh" "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$TEST_BASE/project/.claude/scripts/"
 cp "$REPO_ROOT/scripts/work-resolve.sh" "$TEST_BASE/project/.claude/scripts/"
 cp "$REPO_ROOT/scripts/work-validate.sh" "$TEST_BASE/project/.claude/scripts/"
 

--- a/tests/scenario-spec-resolve.sh
+++ b/tests/scenario-spec-resolve.sh
@@ -431,6 +431,177 @@ else
     fail "F01 should load even when F99 is unknown" "got: $output_mixed"
 fi
 
+# ── Test 12-16: v2 manifest schema compatibility ────────────────────────────
+# Regression for the v2 migration gap (post-2026-04-20): spec-resolve.sh
+# previously used `.features | keys[]` and `.domains | keys[]` jq queries
+# that return null on a v2 manifest, causing `set -euo pipefail` failures
+# and spurious NEEDS_DOMAIN_INFERENCE emissions.
+
+echo ""
+echo "── v2 manifest compatibility ────────────────────"
+
+V2_ROOT="$TEST_BASE/project-v2"
+mkdir -p "$V2_ROOT/.spec/registry" "$V2_ROOT/.spec/domains/serialization"
+mkdir -p "$V2_ROOT/.claude/scripts"
+cp "$REPO_ROOT/scripts/spec-resolve.sh" "$V2_ROOT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$V2_ROOT/.claude/scripts/"
+
+# v2 manifest: .specs[] array, .path instead of .latest_file, no .domains map.
+cat > "$V2_ROOT/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "generated_at": "2026-04-23T00:00:00Z",
+  "spec_count": 2,
+  "specs": [
+    {
+      "id": "serialization.yaml-support",
+      "path": ".spec/domains/serialization/yaml-support.md",
+      "state": "APPROVED",
+      "version": 1,
+      "domains": ["serialization"],
+      "requires": [],
+      "invalidates": [],
+      "decision_refs": [],
+      "kb_refs": []
+    },
+    {
+      "id": "serialization.json-parsing",
+      "path": ".spec/domains/serialization/json-parsing.md",
+      "state": "APPROVED",
+      "version": 1,
+      "domains": ["serialization"],
+      "requires": [],
+      "invalidates": [],
+      "decision_refs": [],
+      "kb_refs": []
+    }
+  ]
+}
+EOF
+
+cat > "$V2_ROOT/.spec/domains/serialization/yaml-support.md" << 'EOF'
+---
+{
+  "id": "serialization.yaml-support",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["serialization"],
+  "amends": [],
+  "amended_by": [],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": [],
+  "open_obligations": []
+}
+---
+
+# serialization.yaml-support — YAML Support
+
+## Requirements
+R1. The serialization layer must accept YAML input.
+EOF
+
+cat > "$V2_ROOT/.spec/domains/serialization/json-parsing.md" << 'EOF'
+---
+{
+  "id": "serialization.json-parsing",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["serialization"],
+  "amends": [],
+  "amended_by": [],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": [],
+  "open_obligations": []
+}
+---
+
+# serialization.json-parsing — JSON Parsing
+
+## Requirements
+R1. The serialization layer must accept JSON input.
+EOF
+
+cd "$V2_ROOT"
+
+# ── Test 12: v2 manifest — no jq error under set -euo pipefail ──────────────
+
+echo ""
+echo "── Test 12: v2 manifest produces no jq null-has-no-keys error"
+
+v2_stderr="$(bash .claude/scripts/spec-resolve.sh "serialization format" 8000 2>&1 >/dev/null)"
+if echo "$v2_stderr" | grep -q "null (null) has no keys"; then
+    fail "v2 manifest must not trigger jq null-traversal error" "stderr: $v2_stderr"
+else
+    pass "v2 manifest does not emit jq schema-mismatch error"
+fi
+
+# ── Test 13: v2 manifest — domain name matching works ──────────────────────
+
+echo ""
+echo "── Test 13: v2 fuzzy match finds specs by domain name"
+
+v2_output="$(bash .claude/scripts/spec-resolve.sh "serialization format" 8000 2>/dev/null)"
+if echo "$v2_output" | grep -q "serialization.yaml-support" \
+    && echo "$v2_output" | grep -q "serialization.json-parsing"; then
+    pass "v2 fuzzy match loads both specs by domain name"
+else
+    fail "v2 fuzzy match should surface both specs" "got: $v2_output"
+fi
+
+# ── Test 14: v2 manifest — NEEDS_DOMAIN_INFERENCE graceful fallback ────────
+# Feature description with no domain-name hits should cleanly fall through
+# to the inference-needed path (not die with a jq error).
+
+echo ""
+echo "── Test 14: v2 NEEDS_DOMAIN_INFERENCE fallback is graceful"
+
+v2_nomatch_stderr="$(bash .claude/scripts/spec-resolve.sh "completely unrelated thing" 8000 2>&1 >/dev/null)"
+v2_nomatch_stdout="$(bash .claude/scripts/spec-resolve.sh "completely unrelated thing" 8000 2>/dev/null)"
+if echo "$v2_nomatch_stderr" | grep -q "NEEDS_DOMAIN_INFERENCE=true"; then
+    pass "NEEDS_DOMAIN_INFERENCE=true signal emitted"
+else
+    fail "should emit NEEDS_DOMAIN_INFERENCE on no match" "stderr: $v2_nomatch_stderr"
+fi
+
+if echo "$v2_nomatch_stdout" | grep -q "serialization"; then
+    pass "available-domains list includes v2 domain"
+else
+    fail "partial bundle should list v2 domains" "stdout: $v2_nomatch_stdout"
+fi
+
+# ── Test 15: v2 manifest — EXPLICIT_SPEC_IDS with domain.slug format ───────
+
+echo ""
+echo "── Test 15: EXPLICIT_SPEC_IDS works with v2 domain.slug IDs"
+
+v2_explicit="$(EXPLICIT_SPEC_IDS="serialization.yaml-support" \
+    bash .claude/scripts/spec-resolve.sh "anything" 8000 2>/dev/null)"
+if echo "$v2_explicit" | grep -q "serialization.yaml-support"; then
+    pass "explicit domain.slug ID resolves in v2 manifest"
+else
+    fail "explicit ID should load in v2" "got: $v2_explicit"
+fi
+
+# ── Test 16: v2 manifest — OVERRIDE_DOMAINS selects from v2 specs ──────────
+
+echo ""
+echo "── Test 16: OVERRIDE_DOMAINS filters v2 specs correctly"
+
+v2_override="$(OVERRIDE_DOMAINS="serialization" \
+    bash .claude/scripts/spec-resolve.sh "x" 8000 2>/dev/null)"
+if echo "$v2_override" | grep -q "serialization.yaml-support" \
+    && echo "$v2_override" | grep -q "serialization.json-parsing"; then
+    pass "OVERRIDE_DOMAINS loads both v2 specs"
+else
+    fail "OVERRIDE_DOMAINS should load serialization specs" "got: $v2_override"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/scenario-version-skew.sh
+++ b/tests/scenario-version-skew.sh
@@ -88,7 +88,7 @@ git -C "$PROJECT" commit -m "start feature work" >/dev/null 2>&1
 git -C "$PROJECT" checkout main >/dev/null 2>&1
 echo "99.99.99" > "$PROJECT/.claude/.vallorcine-version"
 # Add a marker to a command file to detect staleness
-echo "# upgraded-marker" >> "$PROJECT/.claude/commands/quick.md"
+echo "# upgraded-marker" >> "$PROJECT/.claude/skills/feature-quick/SKILL.md"
 git -C "$PROJECT" add -A
 git -C "$PROJECT" commit -m "upgrade vallorcine to v99.99.99" >/dev/null 2>&1
 
@@ -110,9 +110,9 @@ else
     fail "versions should differ" "both are $BRANCH_STAMP"
 fi
 
-# Check that the command file on the branch lacks the upgrade marker
-if ! grep -q "upgraded-marker" "$PROJECT/.claude/commands/quick.md" 2>/dev/null; then
-    pass "feature branch has stale command files"
+# Check that the skill file on the branch lacks the upgrade marker
+if ! grep -q "upgraded-marker" "$PROJECT/.claude/skills/feature-quick/SKILL.md" 2>/dev/null; then
+    pass "feature branch has stale skill files"
 else
     fail "feature branch should have stale files" "upgrade marker found"
 fi
@@ -136,11 +136,11 @@ else
     fail "upgrade should set version to $VERSION" "got: $NEW_STAMP"
 fi
 
-# Verify command files were updated
-if [[ -f "$PROJECT/.claude/commands/quick.md" ]]; then
-    pass "command files present after upgrade"
+# Verify skill files were updated
+if [[ -f "$PROJECT/.claude/skills/feature-quick/SKILL.md" ]]; then
+    pass "skill files present after upgrade"
 else
-    fail "command files should exist after upgrade"
+    fail "skill files should exist after upgrade"
 fi
 
 # ── Assert: version comparison works correctly ───────────────────────────────

--- a/tests/scenario-work-context.sh
+++ b/tests/scenario-work-context.sh
@@ -57,6 +57,7 @@ mkdir -p "$TEST_BASE/project/.claude/scripts"
 # Copy scripts
 cp "$REPO_ROOT/scripts/work-context.sh" "$TEST_BASE/project/.claude/scripts/"
 cp "$REPO_ROOT/scripts/work-lib.sh" "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$TEST_BASE/project/.claude/scripts/"
 
 # ── Test 1: No .work/ directory → empty output ──────────────────────────────
 

--- a/tests/scenario-work-pipeline.sh
+++ b/tests/scenario-work-pipeline.sh
@@ -214,10 +214,10 @@ echo "── Test 5: WD completion triggers readiness cascade"
 # Complete WD-01 and create the spec it produces
 sed -i 's/^status: IN_PROGRESS/status: COMPLETE/' .work/auth-migration/WD-01.md
 
-cat > .spec/domains/auth/F01-jwt-token-contract.md << 'EOF'
+cat > .spec/domains/auth/jwt-token-contract.md << 'EOF'
 ---
 {
-  "id": "F01",
+  "id": "auth/jwt-token-contract",
   "version": 1,
   "status": "ACTIVE",
   "state": "APPROVED",
@@ -230,7 +230,7 @@ cat > .spec/domains/auth/F01-jwt-token-contract.md << 'EOF'
 }
 ---
 
-# F01 — JWT Token Contract
+# JWT Token Contract
 
 ## Requirements
 R1. JWT tokens created with configurable claims.
@@ -241,18 +241,23 @@ R1. JWT tokens created with configurable claims.
 Token format.
 EOF
 
+# v2 manifest schema — `specs` array keyed by domain-slug IDs. v1's
+# `features{}` object keyed by "FNN" IDs cannot resolve v2-style
+# artifact_deps like `auth/jwt-token-contract`.
 cat > .spec/registry/manifest.json << 'EOF'
 {
+  "schema_version": 2,
   "domains": {
     "auth": { "description": "authentication", "feature_count": 1 }
   },
-  "features": {
-    "F01": {
-      "latest_file": "domains/auth/F01-jwt-token-contract.md",
+  "specs": [
+    {
+      "id": "auth/jwt-token-contract",
+      "path": "domains/auth/jwt-token-contract.md",
       "state": "APPROVED",
       "domains": ["auth"]
     }
-  }
+  ]
 }
 EOF
 
@@ -329,15 +334,75 @@ else
 fi
 
 # ── Test 10: Validate all WDs still pass validation after status changes ─────
+#
+# work-validate.sh resolves artifact_dep references against the manifest
+# (commit 2e15cdc). WD-02 declared `produces: auth/token-validator` and
+# WD-03 depends on it with required_state: APPROVED. Completing WD-02 in
+# production registers the produced spec — mirror that here so Test 10 is
+# checking validation against a realistic end-state, not a half-registered one.
+
+cat > .spec/domains/auth/token-validator.md << 'EOF'
+---
+{
+  "id": "auth/token-validator",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": [],
+  "open_obligations": []
+}
+---
+
+# Token Validator
+
+## Requirements
+R1. Interface contract for validating JWT tokens in middleware.
+
+---
+
+## Design Narrative
+Interface-contract spec produced by WD-02.
+EOF
+
+cat > .spec/registry/manifest.json << 'EOF'
+{
+  "schema_version": 2,
+  "domains": {
+    "auth": { "description": "authentication", "feature_count": 2 }
+  },
+  "specs": [
+    {
+      "id": "auth/jwt-token-contract",
+      "path": "domains/auth/jwt-token-contract.md",
+      "state": "APPROVED",
+      "domains": ["auth"]
+    },
+    {
+      "id": "auth/token-validator",
+      "path": "domains/auth/token-validator.md",
+      "state": "APPROVED",
+      "domains": ["auth"]
+    }
+  ]
+}
+EOF
 
 echo ""
 echo "── Test 10: WDs valid after status lifecycle changes"
 
 all_valid=true
 for wd in .work/auth-migration/WD-*.md; do
-    output="$(bash .claude/scripts/work-validate.sh "$wd" 2>&1)"
-    if ! echo "$output" | grep -q "PASS"; then
-        fail "validation failed for $(basename "$wd")" "got: $output"
+    if output="$(bash .claude/scripts/work-validate.sh "$wd" 2>&1)"; then
+        if ! echo "$output" | grep -q "PASS"; then
+            fail "validation failed for $(basename "$wd")" "got: $output"
+            all_valid=false
+        fi
+    else
+        fail "validation exited nonzero for $(basename "$wd")" "got: $output"
         all_valid=false
     fi
 done


### PR DESCRIPTION
## Summary

Three workstreams that accumulated between v0.14.2 and today (2026-04-23), collapsed into one PR for reviewability. Seven commits, split by intent:

**Fixes (3 commits):**
- `fix(spec): v2 manifest schema compatibility across spec/work/curate scripts` — dual-schema read-path helpers in `spec-lib.sh`, unblocks `/work-start`, `/spec-write`, `/feature-plan`, `/feature-test`, `/spec-author`, `/audit` on v2 repos.
- `fix(tests): close four pre-existing scenario-test failures` — `scenario-index-verify` arithmetic bug, `scenario-narrative` stale exit-code assertions, `scenario-version-skew` legacy install-layout reference, `scenario-work-pipeline` v1-manifest fixture.
- `fix(pipeline): prevent parallel-subagent hangs — mode-gated prompts + strict termination` — mode-gates every unconditional `AskUserQuestion` in the three pipeline skills so parallel subagents bypass to `cycle-log` + `escalated-<reason>` substage + `ESCALATED` return instead of hanging on a missing human. Strengthens `/feature-refactor`'s parallel exit with an explicit termination contract. Adds subagent dispatch contract to `/feature-coordinate`. Root-caused from the 2026-04-23 jlsm WU-3 hang.

**Docs (4 commits):**
- `docs: freshness pass through v0.14.2 + held branches` — CONTEXT.md refresh, 7 decisions graduated to SETTLED.md, DEFERRED marked security-aware lens as done.
- `docs: add GETTING-STARTED + GETTING-STARTED-EXISTING onboarding guides` — two new repo-only docs (316 + 333 lines) for people landing on the GitHub page. Not shipped via MANIFEST. README gains a "New here?" link section; `/vallorcine-help` gains URL hints for conceptual questions.
- `docs: spot-check fixes for EXAMPLES + COMPETITIVE + GETTING-STARTED` — verified docs against actual skill/script behavior; corrected the `.spec/` bug in GETTING-STARTED; added `/feature-harden` to the EXAMPLES walkthrough; added four new example sections (parallel coordinator, spec workflow, standalone `/audit`, `/capabilities`); updated COMPETITIVE's "Closed gaps" with v0.14.2 shipments; fixed the `.claude/rules/kit-development.md` user-facing list (was missing `/feature-harden`, `/capabilities`).
- `docs(context): reconcile post-branch-collapse framing` — tiny edit updating CONTEXT's "held for PR" references now that the branches are collapsed into this one.

## What's new for users

- Unbreaking v2-schema projects (scripts that silently failed under `set -euo pipefail`).
- Parallel feature work (`/feature-coordinate`, `/work-start --parallel`) will no longer hang when a pipeline skill would have asked the subagent a question.
- Two onboarding guides on the GitHub repo for people evaluating the kit:
  - [GETTING-STARTED.md](GETTING-STARTED.md) — mental model + decision tree.
  - [GETTING-STARTED-EXISTING.md](GETTING-STARTED-EXISTING.md) — slow-adoption path for brownfield projects.

## Test plan

- [x] `bash tests/test-install.sh` — 59/59 pass.
- [x] `bash tests/scenario-index-verify.sh` — pass (12/12).
- [x] `bash tests/scenario-narrative.sh` — pass (16/16).
- [x] `bash tests/scenario-version-skew.sh` — pass (7/7).
- [x] `bash tests/scenario-work-pipeline.sh` — pass (11/11).
- [x] `bash tests/scenario-parallel-subagent-hang-prevention.sh` — new regression test, pass (10/10 structural invariants).
- [x] User-facing command list in docs cross-checked against `.claude/rules/kit-development.md`.
- [x] MANIFEST unchanged (no new installable files — both getting-started docs are repo-only).

## After merge

Cut v0.14.3. `.changelog-staging.md` already carries the two fix entries; `/release` will bundle them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)