### PR TITLE
fix(work): /work-decompose Phase A/B/C + /work-status routing

### DIFF
--- a/scripts/work-validate.sh
+++ b/scripts/work-validate.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # work-validate.sh — structural validation for work definition files
 # Usage: work-validate.sh <wd-file>
-#        work-validate.sh --group <group-slug>   (validates all WDs + circular dep check)
+#        work-validate.sh --group <group-slug>              (structural + circular dep check)
+#        work-validate.sh --group <group-slug> --decompose  (structural + decompose invariant)
 # Exit 0 = PASS | Exit 1 = FAIL (prints all errors before exiting)
+#
+# The --decompose flag adds the Phase C invariant check: every artifact_dep
+# reference must resolve to either (a) an existing artifact in the repo,
+# (b) an artifact listed in another WD's produces:, or (c) an artifact
+# explicitly declared out-of-scope in work.md's frontmatter. This is what
+# prevents parallel /work-plan runs from diverging — if decompose hasn't
+# settled every cross-WD coordination surface, this invariant fails.
 
 set -euo pipefail
 
@@ -17,16 +25,23 @@ work_require_deps
 # ── Argument parsing ─────────────────────────────────────────────────────────
 
 GROUP_MODE=false
+DECOMPOSE_MODE=false
 GROUP_SLUG=""
 FILE=""
 
+# First pass: identify --group + slug, or <wd-file>. --decompose can appear
+# anywhere after --group.
 if [[ "${1:-}" == "--group" ]]; then
   GROUP_MODE=true
   GROUP_SLUG="${2:-}"
-  [[ -z "$GROUP_SLUG" ]] && { echo "Usage: work-validate.sh --group <group-slug>" >&2; exit 1; }
+  [[ -z "$GROUP_SLUG" ]] && { echo "Usage: work-validate.sh --group <group-slug> [--decompose]" >&2; exit 1; }
+  shift 2
+  for arg in "$@"; do
+    [[ "$arg" == "--decompose" ]] && DECOMPOSE_MODE=true
+  done
 else
   FILE="${1:-}"
-  [[ -z "$FILE" ]] && { echo "Usage: work-validate.sh <wd-file>" >&2; exit 1; }
+  [[ -z "$FILE" ]] && { echo "Usage: work-validate.sh <wd-file> | --group <group-slug> [--decompose]" >&2; exit 1; }
   [[ ! -f "$FILE" ]] && { echo "ERROR: File not found: $FILE" >&2; exit 1; }
 fi
 
@@ -289,6 +304,115 @@ check_circular_deps() {
   return $cycles_found
 }
 
+# ── Decompose invariant: every cross-WD reference has a group-level artifact ─
+#
+# For each artifact_deps entry across all WDs in the group, the referenced
+# artifact must resolve via one of:
+#   (a) exists in the repo (spec in .spec/registry, ADR in .decisions/, KB file)
+#   (b) listed in another WD's produces: array (i.e. produced within this group)
+#   (c) declared explicitly out_of_scope in work.md frontmatter
+#
+# wd: deps are always internal-only and don't require a backing artifact.
+
+check_decompose_invariant() {
+  local group_dir="$1"
+  local project_root
+  project_root="$(dirname "$(work_find_root)")"
+
+  local work_md="$group_dir/work.md"
+  local unsettled=()
+  local settled_count=0
+
+  # Build the union of all produces: entries across all WDs in the group.
+  # Format in the set: "<type>:<ref>" (e.g. "spec:encryption/primitives").
+  local -A PRODUCED
+  while IFS= read -r wd_file; do
+    [[ -z "$wd_file" ]] && continue
+    while IFS='|' read -r p_type p_ref _; do
+      [[ -z "$p_type" ]] && continue
+      PRODUCED["$p_type:$p_ref"]=1
+    done < <(work_fm_produces "$wd_file" 2>/dev/null)
+  done < <(work_list_wds "$group_dir")
+
+  # Read out_of_scope list from work.md (optional).
+  # Format in frontmatter: out_of_scope: ["spec:foo/bar", "adr:some-slug"]
+  local -A OUT_OF_SCOPE
+  if [[ -f "$work_md" ]]; then
+    while IFS= read -r entry; do
+      [[ -z "$entry" ]] && continue
+      OUT_OF_SCOPE["$entry"]=1
+    done < <(work_fm_array "$work_md" "out_of_scope" 2>/dev/null)
+  fi
+
+  # Walk each WD's artifact_deps and classify each reference.
+  while IFS= read -r wd_file; do
+    [[ -z "$wd_file" ]] && continue
+    local wd_id
+    wd_id=$(work_fm "$wd_file" "id")
+
+    while IFS='|' read -r dep_type dep_ref dep_req_state _; do
+      [[ -z "$dep_type" ]] && continue
+
+      # wd: deps are internal and don't require a backing artifact.
+      [[ "$dep_type" == "wd" ]] && continue
+
+      local key="$dep_type:$dep_ref"
+      local reason=""
+
+      case "$dep_type" in
+        spec)
+          reason=$(work_check_spec_dep "$project_root" "$dep_ref" "$dep_req_state") || true
+          ;;
+        adr)
+          reason=$(work_check_adr_dep "$project_root" "$dep_ref" "$dep_req_state") || true
+          ;;
+        kb)
+          reason=$(work_check_kb_dep "$project_root" "$dep_ref") || true
+          ;;
+      esac
+
+      # Settled if the dep resolves cleanly (exists + in required state).
+      if [[ -z "$reason" ]]; then
+        ((settled_count++)) || true
+        continue
+      fi
+
+      # Unsettled in repo — check if produced by another WD in the group.
+      if [[ -n "${PRODUCED[$key]:-}" ]]; then
+        ((settled_count++)) || true
+        continue
+      fi
+
+      # Unsettled + not produced — check if declared out of scope.
+      if [[ -n "${OUT_OF_SCOPE[$key]:-}" ]]; then
+        ((settled_count++)) || true
+        continue
+      fi
+
+      # Unsettled reference.
+      unsettled+=("$wd_id → $dep_type:$dep_ref ($reason)")
+    done < <(work_fm_artifact_deps "$wd_file")
+  done < <(work_list_wds "$group_dir")
+
+  if [[ ${#unsettled[@]} -eq 0 ]]; then
+    echo "  PASS  $settled_count cross-WD reference(s), all settled"
+    return 0
+  fi
+
+  echo "  FAIL  ${#unsettled[@]} unsettled cross-WD reference(s):"
+  for entry in "${unsettled[@]}"; do
+    echo "    $entry"
+  done
+  echo ""
+  echo "  Resolve by either:"
+  echo "    - Authoring the artifact in Phase B (/architect or /spec-author), OR"
+  echo "    - Adding it to another WD's produces: if a WD in this group will"
+  echo "      author it during implementation, OR"
+  echo "    - Declaring it explicitly out-of-scope in work.md's"
+  echo "      out_of_scope: [\"spec:foo/bar\", ...] frontmatter list."
+  return 1
+}
+
 # ── Execution ────────────────────────────────────────────────────────────────
 
 if [[ "$GROUP_MODE" == "true" ]]; then
@@ -320,6 +444,15 @@ if [[ "$GROUP_MODE" == "true" ]]; then
   else
     echo "  FAIL  Circular dependencies detected"
     ((total_errors++)) || true
+  fi
+
+  # Phase C decompose invariant (--decompose flag only).
+  if [[ "$DECOMPOSE_MODE" == "true" ]]; then
+    echo ""
+    echo "── Decompose invariant: every cross-WD reference settled"
+    if ! check_decompose_invariant "$GROUP_DIR"; then
+      ((total_errors++)) || true
+    fi
   fi
 
   echo ""

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -137,82 +137,281 @@ as dependencies) vs. which need to be produced by new work definitions.
 
 ---
 
-## Step 2 — Identify work boundaries
+## Decomposition scope (what this skill does and doesn't do)
 
-Analyze the work group scope from work.md. Identify natural boundaries where:
+`/work-decompose` **shapes the relationships between chunks of work** —
+it does NOT fully scope each chunk. WD-internal specs, architectural
+decisions that only affect one WD, and implementation details are
+deferred to `/work-plan`.
 
-- **Artifact dependencies create seams** — one body of work produces artifacts
-  (specs, ADRs, interface contracts) that another body consumes.
-- **Domain boundaries separate concerns** — work in different domains can
-  proceed independently.
-- **Ordering constraints force sequencing** — some work must complete before
-  other work can start.
-- **Interface contracts mediate interaction** — when two bodies of work need
-  to agree on a shared surface, the interface definition is its own work unit
-  (or part of the first unit that produces the contract).
+The output of `/work-decompose` is:
+1. WD files (`.work/<group>/WD-NN.md`) defining the chunks and their deps
+2. **Only the shared artifacts needed to prevent WD-level divergence:**
+   - Group-level ADRs for decisions that affect multiple WDs
+   - Specs for requirements that apply across WDs (the enforcement layer)
+   - Interface-contract specs at cross-WD seams
 
-### Internal analysis (do not display yet)
+The rule for what belongs in decompose vs work-plan: **does this
+decision or artifact cross a WD boundary?** If yes, it's decompose's
+job. If no, it's a WD-local concern and `/work-plan` handles it.
 
-For each proposed work definition, draft:
-- A title (imperative verb phrase)
-- Which domains it touches
-- What artifacts it depends on (existing specs, ADRs, KB entries)
-- What artifacts it produces (new specs, interface contracts, ADRs)
-- Rough ordering: what must come before/after
+**Zero new artifacts is a valid decompose outcome.** When natural seams
+are obvious and no shared-data decisions need making, the skill writes
+WD files and exits. No research, no architect, no specs.
 
 ---
 
-## Step 3 — Present decomposition
+## Step 2 — Phase A: Seam-finding
 
-Present the proposed work definitions as a table:
+Analyze the work group scope from work.md. The goal is to identify
+**natural seams in the problem** — boundaries that emerge from the
+work's structure, not arbitrary chunks.
+
+### 2a — Look for seams, not chunks
+
+Natural seams:
+- **Produce/consume boundaries** — one body of work produces artifacts
+  that another consumes.
+- **Domain edges** — different domains with independent concerns.
+- **Ordering constraints** — where A must complete before B.
+- **Shared surfaces** — where multiple bodies of work must agree on an
+  interface, protocol, or data shape.
+
+Do NOT target a WD count. The number falls out of the composition:
+an atomic problem is one WD, a problem with 50 natural seams is 50 WDs.
+Splitting a WD to "feel smaller" or merging two to "feel larger" is
+arbitrary and wrong.
+
+### 2b — Dispatch /research for unknowns that affect seam identification
+
+As you analyze the scope, if you hit an unknown that affects where the
+seams go, dispatch `/research` as a subagent:
 
 ```
-## Proposed Work Definitions
+Invoke `/research "<subject>" context: "work-decompose for <group-slug>,
+seam-finding: <what you're trying to resolve>"` as a sub-agent.
+```
 
-| WD | Title | Domains | Depends on | Produces |
-|----|-------|---------|------------|----------|
-| WD-01 | <title> | <domains> | <artifact deps or "none"> | <produced artifacts> |
-| WD-02 | <title> | <domains> | <artifact deps> | <produced artifacts> |
+After each research subagent completes, verify the KB entry exists and
+continue seam analysis with the new findings. Multiple research
+dispatches are allowed — seam-finding is exploratory.
+
+Examples of unknowns that warrant `/research`:
+- "We're touching an unfamiliar protocol — what are the conventional
+  layering boundaries?"
+- "Is there a canonical way to decompose this class of problem that we
+  should follow?"
+- "What existing patterns does the project already use here?"
+
+Examples that do NOT warrant `/research`:
+- WD-internal technology choices (those surface in `/work-plan` later)
+- Implementation details (deferred to the feature pipeline)
+
+### 2c — Produce the seam analysis (internal — do not display yet)
+
+Draft:
+- **Tentative WD chunks** — based on the seams identified. These may
+  move after Phase B.
+- **Coordination surfaces** — cross-WD seams that need settled
+  artifacts to prevent WD-level divergence. For each surface, note:
+  - Which WDs share it
+  - What kind of artifact settles it (ADR, spec, interface contract,
+    or breakdown ADR if the shape itself is unclear)
+- **Existing artifacts that apply** — group-level ADRs/specs already in
+  `.decisions/` or `.spec/` that constrain this work (don't re-author
+  them).
+
+---
+
+## Step 3 — Present Phase A output
+
+Show the user what Phase A found and what Phase B needs to settle
+before the decomposition is final.
+
+```
+## Tentative decomposition — Phase A
+
+Natural seams identified: <N>
+  <short description of each seam>
+
+Tentative work definitions (may shift after Phase B):
+  WD-01 — <title> — <short description>
+  WD-02 — <title> — <short description>
+  ...
+
+## Coordination surfaces needing settlement
+
+Each of these crosses a WD boundary and must be settled before the
+decomposition finalizes. Settling them may also move the seams.
+
+| # | Kind            | Subject                           | Why it's cross-WD       |
+|---|-----------------|-----------------------------------|-------------------------|
+| 1 | breakdown ADR   | How to carve the X subsystem      | Seam shape unclear      |
+| 2 | shared-data ADR | Canonical encoding for IDs        | WD-02, WD-03 both use   |
+| 3 | interface spec  | Event contract for peer lifecycle | WD-01 produces, WD-02/3 consume |
+| 4 | shared spec     | Key rotation cadence requirements | Enforcement across all WDs |
+
+(or "None — seams are clear, no cross-WD settlement needed.")
+
+## Existing artifacts that apply
+  <list ADRs/specs already in the repo that constrain this decomposition>
+
+## Research dispatched
+  <list /research subagent invocations + resulting KB entries>
+```
+
+Use AskUserQuestion with options:
+  - "Proceed to Phase B" (run the /architect and /spec-author passes)
+  - "Pre-commit some decisions" (Other — specify what you already know)
+  - "Defer all to /work-plan" (skip Phase B — fast, but expect WD-level divergence)
+  - "Adjust the seams first" (Other — specify changes to tentative WDs)
+
+If "Pre-commit some decisions": record the pre-committed choices, then
+remove matching items from the surfaces list before proceeding.
+
+If "Defer all": skip to Step 5 (Phase C) with the tentative decomposition.
+Log a warning in manifest.md that Phase B was deferred.
+
+If "Adjust the seams": apply changes and re-present.
+
+If "Proceed to Phase B": continue to Step 4.
+
+---
+
+## Step 4 — Phase B: Architect and shared-spec authoring (user-serial)
+
+Work through the coordination surfaces from Step 3 **one at a time**.
+Architect passes require user deliberation and cannot be parallelized.
+
+For each surface, in order:
+
+### Breakdown ADR (if seam shape was unclear)
+
+Run this FIRST when Phase A couldn't cleanly identify seams:
+
+```
+Invoke `/architect "<decomposition problem>" context: "work-decompose
+for <group-slug>, breakdown: how to carve <subsystem>"` as a sub-agent.
+```
+
+The breakdown ADR's output is the architectural model for the group —
+it decides the shape of the problem space, which typically reveals the
+natural seams. After it completes, **go back to Step 2c and re-draft
+tentative WDs** using the breakdown ADR as input. Then continue with
+the remaining surfaces.
+
+### Shared-data ADR (for cross-WD decisions)
+
+For each shared-data decision:
+
+```
+Invoke `/architect "<decision problem>" context: "work-decompose for
+<group-slug>, shared-data across WDs <list>"` as a sub-agent.
+```
+
+The user deliberates interactively within the architect sub-agent. When
+it returns, the ADR exists in `.decisions/<slug>/`. Record the ADR slug.
+
+### Companion spec for each ADR
+
+ADRs describe *why* a decision was made. Specs define *what the system
+must do* as a result — they are the enforceable layer consumed by
+`/work-plan`, `/feature-test`, `/audit`, and `/spec-verify`. For every
+shared-data ADR that has behavioral implications across WDs, author a
+companion spec:
+
+```
+Invoke `/spec-author "<domain>.<slug>" "<title>" context: "companion
+spec for ADR <adr-slug>, shared across WDs <list>"` as a sub-agent.
+```
+
+After authoring, verify the spec is APPROVED in
+`.spec/registry/manifest.json`. If DRAFT, falsification was incomplete
+— stop and surface the error.
+
+### Interface-contract specs (for cross-WD seams)
+
+For each interface-contract seam identified in Step 3:
+
+```
+Invoke `/spec-author "<domain>.<interface-name>" "<title>" context:
+"interface contract authored during work-decompose, consumed by WDs
+<list>" --kind interface-contract` as a sub-agent.
+```
+
+Verify APPROVED state before continuing.
+
+### Record Phase B outputs
+
+As each surface settles, record the artifacts produced:
+- ADR slugs
+- Spec paths (with domain/slug)
+- Interface-contract paths
+
+These become the `artifact_deps:` WDs will reference in Step 6.
+
+---
+
+## Step 5 — Phase C: Finalize decomposition
+
+With Phase B artifacts in hand, re-evaluate the tentative WDs from
+Step 2c. Seams may have moved — a breakdown ADR or shared-data decision
+often reveals a cleaner carve than the Phase A tentative. Re-chunk if
+needed.
+
+For each final WD, determine:
+- Which Phase B artifacts it consumes → `artifact_deps` entries
+- Which existing artifacts it consumes → `artifact_deps` entries
+- Whether there's a WD-level ordering constraint → `wd:` dep entries
+- What this WD will produce — **optional, leave empty if unclear**. WDs
+  often produce WD-local specs during `/work-plan` that aren't worth
+  predicting at decompose time. Only list `produces:` entries for
+  artifacts whose shape is already settled (typically Phase B outputs
+  that this WD is the author-of-record for).
+
+Present the final decomposition:
+
+```
+## Final decomposition — Phase C
+
+Work definitions: <N>  (natural composition from the problem's seams)
+
+| WD | Title | Domains | Consumes (deps) | Produces |
+|----|-------|---------|-----------------|----------|
+| WD-01 | <title> | <domains> | <artifact deps> | <produces, or "—"> |
+| WD-02 | <title> | <domains> | <artifact deps> | — |
 ...
 
 ## Dependency Graph
 
 WD-01 (no deps)
-  └→ WD-02 (needs: auth/jwt-token-contract from WD-01)
-       └→ WD-03 (needs: auth/middleware-interface from WD-02)
-WD-04 (no deps, parallel with WD-01)
+  └→ WD-02 (needs: <domain>/<spec> APPROVED from Phase B)
+       └→ WD-03 (needs: WD-02 COMPLETE)
 
-## Shared Interface Contracts
+## Phase B artifacts produced
+  ADRs: <list>
+  Specs: <list>
+  Interface contracts: <list>
 
-| Interface | Produced by | Consumed by | Domain |
-|-----------|------------|-------------|--------|
-| <name> | WD-01 | WD-02, WD-03 | <domain> |
-...
-(or "None needed — work definitions are independent.")
+## Invariant check
+  Every cross-WD reference has a group-level artifact: ✓ | ✗
 ```
-
-### Scope signal
-
-If any WD has >5 artifact dependencies, flag it:
-```
-⚠ WD-03 has 7 artifact dependencies — consider splitting into smaller units.
-```
-
----
-
-## Step 4 — Confirm with user
 
 Use AskUserQuestion with options:
   - "Looks good — write these"
-  - "Merge some WDs" (with Other for specifics)
-  - "Split a WD" (with Other for specifics)
-  - "Adjust dependencies" (with Other for specifics)
+  - "Merge some WDs" (Other)
+  - "Split a WD" (Other)
+  - "Adjust dependencies" (Other)
 
-If any adjustment: apply changes and re-present from Step 3.
+If the invariant check fails, list the missing artifacts and do NOT
+offer "Looks good" as an option until they're resolved — either author
+them (loop back to Step 4) or declare them explicitly out of scope.
+
+If any adjustment: apply and re-present from Step 5.
 
 ---
 
-## Step 5 — Write work definitions
+## Step 6 — Write work definitions
 
 For each confirmed WD, write `.work/<group-slug>/WD-<NN>.md`:
 
@@ -257,12 +456,29 @@ produces:
 - kb deps are existence-only (no state check)
 
 **produces rules:**
-- List artifacts this WD will create as part of its specification phase
-- Interface contracts use `kind: interface-contract`
+- **Optional.** Leave empty (`produces: []`) for any WD whose outputs aren't
+  decided at decompose time — that's the honest case for most WDs, since
+  their WD-local specs emerge during `/work-plan`.
+- List `produces:` entries only when this WD is the author-of-record for a
+  specific, already-scoped artifact — typically a Phase B interface contract
+  or shared spec that another WD explicitly consumes via `artifact_deps`.
+- Interface contracts use `kind: interface-contract`.
+- Do NOT predict WD-local specs here — `/work-plan` authors them.
+
+**Scope discipline — what belongs in the WD file:**
+- Title, domains, summary, acceptance criteria — yes
+- Pre-existing artifact_deps (Phase B outputs or earlier) — yes
+- wd: ordering constraints — yes
+- WD-local implementation plans — NO (that's `/work-plan`'s output)
+- WD-internal architectural choices — NO (deferred to `/work-plan`)
+
+If you find yourself wanting to write a lot of WD-local detail at this
+stage, that's a signal the wrong stage is trying to do the work. Stop
+and defer.
 
 ---
 
-## Step 6 — Update manifest
+## Step 7 — Update manifest
 
 Update `.work/<group-slug>/manifest.md`:
 
@@ -284,31 +500,46 @@ Write the text dependency graph from Step 3.
 
 Update the Active Work Groups row for this group: set WDs count to the total.
 
+### Run invariant check
+
+```bash
+bash .claude/scripts/work-validate.sh --group "<group-slug>" --decompose
+```
+
+This verifies that every cross-WD reference has a settled group-level
+artifact (from Phase B or pre-existing). If the check fails, display the
+unsettled references and offer options:
+- "Re-open Phase B to settle them"
+- "Mark them out of scope in work.md and proceed"
+- "Stop"
+
+Decomposition is not complete until the invariant passes or is
+explicitly waived.
+
 ---
 
-## Step 7 — Summary and next steps
+## Step 8 — Summary and next steps
 
 ```
 Decomposition complete: <N> work definitions in '<group-slug>'.
 
-  <N> with no dependencies (ready for specification)
-  <N> with dependencies (blocked until deps are met)
-  <N> shared interface contracts identified
+  <N> with no dependencies (READY — ready for /work-plan)
+  <N> blocked on artifact dependencies
+  <N> Phase B artifacts produced this session
 
 Next steps:
 
   1. Check readiness:
        /work-status "<group-slug>"
 
-  2. Specify the first ready work definition:
+  2. Plan the highest-unblocking work definition:
        /work-plan "<group-slug>" next
 
-  Or implement directly (if specs already exist):
-       /work-start "<group-slug>" next
-
-  3. Or specify interface contracts first (recommended when
-     multiple WDs share surfaces):
-       /spec-author "<interface-name>" for each shared interface
+     /work-plan MUST run on every WD — even when Phase B settled
+     everything and planning has nothing to add, /work-plan transitions
+     DRAFT → SPECIFIED so `/work-start` will accept the WD. Skipping
+     /work-plan is not supported and would bypass WD-local scope
+     discipline.
 ```
 
 Stop.

--- a/skills/work-status/SKILL.md
+++ b/skills/work-status/SKILL.md
@@ -32,14 +32,50 @@ If `--all` flag is set:
 📊 WORK STATUS · all groups
 ───────────────────────────────────────────────
 
-| Group | WDs | Ready | Specifying | Specified | Implementing | Complete |
-|-------|-----|-------|------------|-----------|--------------|----------|
-| <slug> | <n> | <n> | <n> | <n> | <n> | <n> |
+| Group | WDs | Ready | Blocked | Specifying | Specified | Implementing | Complete |
+|-------|-----|-------|---------|------------|-----------|--------------|----------|
+| <slug> | <n> | <n> | <n> | <n> | <n> | <n> | <n> |
 ...
+```
 
-Ready to work on:
-  /work-plan "<slug>" next    — specify the first ready WD (produce specs/ADRs)
-  /work-start "<slug>" next   — implement a fully specified WD
+**Next-step commands must route by state — not suggest both commands for
+the same WD.** `/work-start` rejects READY/BLOCKED WDs with "needs
+planning first"; `/work-plan` rejects SPECIFIED WDs with "already
+specified." Mixing them in suggestions creates a round-trip where the
+user runs the wrong one, gets bounced, and guesses again.
+
+Build the suggestion block by scanning the status of WDs across all groups:
+
+- **If any group has READY WDs** → show `/work-plan "<slug>" next` for
+  those groups. These WDs need planning before implementation can start,
+  even when "Ready" sounds like "ready to work."
+- **If any group has SPECIFIED WDs** → show `/work-start "<slug>" next`
+  for those groups. These are planned and ready to implement.
+- **If any group has SPECIFYING or IMPLEMENTING WDs** → show
+  `/feature-resume "<group>--<wd-slug>"` for those specific in-progress
+  units.
+- **If all remaining WDs in a group are BLOCKED** → do not suggest either
+  `/work-plan` or `/work-start` for that group; instead, route to the
+  specific unblock command (`/spec-author`, `/architect`, `/research`, or
+  upstream WD).
+
+Present suggestions grouped by action type, not jumbled together:
+
+```
+Ready to specify:
+  /work-plan "<group-a>" next    — <N> READY WD(s) need planning
+  /work-plan "<group-b>" next    — <N> READY WD(s) need planning
+
+Ready to implement:
+  /work-start "<group-c>" next   — <N> SPECIFIED WD(s) planned and ready
+
+Resume in progress:
+  /feature-resume "<group-d>--wd-02"   — SPECIFYING
+  /feature-resume "<group-e>--wd-01"   — IMPLEMENTING
+
+Blocked (unblock to proceed):
+  /spec-author "<id>" "<title>"   — for group-f (missing spec)
+  /architect "<problem>"          — for group-g (missing ADR)
 ```
 
 If no work groups exist:
@@ -124,15 +160,29 @@ From the resolver's `## Scope Signal` section, if present.
 
 ## Step 4 — Actionable next steps
 
-Based on the readiness state, present specific next actions:
+Based on the readiness state, present specific next actions. **Route
+suggestions strictly by state.** `/work-start` rejects READY/BLOCKED WDs
+with "needs planning first"; `/work-plan` rejects SPECIFIED WDs with
+"already specified." Never list both commands as options for the same
+WD — it creates a wrong-command round-trip.
 
-### If READY WDs exist:
+### If READY WDs exist (planning not yet run):
 ```
-Ready to work on:
-  /work-plan "<group-slug>" WD-<nn>    — specify a WD (produce specs/ADRs)
-  /work-plan "<group-slug>" next       — specify the highest-value ready WD
+Ready to plan:
+  /work-plan "<group-slug>" WD-<nn>    — plan a specific WD
+  /work-plan "<group-slug>" next       — plan the highest-unblocking WD
+```
+
+Do NOT list `/work-start` here — READY means DRAFT with deps met, and
+`/work-start` requires SPECIFIED. `/work-plan` is mandatory before
+`/work-start`, even when planning has nothing to add (no-op planning
+still transitions DRAFT → SPECIFIED).
+
+### If SPECIFIED WDs exist (planning done, ready to implement):
+```
+Ready to implement:
   /work-start "<group-slug>" WD-<nn>   — implement a specific WD
-  /work-start "<group-slug>" next      — implement the highest-value ready WD
+  /work-start "<group-slug>" next      — implement the highest-unblocking WD
 ```
 
 ### If all remaining WDs are BLOCKED:
@@ -158,12 +208,6 @@ Consider running a retrospective on the overall effort:
 Active:
   WD-<nn> (<title>) — SPECIFYING — resume with /feature-resume "<group>--<wd-slug>"
   WD-<nn> (<title>) — IMPLEMENTING — resume with /feature-resume "<group>--<wd-slug>"
-```
-
-### If WDs are SPECIFIED:
-```
-Ready for implementation:
-  /work-start "<group-slug>" WD-<nn>   — implement a specified WD
 ```
 
 Stop.

--- a/tests/scenario-work-layer-alignment.sh
+++ b/tests/scenario-work-layer-alignment.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# Scenario: work-layer alignment — /work-decompose Phase A/B/C + /work-status
+# routing by state + work-validate --decompose invariant.
+#
+# Defends two bug classes surfaced on jlsm (2026-04-24):
+#
+#   Gap 2 — /work-status suggested /work-start for READY WDs, which /work-start
+#           then rejected, creating a wrong-command round-trip.
+#
+#   Gap 1 — /work-decompose did no research, no architect, no spec authoring —
+#           it was LLM-only scope-splitting. Each WD's /work-plan then ran
+#           /feature-domains independently and re-did architecture in isolation,
+#           producing divergent interpretations across parallel WDs.
+#
+# Structural invariants checked here (grep-based) — full end-to-end behavior
+# is LLM-driven and not mechanically testable. Functional invariants where
+# possible use work-validate.sh --decompose against crafted fixtures.
+#
+# Run from repo root: bash tests/scenario-work-layer-alignment.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-work-layer-alignment"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: work-layer alignment"
+echo "────────────────────────────────────────────────"
+
+# ── Invariant 1: /work-status routes READY WDs to /work-plan only ───────────
+#
+# Before this fix, Step 4 "If READY WDs exist" listed both /work-plan and
+# /work-start under the same header. /work-start rejects READY. This created
+# the round-trip the user hit.
+
+echo ""
+echo "── Invariant 1: /work-status READY routing"
+
+status_skill="$REPO_ROOT/skills/work-status/SKILL.md"
+
+if [[ ! -f "$status_skill" ]]; then
+    fail "/work-status skill missing" "$status_skill"
+else
+    # Extract only the FIRST fenced code block inside the "If READY WDs exist"
+    # section (the suggested-commands block). Explanatory prose after the block
+    # may mention /work-start in a "do NOT" context, which is fine.
+    ready_suggestions=$(awk '
+        /^### If READY WDs exist/{in_section=1; next}
+        in_section && /^### /{exit}
+        in_section && /^```/{in_code=!in_code; if(!in_code){exit}; next}
+        in_section && in_code{print}
+    ' "$status_skill")
+
+    if echo "$ready_suggestions" | grep -q "/work-plan"; then
+        pass "/work-status READY suggestions offer /work-plan"
+    else
+        fail "/work-status READY suggestions do not offer /work-plan" \
+             "READY WDs must be routed to /work-plan first"
+    fi
+
+    if echo "$ready_suggestions" | grep -q "/work-start"; then
+        fail "/work-status READY suggestions still offer /work-start" \
+             "/work-start rejects READY WDs — suggestion creates a round-trip"
+    else
+        pass "/work-status READY suggestions do NOT offer /work-start (correct)"
+    fi
+
+    # The --all mode block must also route correctly.
+    all_block=$(awk '/^## Step 0 — List mode/,/^---$/' "$status_skill")
+    if echo "$all_block" | grep -q "Route suggestions strictly by state\|must route by state"; then
+        pass "/work-status --all mode has explicit state-routing discipline"
+    else
+        fail "/work-status --all mode lacks explicit state-routing discipline" \
+             "must tell the LLM not to jumble /work-plan and /work-start"
+    fi
+fi
+
+# ── Invariant 2: /work-decompose has explicit scope discipline ──────────────
+#
+# The skill must distinguish inter-WD coordination (decompose's job) from
+# WD-internal detailing (/work-plan's job). Without this, decompose over-scopes
+# and creates artifacts that should have been deferred.
+
+echo ""
+echo "── Invariant 2: /work-decompose scope discipline"
+
+decompose_skill="$REPO_ROOT/skills/work-decompose/SKILL.md"
+
+if [[ ! -f "$decompose_skill" ]]; then
+    fail "/work-decompose skill missing" "$decompose_skill"
+else
+    if grep -q "shapes the relationships between chunks" "$decompose_skill"; then
+        pass "/work-decompose declares scope discipline (relationships, not internals)"
+    else
+        fail "/work-decompose missing scope-discipline prose" \
+             "must state it shapes relationships, not full scoping of each chunk"
+    fi
+
+    if grep -q "Zero new artifacts is a valid decompose outcome" "$decompose_skill"; then
+        pass "/work-decompose explicitly allows zero-artifact outcomes"
+    else
+        fail "/work-decompose does not allow zero-artifact outcomes" \
+             "atomic problems should not force research/architect passes"
+    fi
+fi
+
+# ── Invariant 3: /work-decompose has Phase A/B/C structure ──────────────────
+
+echo ""
+echo "── Invariant 3: /work-decompose Phase A/B/C structure"
+
+if [[ -f "$decompose_skill" ]]; then
+    if grep -q "Phase A: Seam-finding" "$decompose_skill"; then
+        pass "Phase A (seam-finding) is defined"
+    else
+        fail "Phase A (seam-finding) missing" \
+             "decompose must have a seam-finding phase"
+    fi
+
+    if grep -q "Phase B: Architect and shared-spec authoring" "$decompose_skill"; then
+        pass "Phase B (architect + spec authoring) is defined"
+    else
+        fail "Phase B (architect + spec authoring) missing" \
+             "decompose must have a group-level architectural pass"
+    fi
+
+    if grep -q "Phase C: Finalize decomposition" "$decompose_skill"; then
+        pass "Phase C (finalize) is defined"
+    else
+        fail "Phase C (finalize) missing" \
+             "decompose must have a re-carving step after Phase B"
+    fi
+fi
+
+# ── Invariant 4: Phase A dispatches /research for unknowns ──────────────────
+
+echo ""
+echo "── Invariant 4: Phase A dispatches /research subagents"
+
+if [[ -f "$decompose_skill" ]]; then
+    phase_a=$(awk '/^## Step 2 — Phase A/,/^## Step 3 — Present Phase A/' "$decompose_skill")
+
+    if echo "$phase_a" | grep -qF 'Invoke `/research'; then
+        pass "Phase A invokes /research as a subagent"
+    else
+        fail "Phase A does not invoke /research" \
+             "seam-finding must dispatch research when unknowns block analysis"
+    fi
+
+    if echo "$phase_a" | grep -qE "Do NOT target a WD count|number falls out of the composition"; then
+        pass "Phase A rejects target-count framing"
+    else
+        fail "Phase A still uses target-count framing" \
+             "WD count must follow natural composition, not a target"
+    fi
+fi
+
+# ── Invariant 5: Phase B dispatches /architect + /spec-author serially ──────
+
+echo ""
+echo "── Invariant 5: Phase B architect + spec authoring dispatches"
+
+if [[ -f "$decompose_skill" ]]; then
+    phase_b=$(awk '/^## Step 4 — Phase B/,/^## Step 5 — Phase C/' "$decompose_skill")
+
+    if echo "$phase_b" | grep -qF 'Invoke `/architect'; then
+        pass "Phase B invokes /architect for cross-WD decisions"
+    else
+        fail "Phase B does not invoke /architect" \
+             "cross-WD decisions must go through architect deliberation"
+    fi
+
+    if echo "$phase_b" | grep -qF 'Invoke `/spec-author'; then
+        pass "Phase B invokes /spec-author for shared specs"
+    else
+        fail "Phase B does not invoke /spec-author" \
+             "shared requirements must be authored as specs (the enforcement layer)"
+    fi
+
+    if echo "$phase_b" | grep -q "Breakdown ADR"; then
+        pass "Phase B documents the breakdown-ADR pattern"
+    else
+        fail "Phase B missing breakdown-ADR pattern" \
+             "when seams are unclear, a breakdown ADR should carve the space"
+    fi
+
+    if echo "$phase_b" | grep -qE "one at a time|user-serial|serially"; then
+        pass "Phase B specifies serial (user-interactive) architect passes"
+    else
+        fail "Phase B does not specify serial architect passes" \
+             "/architect requires user deliberation; parallel dispatch is wrong"
+    fi
+fi
+
+# ── Invariant 6: Phase C runs the invariant check ───────────────────────────
+
+echo ""
+echo "── Invariant 6: Phase C invariant check"
+
+if [[ -f "$decompose_skill" ]]; then
+    if grep -q "work-validate.sh --group .*--decompose" "$decompose_skill"; then
+        pass "Phase C invokes work-validate.sh --decompose"
+    else
+        fail "Phase C does not invoke --decompose invariant" \
+             "every cross-WD reference must be mechanically verified"
+    fi
+fi
+
+# ── Invariant 7: produces: field is now optional ────────────────────────────
+
+echo ""
+echo "── Invariant 7: produces: field is optional in WD frontmatter"
+
+if [[ -f "$decompose_skill" ]]; then
+    # Locate the produces: rules block specifically (the one after artifact_deps rules)
+    if grep -qE "Optional.*Leave empty.*produces: \[\]|produces:.*Optional" "$decompose_skill"; then
+        pass "produces: field is documented as optional"
+    else
+        fail "produces: field is still mandatory/prediction-based" \
+             "honest empty is better than LLM guesses at decompose time"
+    fi
+fi
+
+# ── Invariant 8: /work-plan no-op path documented ───────────────────────────
+#
+# When decompose settled everything, /work-plan may have genuinely no WD-local
+# work. The transition DRAFT → SPECIFIED still happens because /work-plan ran,
+# but the skill must be explicit that no-op is legitimate.
+
+echo ""
+echo "── Invariant 8: /work-plan mandatory even when no-op"
+
+# This currently lives in /work-decompose Step 8 summary — mentioning that
+# /work-plan MUST run even when Phase B settled everything.
+if [[ -f "$decompose_skill" ]]; then
+    if grep -qE "/work-plan MUST run on every WD|Skipping /work-plan is not supported" "$decompose_skill"; then
+        pass "decompose summary tells user /work-plan is mandatory for every WD"
+    else
+        fail "decompose summary does not enforce /work-plan-on-every-WD" \
+             "without this, users skip /work-plan and bypass WD-local discipline"
+    fi
+fi
+
+# ── Invariant 9: work-validate.sh --decompose mode works ────────────────────
+
+echo ""
+echo "── Invariant 9: work-validate.sh --decompose invariant (functional)"
+
+# Fresh workspace
+rm -rf "$TEST_BASE"
+mkdir -p "$TEST_BASE/.work/demo-group"
+mkdir -p "$TEST_BASE/.spec"
+mkdir -p "$TEST_BASE/.decisions"
+cd "$TEST_BASE"
+
+# Seed a minimal work group with one WD that references a non-existent spec.
+cat > .work/demo-group/work.md <<'EOF'
+---
+group: demo-group
+goal: Test group for decompose invariant
+status: active
+created: 2026-04-24
+---
+
+## Goal
+Test group.
+
+## Scope
+### In scope
+- test
+
+### Out of scope
+- none
+
+## Ordering Constraints
+None.
+
+## Shared Interfaces
+None.
+
+## Success Criteria
+- test passes
+EOF
+
+cat > .work/demo-group/manifest.md <<'EOF'
+# Manifest
+EOF
+
+# WD-01 references a spec that doesn't exist and isn't produced by anyone.
+cat > .work/demo-group/WD-01.md <<'EOF'
+---
+id: WD-01
+title: Test WD one
+group: demo-group
+status: DRAFT
+domains: [test]
+artifact_deps:
+  - { type: spec, path: "test/nonexistent", required_state: APPROVED }
+produces: []
+---
+
+## Summary
+Test.
+
+## Acceptance Criteria
+- test passes
+
+## Implementation Notes
+None.
+EOF
+
+# Run --decompose and expect FAIL (the spec is unsettled).
+if bash "$REPO_ROOT/scripts/work-validate.sh" --group demo-group --decompose >/tmp/vallorcine/decompose-out-1.txt 2>&1; then
+    fail "decompose invariant passed when it should have failed (unsettled spec)" \
+         "$(tail -5 /tmp/vallorcine/decompose-out-1.txt)"
+else
+    if grep -q "unsettled cross-WD reference" /tmp/vallorcine/decompose-out-1.txt; then
+        pass "decompose invariant correctly flags unsettled spec reference"
+    else
+        fail "decompose invariant failed but with wrong message" \
+             "$(tail -5 /tmp/vallorcine/decompose-out-1.txt)"
+    fi
+fi
+
+# Now add out_of_scope to work.md and expect PASS.
+cat > .work/demo-group/work.md <<'EOF'
+---
+group: demo-group
+goal: Test group for decompose invariant
+status: active
+created: 2026-04-24
+out_of_scope:
+  - "spec:test/nonexistent"
+---
+
+## Goal
+Test.
+
+## Scope
+### In scope
+- test
+
+### Out of scope
+- test/nonexistent — declared out of scope for this group
+
+## Ordering Constraints
+None.
+
+## Shared Interfaces
+None.
+
+## Success Criteria
+- test passes
+EOF
+
+if bash "$REPO_ROOT/scripts/work-validate.sh" --group demo-group --decompose >/tmp/vallorcine/decompose-out-2.txt 2>&1; then
+    pass "decompose invariant passes when reference is declared out_of_scope"
+else
+    fail "decompose invariant fails even with out_of_scope declaration" \
+         "$(tail -10 /tmp/vallorcine/decompose-out-2.txt)"
+fi
+
+# Now replace out_of_scope with another WD's produces: and expect PASS.
+cat > .work/demo-group/work.md <<'EOF'
+---
+group: demo-group
+goal: Test group
+status: active
+created: 2026-04-24
+---
+
+## Goal
+Test.
+
+## Scope
+### In scope
+- test
+
+### Out of scope
+- none
+
+## Ordering Constraints
+None.
+
+## Shared Interfaces
+None.
+
+## Success Criteria
+- test passes
+EOF
+
+cat > .work/demo-group/WD-02.md <<'EOF'
+---
+id: WD-02
+title: Test WD two — produces the spec WD-01 needs
+group: demo-group
+status: DRAFT
+domains: [test]
+artifact_deps: []
+produces:
+  - { type: spec, path: "test/nonexistent" }
+---
+
+## Summary
+Produces the spec WD-01 consumes.
+
+## Acceptance Criteria
+- spec authored
+
+## Implementation Notes
+None.
+EOF
+
+if bash "$REPO_ROOT/scripts/work-validate.sh" --group demo-group --decompose >/tmp/vallorcine/decompose-out-3.txt 2>&1; then
+    pass "decompose invariant passes when reference is satisfied by another WD's produces:"
+else
+    fail "decompose invariant fails when produces: lists the reference" \
+         "$(tail -10 /tmp/vallorcine/decompose-out-3.txt)"
+fi
+
+# Go back to repo root for cleanup
+cd "$REPO_ROOT"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+    exit 0
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Two related work-layer fixes aligned to the layer's design intent, discovered by chasing the "Ready to pick up / needs planning / nothing to plan" round-trip bug on jlsm.

### The bugs

**Gap 2 (quick UX):** `/work-status` suggested `/work-start` for READY WDs. `/work-start` rejects READY with "needs planning first." The round-trip kept biting.

**Gap 1 (structural):** `/work-decompose` was LLM-only scope-splitting — no `/research`, no `/architect`, no `/spec-author`. Each WD's `/work-plan` then re-did architecture independently in isolation. Parallel `/work-plan` runs across multiple WDs produced divergent interpretations because no group-level coordination surfaces had been settled. The whole "useful architectural direction at /work-plan time" the user was getting was each WD inventing its own.

### The fixes

**Gap 2** — `skills/work-status/SKILL.md`:
- Step 4 suggestions split by state: READY → `/work-plan` only; SPECIFIED → `/work-start` only; SPECIFYING/IMPLEMENTING → `/feature-resume`
- `--all` mode carries the same discipline with section headers (Ready to specify / Ready to implement / Resume in progress / Blocked)

**Gap 1** — `skills/work-decompose/SKILL.md` rewritten as Phase A/B/C:

- **Phase A — Seam-finding.** LLM analyzes scope, dispatches `/research` as subagents for unknowns that affect WD boundaries. Target-count framing (no more "5-8 WDs") dropped; natural composition drives WD count.
- **Phase B — Architect + shared-spec authoring.** User-serial `/architect` passes for each cross-WD decision (can't be parallelized — needs deliberation). `/spec-author` dispatches for companion specs + interface-contract specs. Documents the "breakdown ADR" pattern for when seams are unclear.
- **Phase C — Finalize.** Re-carves WDs given Phase B outputs, writes WD files, runs the invariant check.

**Scope discipline:** `/work-decompose` shapes relationships between chunks, never fully scopes each chunk. Zero-new-artifact outcomes are valid. `produces:` in WD frontmatter is now optional (previously forced an LLM prediction that was often inaccurate).

**New invariant** — `scripts/work-validate.sh --decompose`:
- Every cross-WD reference must resolve to (a) an existing artifact, (b) another WD's `produces:`, or (c) work.md's `out_of_scope:` list
- Mechanical check that prevents parallel `/work-plan` divergence — if decompose hasn't settled every coordination surface, the invariant fails and decomposition can't finalize
- New `out_of_scope:` frontmatter field on `work.md` for explicit opt-outs

## Test plan

- [x] New `tests/scenario-work-layer-alignment.sh` — 20 structural + functional invariants (20/20 pass)
- [x] Install suite: 59/59 pass
- [x] Related work suites: work-validate 17/17, work-resolve 16/16, work-creation 10/10, work-context 11/11, work-pipeline 11/11, work-curate 6/6
- [x] Adjacent: kb-scan-contract 22/22, hang-prevention 10/10
- [ ] Empirical validation on a real decomposition: next time a new work group gets decomposed, verify Phase A/B/C flow actually produces settled coordination artifacts before finalizing. jlsm's existing groups grandfather as-is.

## Files changed

| File | Change |
|---|---|
| `skills/work-status/SKILL.md` | Step 4 + --all mode routing by state, not jumbled |
| `skills/work-decompose/SKILL.md` | Phase A/B/C rewrite, scope discipline, `produces:` optional |
| `scripts/work-validate.sh` | New `--decompose` flag with cross-WD reference invariant |
| `tests/scenario-work-layer-alignment.sh` | New — 20 invariants defending the flow |

## Out of scope for this PR

- **Gap 3:** `/work-plan` doesn't yet consume the group-level envelope as givens. Runs `/feature-domains` independently. Needs a follow-up PR to wire envelope-consumption — but blocked on Gap 1 being in place first (there was no envelope to consume before).
- **Gap 4:** Cross-group dependencies still unenforced. jlsm's `implement-membership/work.md` declared a cross-group dep in prose; resolver ignores it. Independent concern, can ship separately.
- **Migration:** jlsm's existing 4 work groups were built under the old model. They grandfather as-is — no forced re-decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)