### PR TITLE
fix(audit): make KB and prior prove-fix information actionable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,12 +20,13 @@ state of the project — what's happening now and what's next.
 
 ## Current focus
 
-*Last updated: 2026-04-23*
+*Last updated: 2026-04-24*
 
-**v0.14.2 shipped. GSD-gap capabilities landed. Post-v0.14.2 bundle
-(manifest-v2 compat + parallel-subagent hang prevention + doc refresh +
-getting-started guides) collapsed into a single PR on
-`chore/v0.14.3-bundle`.**
+**v0.14.3 shipped (main@`f23cc79`). Active branch `fix/kb-scan-actionable`
+— three coordinated fixes that make `.kb/` actionable across the
+coordinator, audit Suspect, and audit prove-fix. PR not yet opened; two
+follow-on investigations running on the same jlsm session (other
+workflow deviations, audit cost-per-bug) before cutting the PR.**
 
 ### What's shipped since 2026-04-21
 
@@ -175,17 +176,55 @@ exists, not yet coded. No tag = needs both design and implementation.*
 
 ### Do next
 
-**Merge `chore/v0.14.3-bundle` (this PR), then cut v0.14.3.** The
-`.changelog-staging.md` entries for both fix commits are already in
-place; the doc changes are additive. After merge, `/release` will pick
-up the staged notes and bundle them.
+**Wrap the `fix/kb-scan-actionable` investigation, then open the PR.**
 
-**Positioning shift to encode across user-facing docs** (README,
-EXAMPLES.md, landing content, the new getting-started docs): emphasize
-the depth-of-spec-rigor axis (lifecycle, displacement, audit
-integration, computed readiness) over the "spec-driven" label. GSD owns
-the spec-driven label at 55K+ stars. The GETTING-STARTED docs are the
-first place to seed this framing.
+The morning's WIP framing (KB isn't being loaded) was half-right. The
+shipped fix covers three distinct failure modes uncovered empirically
+on jlsm session `763f30a6-4194-4137-812f-97502540135e`:
+
+| Surface | Subagents | Empirical finding | Fix shipped |
+|---|---:|---|---|
+| WU-TDD coordinator dispatch | 4 | All 4 dispatch prompts omit Step 8 entirely (zero KB keywords across 39K chars) | `/feature-coordinate` Step 1a now carries a **KB tendency-scan contract (MANDATORY)** fragment; Step 8 is MANDATORY with `tendency-scan-complete` substage + cycle-log append; coordinator-side verification greps for evidence post-return |
+| Audit Suspect | 27 | KB *does* flow through to packet (17/17 have KB content) — Suspect treats it as passive reference, not attack vectors; 2/95 findings cite KB | `suspect.md` adds a KB attack-pattern sweep step; finding schema gets `KB refs:`; summary reports `KB-driven` count |
+| Audit prove-fix | 83 | `prove-fix.md` has zero KB integration; 0/95 outputs cite KB | `prove-fix.md` Phase 1a1 KB fix-pattern lookup; `kb_refs` input/output; orchestrator forwards `kb_refs` per finding |
+
+The workflow-deviation scan also surfaced **D4: Phase 0 short-circuit
+bypassed for upstream-mitigated findings** — 16 of 36 IMPOSSIBLE
+returns on the jlsm run were mitigated by a prior prove-fix's upstream
+guard, but Phase 0 only checked the local construct and the agent went
+through full Phase 1 anyway. Bundled on this branch: `prove-fix.md`
+Phase 0 budget raised 2 → 4 turns, new 0c "upstream-mitigation check"
+reads up to 2 sibling `prove-fix-*.md` outputs and short-circuits to
+`IMPOSSIBLE / UPSTREAM_MITIGATED` when a caller-side guard blocks the
+attack path.
+
+Status: 22/22 regression invariants pass, 59/59 install tests pass,
+all related audit scenarios green (lens-security 23/23, state-gate 5/5,
+wontfix-obligation 5/5, aggregate-results 32/32, check-test-coverage
+13/13, dedup-findings 12/12), no regressions on hang-prevention
+scenario (10/10).
+
+**Cost-per-bug snapshot (Opus 4.7 API rates):** jlsm audit total
+$1,333, 95 findings, **$14.03/finding** (on trend with 7-audit historical
+$13.61 avg). Prove-fix is 82% of audit-subagent cost. D4 targets ~11%
+prove-fix waste (~$86/audit at this size); KB-actionable fixes
+(D1-D3) target another ~15-25% of findings that should pre-clear.
+Combined ceiling: projected $/finding floor ~$11 on audits with
+similar KB density.
+
+Non-findings verified: the initial "Suspect writing test files" signal
+was a classifier bug (prove-fix dispatch prompts reference
+`Suspect: <filename>`); TodoWrite discipline holding (0 subagent
+violations). Context thrash (D5 — 37/126 agents re-read same file 5+
+times) is intentional per the re-read-before-edit protocol; revisit
+only if post-D4 cost data shows it's still material.
+
+**Next: open the PR.**
+
+**Positioning shift (still outstanding — carries over from v0.14.3):**
+emphasize depth-of-spec-rigor axis over the "spec-driven" label across
+user-facing docs. Not a blocker for the current PR; bundle with the
+next docs pass.
 
 ### Do soon (medium effort, clear designs)
 

--- a/prompts/audit/prove-fix-orchestrator.md
+++ b/prompts/audit/prove-fix-orchestrator.md
@@ -48,8 +48,13 @@ Process findings ONE AT A TIME. For each finding:
    - Suspect file: .feature/float16-vector-support/[suspect filename]
      (your finding only — [finding ID])
    - Cluster packet: .feature/float16-vector-support/[matching packet file]
+   - kb_refs: [comma-separated paths from the finding's `KB refs` field, or "none"]
    - Write output to: .feature/float16-vector-support/prove-fix-[short-id].md
    ```
+
+   Extract `kb_refs` from the Suspect finding's `**KB refs:**` line. When the
+   finding has `KB refs: none`, pass `kb_refs: none` verbatim. When it lists
+   paths, pass them comma-separated so prove-fix can read them in Phase 1a1.
 
    For the short-id in the output filename, use the finding ID with dots
    replaced by dashes (e.g., F-R5.cb.1.1 → prove-fix-F-R5-cb-1-1.md).

--- a/prompts/audit/prove-fix.md
+++ b/prompts/audit/prove-fix.md
@@ -16,17 +16,24 @@ The orchestrator provides:
 - Domain lens (shared_state, contract_boundaries, etc.)
 - Test class path (shared adversarial test class for this lens)
 - Cluster packet path (for construct context)
+- `kb_refs` — KB entry paths that informed the finding (may be "none"). When
+  present, these are the authoritative source for fix guidance — read them
+  in Phase 1a before writing the test.
 
-## Phase 0 — ALREADY-FIXED CHECK (mandatory, max 2 turns)
+## Phase 0 — ALREADY-FIXED CHECK (mandatory, max 4 turns)
 
 Before writing any test, check whether prior fixes in this audit run have
 already resolved this finding. Findings are processed sequentially — earlier
 fixes may have added guards, rollback logic, or exception handling that
-make later findings moot.
+make later findings moot, either *locally* (defense added to this
+construct) or *upstream* (defense added to a caller or guard that
+intercepts the attack input before it reaches this construct).
 
-**Budget: 2 turns maximum.** Turn 1: read the source. Turn 2: write the
-output file (if ALREADY_FIXED) or proceed to Phase 1 (if STILL_VULNERABLE).
-Do NOT read any file other than the construct source in Phase 0.
+**Budget: 4 turns maximum.** Turn 1: read the source. Turn 2: decide
+local defense. Turns 3–4 (only if local defense is absent): scan and read
+at most 2 prior prove-fix outputs for upstream mitigation. Do NOT read
+any file other than the construct source and `prove-fix-*.md` files in
+the same run directory during Phase 0.
 
 ### 0a. Read current source
 
@@ -34,7 +41,7 @@ Read the construct source at the file path and line range from the finding.
 Read it NOW — do not reuse any cached view. The code may have changed
 since the finding was written.
 
-### 0b. Check for the described vulnerability
+### 0b. Check for the described vulnerability locally
 
 The finding describes a specific vulnerability — a missing guard, an
 unchecked cast, a missing rollback, a race condition. Check whether the
@@ -49,14 +56,58 @@ current source code **already has the defense** the finding says is missing:
 - If the finding says "race condition on X" → check if X is now a
   concurrent data structure or has synchronization
 
-### 0c. Decide
+If the local defense is present, go to 0d with result `ALREADY_FIXED`.
 
-**Vulnerability still present:** The described bug exists in the current
-source. Proceed to Phase 1.
+### 0c. Check for upstream mitigation by a prior prove-fix
 
-**Vulnerability already fixed:** The current source already has the
-defense. Short-circuit to IMPOSSIBLE immediately — do NOT read any
-other files, do NOT run git blame, do NOT check test classes:
+If 0b found **no local defense**, do NOT immediately conclude
+`STILL_VULNERABLE`. Many findings that look vulnerable in isolation are
+actually mitigated by a prior prove-fix that added a guard in a caller
+(validation at the entry point, bounds check before dispatch, early
+throw on bad input). Empirical data: on a 95-finding jlsm audit run,
+~17% of findings were upstream-mitigated but reached Phase 1 anyway
+because Phase 0 only checked the construct itself, costing ~11% of
+prove-fix budget per audit.
+
+Do this check exactly once, with a hard 2-file cap:
+
+1. List the other `prove-fix-*.md` files in the same run directory
+   (sibling of your output path). Cheap `ls` / Glob — do NOT read them yet.
+2. From your finding, identify the **attack entry points**: the method
+   signatures a caller would invoke to reach the buggy path (often named
+   in the finding's "Attack" line, or visible at the top of the construct
+   source you just read). Callers above those entry points are where an
+   upstream guard could live.
+3. Scan the filename list for prior findings on constructs that plausibly
+   invoke or wrap your construct (name overlap, same package, same lens,
+   adjacent cluster). Pick AT MOST 2 candidates — prefer the ones most
+   recently completed and whose construct name appears in your source's
+   imports or call chain.
+4. Read the candidates' `Phase 2: Fix` / `Diff` sections only. For each,
+   ask: does the fix block the attack input from reaching my construct?
+   Concrete signs:
+   - A new validation / null-check / size guard at the caller
+   - A new early-throw on the input condition the finding exploits
+   - A new synchronized/locked region that serialises access such that
+     the race you'd need can't occur
+
+If yes → `UPSTREAM_MITIGATED`. Record the prior finding ID and the
+specific line range of the guard.
+
+If no → `STILL_VULNERABLE`. Proceed to Phase 1.
+
+If the 2-file budget is exhausted without finding a match → default to
+`STILL_VULNERABLE` and proceed to Phase 1. Do not read a third file.
+
+### 0d. Decide
+
+**Vulnerability still present (`STILL_VULNERABLE`):** The described bug
+exists in the current source and no upstream prior fix blocks the attack
+path. Proceed to Phase 1.
+
+**Vulnerability already fixed locally (`ALREADY_FIXED`):** The current
+source has the defense. Short-circuit to IMPOSSIBLE immediately — do NOT
+read any other files, do NOT run git blame, do NOT check test classes:
 
 1. Note which lines contain the defense (you already see them from 0a)
 2. Write the output file with:
@@ -64,13 +115,23 @@ other files, do NOT run git blame, do NOT check test classes:
    - Phase 0 result: ALREADY_FIXED
    - Phase 0 detail: "<defense type> at lines <N-M>" (one sentence)
    - Phase 1 result: "Skipped — vulnerability already fixed in current source"
-3. STOP. Do not write a test. Do not proceed to Phase 1. Do not
-   investigate which prior finding added the fix — that is the
-   orchestrator's concern, not yours.
+3. STOP.
 
-**Uncertain:** If the source read in 0a doesn't make the answer obvious,
-proceed to Phase 1 immediately. Do not investigate further — the test
-will determine the truth.
+**Vulnerability mitigated upstream (`UPSTREAM_MITIGATED`):** A prior
+prove-fix in this run added a caller-side or entry-guard that blocks the
+attack path. Short-circuit to IMPOSSIBLE:
+
+1. Write the output file with:
+   - Result: IMPOSSIBLE
+   - Phase 0 result: UPSTREAM_MITIGATED
+   - Phase 0 detail: "Attack path blocked by <prior finding ID> at
+     <file:lines> — <how the guard blocks this input>"
+   - Phase 1 result: "Skipped — attack input intercepted upstream"
+2. STOP. Do not read further construct source, do not attempt Phase 1.
+
+**Uncertain:** If you genuinely cannot decide from 0a–0c within the
+4-turn budget, proceed to Phase 1 immediately. Phase 1's test will
+determine the truth. Do not burn additional Phase 0 turns.
 
 ---
 
@@ -85,6 +146,28 @@ without either a Phase 0 proof or a test that compiles and runs.
 Read the construct source using offset/limit with the line range from
 the finding. You are reading to understand the API — types, method
 signatures, constructors, required setup.
+
+### 1a1. KB fix-pattern lookup (when kb_refs present)
+
+If the finding's `kb_refs` lists one or more `.kb/` entry paths, read them
+before writing the test or fix. These entries encode the project's prior
+experience with this class of bug — they commonly include:
+
+- `## Test guidance` — the adversarial test shape that reliably triggers
+  the pattern (inputs, setup, assertions). Use this as your test template.
+- `## Fix pattern` / recommended mitigation — the canonical defense for
+  this pattern (e.g., "wrap SecretKeySpec lifetime in try-with-resources",
+  "use AES-GCM with 96-bit random IV, never reuse"). Use this as your
+  fix baseline unless the test proves it insufficient.
+- `applies_to` — the scope of the pattern. Confirm your construct matches
+  before applying the fix blindly; if the pattern does not actually apply
+  to this finding, note the mismatch and proceed with independent reasoning.
+
+Budget: 2-3 turns. Read only the KB entries listed in `kb_refs`. Do NOT
+run `kb-search.sh` or browse `.kb/` — the packet already filtered for
+relevance. If `kb_refs: none`, skip this step entirely.
+
+Record consulted paths in the output file's `KB refs consulted` field.
 
 ### 1a2. Check existing test coverage
 
@@ -317,8 +400,13 @@ FIX_IMPOSSIBLE with:
   already-fixed proof or a test that compiles and runs.
 - **Cannot modify tests in Phase 2.** Only source code. If you need a
   test changed, emit a relaxation request.
-- **Cannot read files outside the finding's construct paths** and the
-  test class.
+- **Cannot read files outside the finding's construct paths**, the test
+  class, the KB entries listed in `kb_refs`, and sibling `prove-fix-*.md`
+  outputs in the same run directory. Direct `.kb/` reads are allowed
+  only for paths the orchestrator passed in `kb_refs` — do not browse
+  `.kb/` or run `kb-search.sh`. Sibling `prove-fix-*.md` reads are
+  allowed only during Phase 0c (upstream-mitigation check) with a hard
+  2-file cap — do not read them during Phase 1 or Phase 2.
 - **Cannot make speculative improvements** to surrounding code.
 - **Cannot read Suspect's analysis reasoning** — the finding description
   and source code are sufficient.
@@ -332,9 +420,14 @@ Write the output file to the path the orchestrator specified:
 
 ## Result: <CONFIRMED_AND_FIXED | IMPOSSIBLE | FIX_IMPOSSIBLE>
 
+### KB refs consulted
+- <.kb/path/to/entry.md> — <what guidance it provided, or "pattern did not apply">
+- (or "none" if finding carried kb_refs: none)
+
 ### Phase 0: Already-fixed check
-- **Result:** <STILL_VULNERABLE | ALREADY_FIXED | UNCERTAIN>
-- **Detail:** <what was checked — specific lines that provide/lack the defense>
+- **Result:** <STILL_VULNERABLE | ALREADY_FIXED | UPSTREAM_MITIGATED | UNCERTAIN>
+- **Detail:** <what was checked — specific lines that provide/lack the defense, OR the prior finding ID + guard location for UPSTREAM_MITIGATED>
+- **Prior prove-fix consulted (UPSTREAM_MITIGATED only):** <list of prove-fix-*.md paths read during 0c, up to 2, or "none">
 
 ### Phase 1: Verify (skipped if Phase 0 = ALREADY_FIXED)
 - **Test method:** <method name> (or "removed" if impossible, or "skipped" if Phase 0)

--- a/prompts/audit/suspect.md
+++ b/prompts/audit/suspect.md
@@ -176,7 +176,41 @@ These clearings apply ONLY to concurrency-domain findings. They do not
 clear findings in other concern areas (validation, transformation, etc.)
 for the same construct.
 
-### 4. Card-driven analysis
+### 4. KB attack-pattern sweep (MANDATORY when packet lists KB entries)
+
+Your packet's `### KB entries` section lists KB summaries that Assembly
+projected from `classification.md` as relevant to this cluster. Treat each
+`type: adversarial-finding` entry as a **candidate attack vector**, not as
+background reference material. The KB is where the project records bugs
+already found; you are sweeping this cluster for recurrences.
+
+For each KB entry in the packet:
+
+1. Read the summary and identify the `applies_to` pattern (construct
+   kind, domain, language feature — e.g., "any JVM class holding
+   SecretKeySpec", "cache entries with external invalidation").
+2. Match against this cluster's constructs. Does any construct in your
+   file list exhibit the `applies_to` pattern?
+   - **Yes, pattern present and not mitigated** → emit a FINDING. Record
+     the KB entry path in `kb_refs` on the finding. The KB entry is the
+     card evidence.
+   - **Yes, pattern present and mitigated** → emit a CLEARED row with
+     evidence (the specific defense + line number) AND the KB entry path.
+     This explicitly proves you checked the known pattern rather than
+     silently passing over it.
+   - **No, pattern does not apply to this cluster** → do not emit
+     anything; the KB entry is a no-op for this cluster.
+
+If the packet has zero KB entries: skip the sweep. Do not invent KB
+references — `kb_refs: none` is the correct output when the packet
+carried no KB content.
+
+**Why this is mandatory.** Without the sweep, Suspect agents rediscover
+patterns the project has already catalogued, inflating finding volume
+and prove-fix cost. The packet is the KB channel — if you ignore it,
+KB compounding fails silently.
+
+### 5. Card-driven analysis
 
 Use construct cards to systematically check interaction points:
 
@@ -195,7 +229,7 @@ For each reconciliation inconsistency in the cluster:
 - The invokes/entry_points mismatch may indicate a caller using an
   API differently than intended. Analyze the actual call site.
 
-### 5. Cross-cluster boundary observations
+### 6. Cross-cluster boundary observations
 
 For constructs that have invokes/invoked_by edges to constructs outside
 this cluster:
@@ -246,11 +280,12 @@ Write `.feature/<slug>/suspect-<lens>-cluster-<N>.md`:
 - **Card evidence:** <which card field (assumption, co_mutator,
   inconsistency) led to this finding, or "independent">
 - **Spec requirement:** <ID or "none">
+- **KB refs:** <packet KB entry paths that informed this finding, or "none">
 - **Lines:** <relevant line numbers>
 
 ## Clearings
 
-| Construct | Concern | Clearing | Evidence (line) |
+| Construct | Concern | Clearing | Evidence (line) | KB ref (if any) |
 
 ## Boundary Observations
 
@@ -262,10 +297,12 @@ Write `.feature/<slug>/suspect-<lens>-cluster-<N>.md`:
 ## Summary
 - Constructs analyzed: <n>
 - Applicable cells checked: <n>
-- Findings: <n>
-- Cleared: <n>
+- KB entries in packet: <n>
+- KB entries swept: <n> (must equal "entries in packet" unless explicitly skipped — record reason)
+- Findings: <n> (of which <n> card-driven, <n> KB-driven)
+- Cleared: <n> (of which <n> KB-verified — explicit clearings against a KB pattern)
 - Boundary observations: <n>
 ```
 
 Return a single summary line:
-"Suspect <lens>/C<N> — <n> findings, <n> cleared, <n> boundary observations, <n> card-driven"
+"Suspect <lens>/C<N> — <n> findings, <n> cleared, <n> boundary observations, <n> card-driven, <n> KB-driven"

--- a/skills/feature-coordinate/SKILL.md
+++ b/skills/feature-coordinate/SKILL.md
@@ -174,6 +174,51 @@ still try to open AskUserQuestion (new site added without gating), treat
 that as a bug: record it to cycle-log.md and return ESCALATED.
 ```
 
+### KB tendency-scan contract (MANDATORY)
+
+Rich per-unit dispatch prompts describe the work concretely (spec
+requirements, construct contracts, test expectations). A side-effect is
+that cross-cutting pipeline steps buried inside `/feature-implement` and
+`/feature-test` never surface into the subagent's attention — the subagent
+runs the dispatch prompt faithfully and skips the skill's numbered steps
+it was nominally told to invoke.
+
+Empirical gap (2026-04-24): across a 4-WU parallel run, 0 of 4 subagents
+consulted `.kb/` during implementation. The Step 8 tendency scan in
+`/feature-implement` and the Lens B scan in `/feature-test` did not fire
+on any unit. Audit subsequently produced findings for patterns already in
+`.kb/` as adversarial-finding entries.
+
+Include the following verbatim (or paraphrased keeping the semantics) in
+every subagent prompt that invokes `/feature-implement` or `/feature-test`:
+
+```
+## KB tendency-scan contract (MANDATORY)
+
+After each construct's tests pass in `/feature-implement` Step 8 — and for
+each new test class in `/feature-test` Lens B — you MUST run:
+
+  bash .claude/scripts/kb-search.sh "<domain> <construct-type>" --kb-root .kb --top 5
+
+For each result with `type: adversarial-finding`:
+  - Read the entry's `applies_to` patterns and `## Test guidance`
+  - Check your just-implemented code (or tests) against the pattern
+  - If matched: fix proactively and re-run tests (implementation), or add
+    a targeted test method (tests)
+  - If not applicable: record why in a one-line note
+
+After each scan, write the substage checkpoint to units/WU-<n>/status.md:
+  Substage: tendency-scan-complete: <n> patterns checked, <n> applied
+
+Append one line to units/WU-<n>/cycle-log.md:
+  tendency-scan (<construct>): <n> results / <n> applied / <n> skipped
+
+Budget: <30 seconds per construct, ≤5 KB entries deep-read. The scan
+prevents re-introducing patterns already known to `.kb/`. Skipping it is a
+silent correctness loss, not a performance win — audit will rediscover the
+same patterns at higher cost.
+```
+
 ### Coordinator-side verification
 
 After each subagent returns, in addition to checking status.md for
@@ -181,6 +226,13 @@ After each subagent returns, in addition to checking status.md for
 - Status.md Stage/Substage matches the summary line verb (COMPLETE →
   `complete`; ESCALATED → `escalated-<reason>`).
 - If they disagree, trust status.md — the canonical state is on disk.
+- Grep `units/WU-<n>/cycle-log.md` for `tendency-scan (` entries. A
+  COMPLETE unit with zero `tendency-scan` entries AND a non-empty `.kb/`
+  is a contract violation — the KB scan contract was dispatched but the
+  subagent skipped it. Record this to the feature-level `cycle-log.md`:
+  `tendency-scan-missing: WU-<n> — <n constructs>, KB present`. Do not
+  escalate; surface this in the Step 4e token summary so the user knows
+  KB leverage was lost for that unit.
 
 ---
 

--- a/skills/feature-implement/SKILL.md
+++ b/skills/feature-implement/SKILL.md
@@ -251,8 +251,11 @@ For each construct:
 6. After a successful compile, re-read the edited lines to verify the edit
    persisted (earlier work unit edits can silently revert if old_string was stale).
 7. Update status.md substage → "implemented: <construct name>" after each passing unit
-8. **Tendency scan** — after this construct's tests pass, check for known
-   anti-patterns before moving to the next construct:
+8. **Tendency scan (MANDATORY)** — after this construct's tests pass, check
+   for known anti-patterns before moving to the next construct. This step
+   is not optional: the compounding-KB claim depends on it firing for every
+   construct. Skipping it is a silent correctness loss.
+
    a. If `.feature/<slug>/known_issues.md` exists, read TENDENCY entries that
       apply to this construct's domain. Do NOT introduce these patterns.
    b. If `.kb/CLAUDE.md` exists, run:
@@ -262,8 +265,18 @@ For each construct:
    c. Scan your just-implemented code for matches against these patterns.
       If found: fix proactively, re-run tests, confirm still green.
       If not found: continue to next construct.
-   d. This scan should take <30 seconds. Do not deep-read more than 5 KB
-      entries. The goal is catching known anti-patterns, not a full audit.
+   d. **Checkpoint writes (MANDATORY).** After the scan — even if `.kb/` is
+      empty or produces zero matches — write both:
+      - `status.md` substage →
+        `tendency-scan-complete: <construct> — <n> patterns checked, <n> applied`
+      - `cycle-log.md` append →
+        `tendency-scan (<construct>): <n> results / <n> applied / <n> skipped`
+
+      Zero-result scans still write the checkpoint (`0 / 0 / 0`). The absence
+      of the checkpoint is the signal that the scan was skipped, so it must
+      always be present.
+   e. Budget: <30 seconds per construct, ≤5 KB entries deep-read. The goal is
+      catching known anti-patterns, not a full audit.
 
 If a test fails unexpectedly after implementation: see Escalation Protocol.
 

--- a/tests/scenario-kb-scan-contract.sh
+++ b/tests/scenario-kb-scan-contract.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# Scenario: KB tendency-scan contract must be present at every pipeline
+# surface where a subagent consumes KB context.
+#
+# Empirical gap (2026-04-24): across a 4-WU jlsm parallel run, 0 of 4
+# WU-TDD subagents called kb-search.sh. The /feature-implement Step 8
+# instruction existed in the skill file, but the coordinator-composed
+# dispatch prompt never surfaced it to the subagent. Separately, audit
+# Suspect agents received KB context in their cluster packets but used
+# it at most 2/95 times in findings because the per-construct protocol
+# didn't iterate KB as attack patterns. Prove-fix never mentioned KB at
+# all.
+#
+# Six structural invariants defend against regression:
+#
+# 1. /feature-coordinate Step 1a embeds a "KB tendency-scan contract"
+#    fragment that subagent dispatch prompts must include, referencing
+#    kb-search.sh and the tendency-scan-complete substage.
+# 2. /feature-implement Step 8 requires a tendency-scan-complete
+#    substage write AND a cycle-log append after every construct's scan
+#    (including zero-result scans).
+# 3. /feature-coordinate's coordinator-side verification checks for
+#    tendency-scan cycle-log entries on COMPLETE units.
+# 4. prompts/audit/suspect.md has a KB attack-pattern sweep step that
+#    iterates packet KB entries as attack vectors, and its finding
+#    schema includes a kb_refs field.
+# 5. prompts/audit/prove-fix.md has a KB fix-pattern lookup step (Phase
+#    1a1) and its output schema records consulted KB refs.
+# 6. prompts/audit/prove-fix-orchestrator.md passes kb_refs from each
+#    Suspect finding through to the prove-fix dispatch.
+#
+# This is a grep-based structural test — it validates the prose is
+# present, not that the runtime subagent actually runs it. Pairs with
+# the existing scenario-parallel-subagent-hang-prevention.sh which
+# defends the termination-contract pattern this test mirrors.
+#
+# Run from repo root: bash tests/scenario-kb-scan-contract.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: KB tendency-scan contract"
+echo "────────────────────────────────────────────────"
+
+# ── Invariant 1: /feature-coordinate carries the KB scan contract ────────────
+
+echo ""
+echo "── Invariant 1: /feature-coordinate dispatch contract includes KB scan"
+
+coord_skill="$REPO_ROOT/skills/feature-coordinate/SKILL.md"
+
+if [[ ! -f "$coord_skill" ]]; then
+    fail "/feature-coordinate skill file missing" "$coord_skill"
+else
+    if grep -q "KB tendency-scan contract" "$coord_skill"; then
+        pass "coordinator has 'KB tendency-scan contract' section"
+    else
+        fail "coordinator missing 'KB tendency-scan contract' section" \
+             "dispatch template must surface Step 8 to subagents"
+    fi
+
+    if grep -q "kb-search.sh" "$coord_skill"; then
+        pass "coordinator dispatch references kb-search.sh verbatim"
+    else
+        fail "coordinator dispatch does not reference kb-search.sh" \
+             "subagent prompt must include the command invocation"
+    fi
+
+    if grep -q "tendency-scan-complete" "$coord_skill"; then
+        pass "coordinator references tendency-scan-complete substage"
+    else
+        fail "coordinator missing tendency-scan-complete substage reference" \
+             "dispatch must instruct subagent to write the checkpoint"
+    fi
+fi
+
+# ── Invariant 2: /feature-implement Step 8 writes substage + cycle-log ──────
+
+echo ""
+echo "── Invariant 2: /feature-implement Step 8 checkpoint writes"
+
+impl_skill="$REPO_ROOT/skills/feature-implement/SKILL.md"
+
+if [[ ! -f "$impl_skill" ]]; then
+    fail "/feature-implement skill file missing" "$impl_skill"
+else
+    # Extract Step 8 region (from "Tendency scan" header to next top-level step
+    # or Escalation protocol)
+    step8=$(awk '/\*\*Tendency scan/,/^## Escalation protocol|^If a test fails unexpectedly/' "$impl_skill")
+
+    if echo "$step8" | grep -q "MANDATORY"; then
+        pass "Step 8 is labelled MANDATORY"
+    else
+        fail "Step 8 not labelled MANDATORY" \
+             "optional phrasing lets subagents skip the scan"
+    fi
+
+    if echo "$step8" | grep -q "tendency-scan-complete"; then
+        pass "Step 8 requires tendency-scan-complete substage write"
+    else
+        fail "Step 8 missing tendency-scan-complete substage write" \
+             "absence of checkpoint is how skipped scans stay invisible"
+    fi
+
+    if echo "$step8" | grep -q "cycle-log.md"; then
+        pass "Step 8 requires cycle-log.md append after scan"
+    else
+        fail "Step 8 missing cycle-log.md append" \
+             "needed for coordinator-side verification in Invariant 3"
+    fi
+
+    if echo "$step8" | grep -qi "zero-result\|0 / 0 / 0\|even if.*empty\|even if.*produces zero"; then
+        pass "Step 8 enforces checkpoint even on zero-result scans"
+    else
+        fail "Step 8 does not require checkpoint on zero-result scans" \
+             "absence-is-signal requires the scan always write a checkpoint"
+    fi
+fi
+
+# ── Invariant 3: coordinator verifies tendency-scan cycle-log entries ───────
+
+echo ""
+echo "── Invariant 3: coordinator checks tendency-scan evidence post-return"
+
+if [[ -f "$coord_skill" ]]; then
+    verify_block=$(awk '/### Coordinator-side verification/,/^## /' "$coord_skill")
+    if echo "$verify_block" | grep -q "tendency-scan"; then
+        pass "coordinator verification block greps for tendency-scan entries"
+    else
+        fail "coordinator verification does not check tendency-scan entries" \
+             "skipped scans will not be surfaced without this check"
+    fi
+fi
+
+# ── Invariant 4: suspect.md KB attack-pattern sweep + kb_refs field ─────────
+
+echo ""
+echo "── Invariant 4: suspect.md KB attack-pattern sweep"
+
+suspect_prompt="$REPO_ROOT/prompts/audit/suspect.md"
+
+if [[ ! -f "$suspect_prompt" ]]; then
+    fail "suspect.md missing" "$suspect_prompt"
+else
+    if grep -q "KB attack-pattern sweep" "$suspect_prompt"; then
+        pass "suspect.md has 'KB attack-pattern sweep' step"
+    else
+        fail "suspect.md missing KB attack-pattern sweep" \
+             "per-construct protocol must iterate packet KB as attack vectors"
+    fi
+
+    if grep -q "MANDATORY when packet lists KB entries" "$suspect_prompt"; then
+        pass "KB sweep is marked MANDATORY when packet carries KB"
+    else
+        fail "KB sweep not explicitly mandatory" \
+             "optional phrasing leaves KB as passive reference material"
+    fi
+
+    if grep -q -E "^\s*-\s+\*\*KB refs:\*\*" "$suspect_prompt"; then
+        pass "suspect.md finding schema includes KB refs field"
+    else
+        fail "suspect.md finding schema missing KB refs field" \
+             "KB-informed findings have nowhere to record provenance"
+    fi
+
+    if grep -q "KB-driven" "$suspect_prompt"; then
+        pass "suspect.md summary line reports KB-driven count"
+    else
+        fail "suspect.md summary line missing KB-driven count" \
+             "Report needs the KB-leverage signal to surface it in audit-report.md"
+    fi
+fi
+
+# ── Invariant 5: prove-fix.md KB fix-pattern lookup ─────────────────────────
+
+echo ""
+echo "── Invariant 5: prove-fix.md KB fix-pattern lookup"
+
+provefix_prompt="$REPO_ROOT/prompts/audit/prove-fix.md"
+
+if [[ ! -f "$provefix_prompt" ]]; then
+    fail "prove-fix.md missing" "$provefix_prompt"
+else
+    if grep -q "KB fix-pattern lookup" "$provefix_prompt"; then
+        pass "prove-fix.md has KB fix-pattern lookup step"
+    else
+        fail "prove-fix.md missing KB fix-pattern lookup" \
+             "fix construction cannot benefit from KB guidance otherwise"
+    fi
+
+    if grep -q "kb_refs" "$provefix_prompt"; then
+        pass "prove-fix.md consumes kb_refs from the finding"
+    else
+        fail "prove-fix.md does not reference kb_refs" \
+             "no channel to carry KB paths from Suspect through to fix construction"
+    fi
+
+    if grep -q "KB refs consulted" "$provefix_prompt"; then
+        pass "prove-fix.md output records consulted KB refs"
+    else
+        fail "prove-fix.md output schema missing 'KB refs consulted'" \
+             "Report cannot attribute fixes back to KB entries"
+    fi
+
+    # The hard-rules block used to forbid reading outside construct paths —
+    # confirm the carve-out for kb_refs is present so prove-fix isn't
+    # contradicting its own Phase 1a1 instruction.
+    if grep -q "kb_refs.*allowed\|allowed.*kb_refs\|listed in .kb_refs\|listed in \`kb_refs\`" "$provefix_prompt"; then
+        pass "prove-fix.md hard rules carve out kb_refs for reading"
+    else
+        fail "prove-fix.md hard rules still forbid all .kb/ reads" \
+             "Phase 1a1 cannot fire without a carve-out in the Cannot-read rule"
+    fi
+fi
+
+# ── Invariant 6: prove-fix-orchestrator passes kb_refs to each dispatch ─────
+
+echo ""
+echo "── Invariant 6: prove-fix-orchestrator forwards kb_refs"
+
+orch_prompt="$REPO_ROOT/prompts/audit/prove-fix-orchestrator.md"
+
+if [[ ! -f "$orch_prompt" ]]; then
+    fail "prove-fix-orchestrator.md missing" "$orch_prompt"
+else
+    if grep -q "kb_refs" "$orch_prompt"; then
+        pass "orchestrator dispatch template includes kb_refs line"
+    else
+        fail "orchestrator does not forward kb_refs" \
+             "each prove-fix agent will see kb_refs unset regardless of Suspect output"
+    fi
+fi
+
+# ── Invariant 7: Phase 0 upstream-mitigation short-circuit ──────────────────
+#
+# 16 of 36 IMPOSSIBLE returns on jlsm were "already-fixed-proxy" — findings
+# whose attack path was blocked by an upstream fix from an earlier prove-fix
+# in the same run, but the agent went through full Phase 1 anyway because
+# Phase 0 only checked the local construct. Phase 0c must check prior
+# prove-fix outputs for upstream mitigation before falling through.
+
+echo ""
+echo "── Invariant 7: prove-fix Phase 0 upstream-mitigation short-circuit"
+
+if [[ -f "$provefix_prompt" ]]; then
+    if grep -q "UPSTREAM_MITIGATED" "$provefix_prompt"; then
+        pass "prove-fix.md recognises UPSTREAM_MITIGATED Phase 0 result"
+    else
+        fail "prove-fix.md missing UPSTREAM_MITIGATED result code" \
+             "Phase 0 short-circuit for upstream-fixed findings has no output shape"
+    fi
+
+    if grep -qE "0c\.|upstream mitigation|upstream.*prior prove-fix|prior prove-fix.*upstream" "$provefix_prompt"; then
+        pass "prove-fix.md Phase 0 has upstream-mitigation check step"
+    else
+        fail "prove-fix.md Phase 0 does not describe the upstream-mitigation check" \
+             "the 0c step must instruct scanning prior prove-fix-*.md outputs"
+    fi
+
+    if grep -qE "2-file cap|max 2|at most 2|2 prior outputs|2 prior prove-fix" "$provefix_prompt"; then
+        pass "prove-fix.md Phase 0 caps prior-output reads to 2 files"
+    else
+        fail "prove-fix.md Phase 0 does not cap prior-output reads" \
+             "uncapped prior-output scan risks bigger waste than it saves"
+    fi
+
+    # Hard rules must carve out prove-fix-*.md reads for Phase 0
+    if grep -qE "prove-fix-\*\.md|sibling .prove-fix|prove-fix.*sibling" "$provefix_prompt"; then
+        pass "prove-fix.md hard rules carve out prove-fix-*.md reads"
+    else
+        fail "prove-fix.md hard rules still forbid sibling prove-fix output reads" \
+             "Phase 0c cannot fire without a carve-out in the Cannot-read rule"
+    fi
+
+    # Output schema should allow recording consulted prior outputs
+    if grep -q "Prior prove-fix consulted" "$provefix_prompt"; then
+        pass "prove-fix.md output schema records consulted prior outputs"
+    else
+        fail "prove-fix.md output schema missing 'Prior prove-fix consulted'" \
+             "Report cannot attribute upstream-mitigation short-circuits otherwise"
+    fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+    exit 0
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Four coordinated fixes on the shared design axis *"information is reachable but not actionable"*, discovered empirically on a jlsm encryption audit (`763f30a6`, 126 subagents, 2026-04-24).

### The gap

| Surface | Empirical finding |
|---|---|
| WU-TDD coordinator dispatch | 0 of 4 subagents consulted `.kb/` — dispatch prompts (5.9K–12.6K chars each) contain zero KB-related keywords; subagents run the rich prompt and never reach `/feature-implement` Step 8 |
| Audit Suspect | 17/17 cluster packets carry KB content, but only 2/95 findings reference KB — per-construct protocol treats KB as passive reference, not attack vectors |
| Audit prove-fix | 0/95 outputs reference KB; no step in `prove-fix.md` mentioned KB at all |
| prove-fix Phase 0 | 16 of 36 IMPOSSIBLE returns were upstream-mitigated by a prior prove-fix in the same run, but Phase 0 only checked the local construct so the agent went through full Phase 1 anyway |

### The fix (four axes)

**D1 — `/feature-coordinate` Step 1a:** new MANDATORY *KB tendency-scan contract* fragment that every subagent dispatch prompt must include. Mirrors the v0.14.3 termination-contract pattern. Coordinator-side verification now greps `cycle-log.md` for scan evidence on COMPLETE units.

**D2 — `/feature-implement` Step 8:** MANDATORY substage + `cycle-log` checkpoint writes after every construct (including zero-result scans). Absence of the checkpoint becomes the signal that the scan was skipped.

**D3 — `prompts/audit/suspect.md`:** new *KB attack-pattern sweep* step iterates packet KB entries as attack vectors; finding schema gets `KB refs:`; Clearings table gets `KB ref` column; summary reports `KB-driven` count.

**D4 — `prompts/audit/prove-fix.md`:** new Phase 1a1 *KB fix-pattern lookup* consumes orchestrator-supplied `kb_refs`; new Phase 0c *upstream-mitigation check* scans up to 2 sibling `prove-fix-*.md` outputs for caller-side guards that block the attack path, short-circuiting as `IMPOSSIBLE / UPSTREAM_MITIGATED`. Phase 0 budget raised 2 → 4 turns; local `ALREADY_FIXED` path unchanged. `prove-fix-orchestrator.md` forwards `kb_refs` from Suspect findings through to each dispatch.

### Cost projection

Opus 4.7 API rates; jlsm audit baseline $14.03/bug ($1,333 for 95 findings, on trend with 7-audit historical $13.61 avg).

- **D4** targets ~11% prove-fix cost reduction — ~$86/audit at this size
- **D1–D3** target ~15–25% of findings pre-clearing at Suspect rather than being dispatched to prove-fix — $115–$190/audit savings
- **Combined ceiling:** projected floor ~$11/bug on audits with similar KB density

## Test plan

- [x] New `tests/scenario-kb-scan-contract.sh` — 22 structural invariants across 7 surfaces, 22/22 pass
- [x] `tests/scenario-parallel-subagent-hang-prevention.sh` — 10/10 pass (no regression)
- [x] `tests/test-install.sh` — 59/59 pass
- [x] Related audit scenarios: lens-security 23/23, state-gate 5/5, wontfix-obligation 5/5, aggregate-results 32/32, check-test-coverage 13/13, dedup-findings 12/12
- [ ] Empirical validation: re-run audit on jlsm WD-01 with fixes active and compare finding volume, IMPOSSIBLE ratio, and $/bug against the baseline

## Files changed

| File | Why |
|---|---|
| `skills/feature-coordinate/SKILL.md` | KB tendency-scan contract in dispatch template + post-return verification |
| `skills/feature-implement/SKILL.md` | Step 8 MANDATORY + substage/cycle-log checkpoint writes |
| `prompts/audit/suspect.md` | KB attack-pattern sweep + `kb_refs` finding field + `KB-driven` summary |
| `prompts/audit/prove-fix.md` | Phase 1a1 KB lookup + Phase 0c upstream mitigation + schema additions |
| `prompts/audit/prove-fix-orchestrator.md` | Forwards `kb_refs` to each dispatch |
| `tests/scenario-kb-scan-contract.sh` | New — 22 invariants defending the contract |
| `CONTEXT.md` | Session state refresh |

🤖 Generated with [Claude Code](https://claude.com/claude-code)