### PR TITLE
fix(work): work-layer followups (Gaps 3+4 + dry-run hardening)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,11 +22,13 @@ state of the project — what's happening now and what's next.
 
 *Last updated: 2026-04-24*
 
-**v0.14.3 shipped (main@`f23cc79`). Active branch `fix/kb-scan-actionable`
-— three coordinated fixes that make `.kb/` actionable across the
-coordinator, audit Suspect, and audit prove-fix. PR not yet opened; two
-follow-on investigations running on the same jlsm session (other
-workflow deviations, audit cost-per-bug) before cutting the PR.**
+**PR #59 merged (v0.14.4 + Phase A/B/C + /work-status routing).
+Follow-up PR open on `fix/work-layer-followups` — bundles Gap 4
+(cross-group deps via `external_deps:`) + Gap 3 (/work-plan and
+/feature-domains honour the group envelope). Two commits, 36/36
+scenario tests green, 59/59 install tests green. jlsm migration of
+`implement-membership` to `external_deps:` deferred to post-release —
+jlsm needs the upgraded kit first.**
 
 ### What's shipped since 2026-04-21
 
@@ -176,55 +178,43 @@ exists, not yet coded. No tag = needs both design and implementation.*
 
 ### Do next
 
-**Wrap the `fix/kb-scan-actionable` investigation, then open the PR.**
+**Merge the work-layer-followups PR, cut a release, then migrate
+jlsm's `implement-membership` cross-group dep.**
 
-The morning's WIP framing (KB isn't being loaded) was half-right. The
-shipped fix covers three distinct failure modes uncovered empirically
-on jlsm session `763f30a6-4194-4137-812f-97502540135e`:
+Gap 3 + Gap 4 from the original `/ideate continue` WIP are landed on
+`fix/work-layer-followups` (2 commits). Once merged and released, jlsm
+can upgrade the kit and the prose cross-group-dep declaration in
+`.work/implement-membership/work.md` can be replaced with an
+`external_deps:` entry. Also archive `implement-sstable-enhancements`
+(all WDs COMPLETE per prior session notes — verify and archive).
 
-| Surface | Subagents | Empirical finding | Fix shipped |
-|---|---:|---|---|
-| WU-TDD coordinator dispatch | 4 | All 4 dispatch prompts omit Step 8 entirely (zero KB keywords across 39K chars) | `/feature-coordinate` Step 1a now carries a **KB tendency-scan contract (MANDATORY)** fragment; Step 8 is MANDATORY with `tendency-scan-complete` substage + cycle-log append; coordinator-side verification greps for evidence post-return |
-| Audit Suspect | 27 | KB *does* flow through to packet (17/17 have KB content) — Suspect treats it as passive reference, not attack vectors; 2/95 findings cite KB | `suspect.md` adds a KB attack-pattern sweep step; finding schema gets `KB refs:`; summary reports `KB-driven` count |
-| Audit prove-fix | 83 | `prove-fix.md` has zero KB integration; 0/95 outputs cite KB | `prove-fix.md` Phase 1a1 KB fix-pattern lookup; `kb_refs` input/output; orchestrator forwards `kb_refs` per finding |
+**Shipped in v0.14.4 (2026-04-24):** KB actionable across coordinator /
+suspect / prove-fix, and prove-fix Phase 0c upstream-mitigation
+short-circuit. Empirical baseline on jlsm audit: $14.03/finding
+(95 findings, $1,333), projected floor ~$11/finding once fixes soak.
+Full narrative in SETTLED.md once graduated; summary preserved in
+git history via PR #58 + PR #59.
 
-The workflow-deviation scan also surfaced **D4: Phase 0 short-circuit
-bypassed for upstream-mitigated findings** — 16 of 36 IMPOSSIBLE
-returns on the jlsm run were mitigated by a prior prove-fix's upstream
-guard, but Phase 0 only checked the local construct and the agent went
-through full Phase 1 anyway. Bundled on this branch: `prove-fix.md`
-Phase 0 budget raised 2 → 4 turns, new 0c "upstream-mitigation check"
-reads up to 2 sibling `prove-fix-*.md` outputs and short-circuits to
-`IMPOSSIBLE / UPSTREAM_MITIGATED` when a caller-side guard blocks the
-attack path.
-
-Status: 22/22 regression invariants pass, 59/59 install tests pass,
-all related audit scenarios green (lens-security 23/23, state-gate 5/5,
-wontfix-obligation 5/5, aggregate-results 32/32, check-test-coverage
-13/13, dedup-findings 12/12), no regressions on hang-prevention
-scenario (10/10).
-
-**Cost-per-bug snapshot (Opus 4.7 API rates):** jlsm audit total
-$1,333, 95 findings, **$14.03/finding** (on trend with 7-audit historical
-$13.61 avg). Prove-fix is 82% of audit-subagent cost. D4 targets ~11%
-prove-fix waste (~$86/audit at this size); KB-actionable fixes
-(D1-D3) target another ~15-25% of findings that should pre-clear.
-Combined ceiling: projected $/finding floor ~$11 on audits with
-similar KB density.
-
-Non-findings verified: the initial "Suspect writing test files" signal
-was a classifier bug (prove-fix dispatch prompts reference
-`Suspect: <filename>`); TodoWrite discipline holding (0 subagent
-violations). Context thrash (D5 — 37/126 agents re-read same file 5+
-times) is intentional per the re-read-before-edit protocol; revisit
-only if post-D4 cost data shows it's still material.
-
-**Next: open the PR.**
+**Landed on fix/work-layer-followups (not yet released):**
+- **Gap 4** — `external_deps:` on `work.md` lets a group declare that
+  all its WDs are BLOCKED until a sibling group reaches COMPLETE.
+  `scripts/work-resolve.sh` applies the gate to DRAFT and SPECIFIED
+  WDs; IMPLEMENTING/COMPLETE/SPECIFYING are left alone.
+  `scripts/work-validate.sh` checks shape and referenced-group
+  existence, and now rejects cross-group `wd:` artifact_deps so
+  validate and runtime agree on what's reachable.
+  Tests: `scenario-work-cross-group-deps.sh` (11/11).
+- **Gap 3** — `/work-plan` Step 4a brief template has an AUTHORITATIVE
+  "Group Envelope" section. `/feature-domains` Step 2 reads it,
+  classifies envelope-covered domains as `resolved` without a fresh
+  `/architect` dispatch, and escalates WD-local contradictions back to
+  `/work-decompose` via a new `escalate-decompose` classification.
+  `/work-plan` Step 5b dedupes spec authoring against the envelope.
+  Tests: 5 new invariants in `scenario-work-layer-alignment.sh` (25/25).
 
 **Positioning shift (still outstanding — carries over from v0.14.3):**
 emphasize depth-of-spec-rigor axis over the "spec-driven" label across
-user-facing docs. Not a blocker for the current PR; bundle with the
-next docs pass.
+user-facing docs. Bundle with the next docs pass.
 
 ### Do soon (medium effort, clear designs)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,10 +25,12 @@ state of the project — what's happening now and what's next.
 **PR #59 merged (v0.14.4 + Phase A/B/C + /work-status routing).
 Follow-up PR open on `fix/work-layer-followups` — bundles Gap 4
 (cross-group deps via `external_deps:`) + Gap 3 (/work-plan and
-/feature-domains honour the group envelope). Two commits, 36/36
-scenario tests green, 59/59 install tests green. jlsm migration of
-`implement-membership` to `external_deps:` deferred to post-release —
-jlsm needs the upgraded kit first.**
+/feature-domains honour the group envelope) plus three pre-existing
+bugs and four SKILL.md guidance refinements surfaced empirically by
+exercising the kit end-to-end against a fresh work group on a local
+jlsm clone. Six commits, 36/36 scenario tests + 59/59 install tests
+green. jlsm migration of `implement-membership` to `external_deps:`
+deferred to post-release — jlsm needs the upgraded kit first.**
 
 ### What's shipped since 2026-04-21
 
@@ -211,6 +213,29 @@ git history via PR #58 + PR #59.
   `/work-decompose` via a new `escalate-decompose` classification.
   `/work-plan` Step 5b dedupes spec authoring against the envelope.
   Tests: 5 new invariants in `scenario-work-layer-alignment.sh` (25/25).
+- **Three pre-existing bugs surfaced empirically by dry-running the
+  kit against a local jlsm clone:**
+  - `work_fm_produces` parser dropped `slug:` for ADR produces (78
+    false-alarm validation errors across 13 jlsm decisions-backlog
+    WDs → 0).
+  - Validate-vs-resolve spec lookup asymmetry (single-WD validate was
+    ID-only; resolve accepted slash-paths). Both now share
+    `work_check_spec_dep` with Strategy 0 ID lookup + path fallbacks.
+  - `wd:` state mismatch was incorrectly a validation FAIL — natural
+    mid-flight state was being double-reported. Now resolver-only
+    (resolver continues to surface as BLOCKED). Test 17 inverted to
+    match the corrected contract.
+- **Four SKILL.md guidance refinements** from the same dry-run:
+  /work scoping interview leads with tradeoff analysis before
+  AskUserQuestion; /work-decompose Phase A research-dispatch criterion
+  ("dispatch when the answer changes WD shape"); Phase B decidability
+  test ("settle now when shape isn't decidable from any single WD's
+  perspective"); SPECIFIED-vs-COMPLETE choice for `wd:` deps surfaced
+  explicitly (default-by-precedent was COMPLETE → fully sequential;
+  SPECIFIED unlocks parallel planning under Group Envelope).
+- **Empirical Gap 3 still untested.** Structural tests prove the
+  SKILL.md says the right things; first real `/work-plan` run on a
+  WD with a Group Envelope is the actual validation.
 
 **Positioning shift (still outstanding — carries over from v0.14.3):**
 emphasize depth-of-spec-rigor axis over the "spec-driven" label across

--- a/scripts/work-lib.sh
+++ b/scripts/work-lib.sh
@@ -272,11 +272,16 @@ work_list_groups() {
 }
 
 # ── Check if a spec artifact exists and is in required state ─────────────────
+# Accepts either a spec ID (e.g., "auth.jwt-contract", period form) or a
+# slash-path (e.g., "auth/jwt-contract"). The two forms are equivalent —
+# Strategy 0 tries the ID lookup first; Strategies 1-3 fall back to path
+# matching. validate and resolve both delegate here so single-WD validate
+# and decompose-invariant treat refs identically.
 # Returns 0 if met, 1 if not. Writes reason to stdout on failure.
 work_check_spec_dep() {
   local project_root="$1"
-  local spec_path="$2"       # e.g., "auth/jwt-token-contract"
-  local required_state="$3"  # e.g., "APPROVED"
+  local spec_path="$2"
+  local required_state="$3"
   local manifest="$project_root/.spec/registry/manifest.json"
 
   if [[ ! -f "$manifest" ]]; then
@@ -284,56 +289,64 @@ work_check_spec_dep() {
     return 1
   fi
 
-  # Search by multiple matching strategies against manifest features
   local found_file=""
   local found_state=""
 
-  # Extract domain and name from spec_path (e.g., "auth/jwt-token-contract")
-  local spec_domain="${spec_path%%/*}"
-  local spec_name="${spec_path##*/}"
+  # Strategy 0: spec_path is a literal spec ID. Direct manifest lookup.
+  local id_file
+  id_file=$(spec_file_for_id "$manifest" "$spec_path")
+  if [[ -n "$id_file" && -f "$id_file" ]]; then
+    found_file="$id_file"
+    found_state=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$id_file" \
+      | jq -r '.state // ""' 2>/dev/null || true)
+  fi
 
-  while IFS= read -r fid; do
-    # spec_file_for_id resolves the absolute path for both v1 and v2 manifests.
-    local absfile
-    absfile=$(spec_file_for_id "$manifest" "$fid")
-    [[ -z "$absfile" ]] && continue
-    # Re-derive the path relative to .spec/ for substring matching. Callers
-    # pass spec_path as "<domain>/<name>", so we match against the tail of the
-    # resolved path.
-    local latest="${absfile#"$project_root"/.spec/}"
+  # Strategies 1-3: slash-path matching. Iterate manifest IDs and substring-
+  # match the spec_path against each spec's relative file path. Used when
+  # callers pass "<domain>/<name>" rather than a registered ID.
+  if [[ -z "$found_file" ]]; then
+    local spec_domain="${spec_path%%/*}"
+    local spec_name="${spec_path##*/}"
 
-    local match=false
+    while IFS= read -r fid; do
+      local absfile
+      absfile=$(spec_file_for_id "$manifest" "$fid")
+      [[ -z "$absfile" ]] && continue
+      local latest="${absfile#"$project_root"/.spec/}"
 
-    # Strategy 1: exact substring match
-    [[ "$latest" == *"$spec_path"* ]] && match=true
+      local match=false
 
-    # Strategy 2: domain directory match + filename contains spec_name
-    if [[ "$match" != "true" ]]; then
-      local latest_basename="${latest##*/}"
-      latest_basename="${latest_basename%.md}"  # strip .md
-      if [[ "$latest" == *"/$spec_domain/"* && "$latest_basename" == *"$spec_name"* ]]; then
-        match=true
+      # Strategy 1: exact substring match
+      [[ "$latest" == *"$spec_path"* ]] && match=true
+
+      # Strategy 2: domain directory match + filename contains spec_name
+      if [[ "$match" != "true" ]]; then
+        local latest_basename="${latest##*/}"
+        latest_basename="${latest_basename%.md}"
+        if [[ "$latest" == *"/$spec_domain/"* && "$latest_basename" == *"$spec_name"* ]]; then
+          match=true
+        fi
       fi
-    fi
 
-    # Strategy 3: spec_name is a suffix of the filename (handles F01- prefix)
-    if [[ "$match" != "true" ]]; then
-      local latest_basename="${latest##*/}"
-      latest_basename="${latest_basename%.md}"
-      if [[ "$latest_basename" == *"-$spec_name" || "$latest_basename" == "$spec_name" ]]; then
-        match=true
+      # Strategy 3: spec_name is a suffix of the filename (handles F01- prefix)
+      if [[ "$match" != "true" ]]; then
+        local latest_basename="${latest##*/}"
+        latest_basename="${latest_basename%.md}"
+        if [[ "$latest_basename" == *"-$spec_name" || "$latest_basename" == "$spec_name" ]]; then
+          match=true
+        fi
       fi
-    fi
 
-    if [[ "$match" == "true" ]]; then
-      found_file="$absfile"
-      if [[ -f "$found_file" ]]; then
-        found_state=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$found_file" \
-          | jq -r '.state // ""' 2>/dev/null || true)
+      if [[ "$match" == "true" ]]; then
+        found_file="$absfile"
+        if [[ -f "$found_file" ]]; then
+          found_state=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$found_file" \
+            | jq -r '.state // ""' 2>/dev/null || true)
+        fi
+        break
       fi
-      break
-    fi
-  done < <(spec_manifest_ids "$manifest")
+    done < <(spec_manifest_ids "$manifest")
+  fi
 
   if [[ -z "$found_file" || ! -f "$found_file" ]]; then
     echo "spec not found: $spec_path"

--- a/scripts/work-lib.sh
+++ b/scripts/work-lib.sh
@@ -169,6 +169,9 @@ work_fm_artifact_deps() {
 
 # ── Extract produces as structured records ───────────────────────────────────
 # Same format as artifact_deps output: type|path|state|kind
+# Accepts path:, slug:, or ref: as the identifier — ADR produces conventionally
+# use slug: (matches .decisions/<slug>/adr.md layout), while spec produces use
+# path:. Mirrors work_fm_artifact_deps so the two parsers agree on shape.
 work_fm_produces() {
   local file="$1"
   awk '
@@ -181,7 +184,7 @@ work_fm_produces() {
           line = $0
           sub(/^  - \{[ ]*/, "", line)
           sub(/\}[ ]*$/, "", line)
-          dep_type = ""; dep_path = ""; kind = ""
+          dep_type = ""; dep_path = ""; dep_slug = ""; kind = ""
           n_fields = split(line, fields, ",")
           for (i = 1; i <= n_fields; i++) {
             gsub(/^[ ]+|[ ]+$/, "", fields[i])
@@ -196,9 +199,12 @@ work_fm_produces() {
             gsub(/^["'"'"']|["'"'"']$/, "", val)
             if (kv[1] == "type") dep_type = val
             else if (kv[1] == "path") dep_path = val
+            else if (kv[1] == "slug") dep_slug = val
+            else if (kv[1] == "ref") dep_path = val
             else if (kv[1] == "kind") kind = val
           }
-          print dep_type "|" dep_path "||" kind
+          ref = (dep_path != "") ? dep_path : dep_slug
+          print dep_type "|" ref "||" kind
         } else if ($0 !~ /^  /) {
           in_prod = 0
         }

--- a/scripts/work-lib.sh
+++ b/scripts/work-lib.sh
@@ -207,6 +207,50 @@ work_fm_produces() {
   ' "$file"
 }
 
+# ── Extract external_deps as structured records ─────────────────────────────
+# Group-level frontmatter on work.md that applies to every WD in the group.
+# Shape: external_deps: [ { type: group, ref: "<slug>", required_state: COMPLETE } ]
+# Output: one line per dep in format: type|ref|required_state
+# Usage: work_fm_external_deps <work-md-file>
+work_fm_external_deps() {
+  local file="$1"
+  awk '
+    /^---$/ { n++; next }
+    n >= 2 { exit }
+    n == 1 {
+      if ($0 ~ /^external_deps:/) { in_deps = 1; next }
+      if (in_deps) {
+        if ($0 ~ /^  - \{/) {
+          line = $0
+          sub(/^  - \{[ ]*/, "", line)
+          sub(/\}[ ]*$/, "", line)
+          dep_type = ""; dep_ref = ""; req_state = ""
+          n_fields = split(line, fields, ",")
+          for (i = 1; i <= n_fields; i++) {
+            gsub(/^[ ]+|[ ]+$/, "", fields[i])
+            split(fields[i], kv, ":")
+            gsub(/^[ ]+|[ ]+$/, "", kv[1])
+            val = ""
+            for (j = 2; j <= length(kv); j++) {
+              if (j > 2) val = val ":"
+              val = val kv[j]
+            }
+            gsub(/^[ ]+|[ ]+$/, "", val)
+            gsub(/^["'"'"']|["'"'"']$/, "", val)
+            if (kv[1] == "type") dep_type = val
+            else if (kv[1] == "ref") dep_ref = val
+            else if (kv[1] == "required_state") req_state = val
+            else if (kv[1] == "required_status") req_state = val
+          }
+          print dep_type "|" dep_ref "|" req_state
+        } else if ($0 !~ /^  /) {
+          in_deps = 0
+        }
+      }
+    }
+  ' "$file"
+}
+
 # ── List all work definition files in a group ────────────────────────────────
 # Returns absolute paths, one per line.
 work_list_wds() {
@@ -317,6 +361,51 @@ work_check_adr_dep() {
       echo "ADR $slug is $actual_status (need $required_status)"
       return 1
     fi
+  fi
+
+  return 0
+}
+
+# ── Check if a work group meets an external_deps required_state ──────────────
+# Group is COMPLETE iff every WD in the group has status COMPLETE.
+# Returns 0 + empty output if met. Returns 1 + reason string on failure.
+# Usage: work_check_group_dep <work_dir> <group_slug> <required_state>
+work_check_group_dep() {
+  local work_dir="$1"
+  local group_slug="$2"
+  local required_state="$3"
+  local group_dir="$work_dir/$group_slug"
+
+  if [[ ! -d "$group_dir" ]]; then
+    echo "group '$group_slug' not found"
+    return 1
+  fi
+
+  # Only COMPLETE is supported currently — see scripts/work-validate.sh.
+  if [[ "$required_state" != "COMPLETE" ]]; then
+    echo "unsupported required_state '$required_state' (only COMPLETE)"
+    return 1
+  fi
+
+  local total=0
+  local complete=0
+  local wd_file
+  local wd_status
+  while IFS= read -r wd_file; do
+    [[ -z "$wd_file" ]] && continue
+    ((total++)) || true
+    wd_status=$(work_fm "$wd_file" "status")
+    [[ "$wd_status" == "COMPLETE" ]] && { ((complete++)) || true; }
+  done < <(work_list_wds "$group_dir")
+
+  if (( total == 0 )); then
+    echo "group '$group_slug' has no WDs"
+    return 1
+  fi
+
+  if (( complete < total )); then
+    echo "group '$group_slug' is $complete/$total COMPLETE (need all)"
+    return 1
   fi
 
   return 0

--- a/scripts/work-resolve.sh
+++ b/scripts/work-resolve.sh
@@ -38,6 +38,33 @@ GROUP_DIR="$WORK_DIR/$GROUP_SLUG"
   exit 1
 }
 
+# ── Cross-group dependencies (external_deps on work.md) ─────────────────────
+# Any unmet external dep becomes a uniform blocker applied to all DRAFT and
+# SPECIFIED WDs in this group. IMPLEMENTING, SPECIFYING, and COMPLETE WDs
+# are left alone — already-in-flight or finished work is not retroactively
+# un-done by a later external_deps declaration.
+
+EXTERNAL_BLOCKER=""
+GROUP_WORK_MD="$GROUP_DIR/work.md"
+if [[ -f "$GROUP_WORK_MD" ]]; then
+  work_dir_abs="$WORK_DIR"
+  while IFS='|' read -r ext_type ext_ref ext_req_state; do
+    [[ -z "$ext_type" ]] && continue
+    ext_reason=""
+    case "$ext_type" in
+      group)
+        ext_reason=$(work_check_group_dep "$work_dir_abs" "$ext_ref" "$ext_req_state") || true
+        ;;
+      *)
+        ext_reason="unknown external_deps type: $ext_type"
+        ;;
+    esac
+    if [[ -n "$ext_reason" ]]; then
+      EXTERNAL_BLOCKER+="external $ext_type:$ext_ref — $ext_reason"$'\n'
+    fi
+  done < <(work_fm_external_deps "$GROUP_WORK_MD")
+fi
+
 # ── Collect all work definitions ─────────────────────────────────────────────
 
 declare -A WD_STATUS    # id -> status
@@ -106,6 +133,8 @@ while IFS= read -r wd_file; do
       fi
     done < <(work_fm_artifact_deps "$wd_file")
     WD_DEP_COUNT["$wd_id"]=$spec_dep_count
+    # Apply any group-level external_deps gate.
+    [[ -n "$EXTERNAL_BLOCKER" ]] && spec_blockers+="$EXTERNAL_BLOCKER"
     if [[ -z "$spec_blockers" ]]; then
       WD_STATUS["$wd_id"]="SPECIFIED"
       ((SPECIFIED_COUNT++)) || true
@@ -153,6 +182,9 @@ while IFS= read -r wd_file; do
   done < <(work_fm_artifact_deps "$wd_file")
 
   WD_DEP_COUNT["$wd_id"]=$dep_count
+
+  # Apply any group-level external_deps gate.
+  [[ -n "$EXTERNAL_BLOCKER" ]] && blockers+="$EXTERNAL_BLOCKER"
 
   if [[ -z "$blockers" ]]; then
     WD_STATUS["$wd_id"]="READY"

--- a/scripts/work-validate.sh
+++ b/scripts/work-validate.sh
@@ -141,9 +141,16 @@ validate_wd_file() {
             # check deferred until ADR schema is revisited.
             ;;
           wd)
+            # wd: deps are scoped to the WD's own group. Cross-group
+            # coordination belongs in work.md's external_deps:. A wd: ref
+            # to another group validates OK today but is unreachable at
+            # runtime (scripts/work-resolve.sh populates its WD table from
+            # the current group only), so catch the mismatch here.
             if [[ ! -d "$project_root/.work" ]]; then
               echo "  WARN: cannot verify wd '$dep_ref' — no .work/ directory" >&2
             else
+              local current_group_dir
+              current_group_dir="$(dirname "$file")"
               local wd_found=0
               local wd_f
               while IFS= read -r wd_f; do
@@ -161,9 +168,24 @@ validate_wd_file() {
                   fi
                   break
                 fi
-              done < <(find "$project_root/.work" -name "WD-*.md" 2>/dev/null)
+              done < <(find "$current_group_dir" -maxdepth 1 -name "WD-*.md" 2>/dev/null)
               if [[ $wd_found -eq 0 ]]; then
-                errors+=("artifact_deps: wd '$dep_ref' not found in .work/")
+                local cross_group=0
+                local other_f
+                while IFS= read -r other_f; do
+                  [[ -z "$other_f" ]] && continue
+                  local other_id
+                  other_id="$(work_fm "$other_f" "id" 2>/dev/null)"
+                  if [[ "$other_id" == "$dep_ref" ]]; then
+                    cross_group=1
+                    break
+                  fi
+                done < <(find "$project_root/.work" -name "WD-*.md" 2>/dev/null)
+                if (( cross_group == 1 )); then
+                  errors+=("artifact_deps: wd '$dep_ref' is in a different group — use external_deps: on work.md for cross-group coordination")
+                else
+                  errors+=("artifact_deps: wd '$dep_ref' not found in group")
+                fi
               fi
             fi
             ;;
@@ -302,6 +324,78 @@ check_circular_deps() {
   done
 
   return $cycles_found
+}
+
+# ── External deps: group-level cross-group coordination gate ────────────────
+#
+# work.md may declare external_deps: — a list of references to sibling work
+# groups that must reach a required_state before this group's WDs are ready.
+# Validates shape and that referenced groups exist. Only type=group with
+# required_state=COMPLETE is currently supported; scripts/work-lib.sh's
+# work_check_group_dep enforces the same restriction at runtime.
+
+validate_external_deps() {
+  local group_dir="$1"
+  local work_md="$group_dir/work.md"
+
+  # work.md is optional — some groups predate it. Nothing to validate.
+  [[ ! -f "$work_md" ]] && return 0
+
+  local work_dir
+  work_dir="$(dirname "$group_dir")"
+
+  local errors=()
+  local ent_count=0
+  local ext_type ext_ref ext_req_state
+  while IFS='|' read -r ext_type ext_ref ext_req_state; do
+    [[ -z "$ext_type" ]] && continue
+    ((ent_count++)) || true
+
+    if [[ "$ext_type" != "group" ]]; then
+      errors+=("external_deps: invalid type '$ext_type' (only 'group' supported)")
+      continue
+    fi
+
+    if [[ -z "$ext_ref" ]]; then
+      errors+=("external_deps: missing ref for group entry")
+      continue
+    fi
+
+    if [[ -z "$ext_req_state" ]]; then
+      errors+=("external_deps: group:$ext_ref missing required_state")
+      continue
+    fi
+
+    if [[ "$ext_req_state" != "COMPLETE" ]]; then
+      errors+=("external_deps: group:$ext_ref required_state '$ext_req_state' unsupported (only COMPLETE)")
+      continue
+    fi
+
+    if [[ ! -d "$work_dir/$ext_ref" ]]; then
+      errors+=("external_deps: referenced group '$ext_ref' does not exist")
+    fi
+
+    local self_slug
+    self_slug="$(basename "$group_dir")"
+    if [[ "$ext_ref" == "$self_slug" ]]; then
+      errors+=("external_deps: group '$ext_ref' references itself")
+    fi
+  done < <(work_fm_external_deps "$work_md")
+
+  if (( ${#errors[@]} > 0 )); then
+    echo "  FAIL  external_deps in $work_md"
+    for err in "${errors[@]}"; do
+      echo "    $err"
+    done
+    return 1
+  fi
+
+  if (( ent_count > 0 )); then
+    echo "  PASS  $ent_count external_deps entry(ies) valid"
+  else
+    echo "  PASS  no external_deps declared"
+  fi
+  return 0
 }
 
 # ── Decompose invariant: every cross-WD reference has a group-level artifact ─
@@ -443,6 +537,13 @@ if [[ "$GROUP_MODE" == "true" ]]; then
     echo "  PASS  No circular dependencies"
   else
     echo "  FAIL  Circular dependencies detected"
+    ((total_errors++)) || true
+  fi
+
+  # Check external_deps shape + referenced group existence
+  echo ""
+  echo "── External deps check"
+  if ! validate_external_deps "$GROUP_DIR"; then
     ((total_errors++)) || true
   fi
 

--- a/scripts/work-validate.sh
+++ b/scripts/work-validate.sh
@@ -115,18 +115,27 @@ validate_wd_file() {
             local manifest="$project_root/.spec/registry/manifest.json"
             if [[ ! -f "$manifest" ]]; then
               echo "  WARN: cannot verify spec '$dep_ref' — no .spec/registry/manifest.json" >&2
-            elif ! declare -f spec_file_for_id >/dev/null; then
-              echo "  WARN: cannot verify spec '$dep_ref' — spec-lib.sh not loaded" >&2
             else
-              local target
-              target="$(spec_file_for_id "$manifest" "$dep_ref")"
-              if [[ -z "$target" || ! -f "$target" ]]; then
-                errors+=("artifact_deps: spec '$dep_ref' not found in registry (dead reference)")
-              elif [[ -n "$dep_req_state" ]]; then
-                local actual
-                actual="$(fm "$target" '.state // ""')"
-                if [[ -n "$actual" && "$actual" != "$dep_req_state" ]]; then
-                  errors+=("artifact_deps: spec '$dep_ref' has state '$actual', required_state is '$dep_req_state'")
+              # Delegate to work_check_spec_dep so validate and resolve agree
+              # on what counts as a resolvable reference. Accepts both spec ID
+              # (period-style) and slash-path forms.
+              local spec_reason
+              spec_reason="$(work_check_spec_dep "$project_root" "$dep_ref" "$dep_req_state")" || true
+              if [[ -n "$spec_reason" ]]; then
+                if [[ "$spec_reason" == "spec not found"* ]]; then
+                  errors+=("artifact_deps: spec '$dep_ref' not found in registry (dead reference)")
+                elif [[ "$spec_reason" == *"need "* ]]; then
+                  # Re-format as "has state 'X', required_state is 'Y'" for the
+                  # established test contract.
+                  local actual_state
+                  actual_state="$(echo "$spec_reason" | sed -n "s/^spec [^ ]* is \(.*\) (need .*)$/\1/p")"
+                  if [[ -n "$actual_state" ]]; then
+                    errors+=("artifact_deps: spec '$dep_ref' has state '$actual_state', required_state is '$dep_req_state'")
+                  else
+                    errors+=("artifact_deps: spec '$dep_ref' state mismatch: $spec_reason")
+                  fi
+                else
+                  errors+=("artifact_deps: spec '$dep_ref': $spec_reason")
                 fi
               fi
             fi
@@ -146,6 +155,13 @@ validate_wd_file() {
             # to another group validates OK today but is unreachable at
             # runtime (scripts/work-resolve.sh populates its WD table from
             # the current group only), so catch the mismatch here.
+            #
+            # State mismatch (target WD's current status != required_state) is
+            # NOT a validation FAIL. wd: deps describe the eventual ordering;
+            # at any moment, some siblings are upstream and some are downstream
+            # of one another. scripts/work-resolve.sh surfaces this as BLOCKED
+            # with a clear reason. Double-reporting it as FAIL here was noisy
+            # for active groups and blocked legitimate fresh decompositions.
             if [[ ! -d "$project_root/.work" ]]; then
               echo "  WARN: cannot verify wd '$dep_ref' — no .work/ directory" >&2
             else
@@ -159,13 +175,6 @@ validate_wd_file() {
                 wd_id="$(work_fm "$wd_f" "id")"
                 if [[ "$wd_id" == "$dep_ref" ]]; then
                   wd_found=1
-                  if [[ -n "$dep_req_state" ]]; then
-                    local wd_status
-                    wd_status="$(work_fm "$wd_f" "status")"
-                    if [[ -n "$wd_status" && "$wd_status" != "$dep_req_state" ]]; then
-                      errors+=("artifact_deps: wd '$dep_ref' has status '$wd_status', required_status is '$dep_req_state'")
-                    fi
-                  fi
                   break
                 fi
               done < <(find "$current_group_dir" -maxdepth 1 -name "WD-*.md" 2>/dev/null)

--- a/skills/feature-domains/SKILL.md
+++ b/skills/feature-domains/SKILL.md
@@ -202,7 +202,28 @@ For each pending domain:
    pass through silently to the test phase where the spec analyst pre-pass
    (Step 1c of /feature-test) will read and apply them.
 5. Read `.decisions/CLAUDE.md` — check for relevant ADR
-6. **Work group context:** If `.work/` exists, run:
+6. **Group envelope (AUTHORITATIVE).** If `brief.md` has a `## Group Envelope`
+   section, it lists group-level specs/ADRs/KB entries that the enclosing work
+   group settled during `/work-decompose` Phase B. Read each one's content:
+   - For a `spec <domain>/<name>` entry: open `.spec/domains/<domain>/<name>.md`
+     (or resolve via `.spec/registry/manifest.json`) and read the requirement
+     statements.
+   - For an `adr <slug>` entry: open `.decisions/<slug>/adr.md` and read the
+     decision.
+
+   Then check if the envelope item covers the current domain's decision. If yes,
+   classify the domain as `resolved` with source `group envelope: <ref>` — no
+   `/architect` dispatch. Envelope hits take precedence over Step 5's
+   `.decisions/CLAUDE.md` scan (same classification, explicit source).
+
+   **Contradiction escalation.** If WD-local analysis would reach a decision that
+   contradicts an envelope spec or ADR (different data shape, incompatible
+   assumption, overlapping scope with divergent intent), do NOT override locally.
+   Classify the domain as `escalate-decompose` with a note describing the
+   contradiction. The user must revisit `/work-decompose` to surface the
+   cross-WD decision that was missed in Phase B. See "Classification rules"
+   below.
+7. **Work group context (redundancy hint).** If `.work/` exists, run:
    ```bash
    bash .claude/scripts/work-context.sh --domains "<current domain>"
    ```
@@ -211,7 +232,10 @@ For each pending domain:
    this domain — its domain results may be reusable." This avoids commissioning
    redundant research across related work definitions. Do not display the full
    work context — just note the overlap for the Domain Scout's classification.
-7. Classify using the rules below
+   This is distinct from Step 6's group envelope check — envelope items are
+   AUTHORITATIVE (skip decision entirely); redundancy hints are ADVISORY (reuse
+   prior analysis if relevant).
+8. Classify using the rules below
 
 ### Classification rules
 
@@ -242,6 +266,21 @@ checks for existing coverage — it does not make architectural decisions.
 
 **`pending-research`** — KB gap exists and research is needed before a decision
 can be made (or the domain is purely informational with no decision component).
+
+**`escalate-decompose`** — WD-local analysis would contradict a group-level
+spec or ADR listed in the brief's `## Group Envelope` section. The
+decomposition assumed a shared shape or decision that doesn't actually fit
+this WD, so the contradiction is a cross-WD concern that Phase B missed.
+Stop domain analysis for this feature and tell the user:
+```
+  ⚠ ESCALATE  <domain> — contradicts group envelope item <ref>
+              <one-line description of the contradiction>
+
+  This surfaces a cross-WD decision Phase B missed. Revisit with:
+    /work-decompose "<group-slug>"
+```
+Do NOT self-resolve. Do NOT override the envelope. Decomposition must settle
+this before planning can continue.
 
 **`skipped`** — user explicitly confirmed proceeding without coverage.
 
@@ -276,8 +315,39 @@ Display:
 
 ## Step 3 — Resolve missing work (pending domains only)
 
-Process each pending domain in order. For each one, resolve it before moving
-to the next — don't batch commissions and leave them for the user.
+### Escalation check (always first)
+
+If any domain was classified `escalate-decompose` during Step 2, do NOT
+proceed with resolution. Phase B of `/work-decompose` missed a cross-WD
+coordination surface that WD-local analysis has now surfaced. Display:
+
+```
+───────────────────────────────────────────────
+🚨 ESCALATE to /work-decompose · <slug>
+───────────────────────────────────────────────
+Domain(s) contradict the group envelope:
+  - <domain A> — contradicts <envelope ref>: <short reason>
+  - <domain B> — contradicts <envelope ref>: <short reason>
+
+Group-level decomposition missed these cross-WD decisions. Fix at the
+group level, not locally — overriding the envelope here would leave
+sibling WDs planning against stale assumptions.
+
+Next:
+  /work-decompose "<group-slug>"
+
+Domain analysis will resume after the new envelope is settled.
+───────────────────────────────────────────────
+```
+
+Set status.md: stage Domains → `escalated`, substage → `envelope-contradiction`.
+Append `domains-escalated-decompose` to cycle-log.md. Stop.
+
+### Resolve per-domain
+
+Process each remaining pending domain in order. For each one, resolve it
+before moving to the next — don't batch commissions and leave them for the
+user.
 
 ### If research is missing
 

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -184,8 +184,14 @@ arbitrary and wrong.
 
 ### 2b — Dispatch /research for unknowns that affect seam identification
 
-As you analyze the scope, if you hit an unknown that affects where the
-seams go, dispatch `/research` as a subagent:
+**Criterion:** dispatch `/research` when you cannot choose between two
+materially different decompositions without external information. If
+your uncertainty would only change WD-internal details, defer to
+`/work-plan`. If it would change the *shape* of the WD chunks or their
+boundaries, research now.
+
+As you analyze the scope, if you hit such an unknown, dispatch
+`/research` as a subagent:
 
 ```
 Invoke `/research "<subject>" context: "work-decompose for <group-slug>,
@@ -196,16 +202,20 @@ After each research subagent completes, verify the KB entry exists and
 continue seam analysis with the new findings. Multiple research
 dispatches are allowed — seam-finding is exploratory.
 
-Examples of unknowns that warrant `/research`:
+Examples that meet the criterion (different decompositions hinge on
+the answer):
 - "We're touching an unfamiliar protocol — what are the conventional
-  layering boundaries?"
+  layering boundaries?" (boundaries decide WD count and shape)
 - "Is there a canonical way to decompose this class of problem that we
-  should follow?"
+  should follow?" (canonical pattern dictates the carve)
 - "What existing patterns does the project already use here?"
+  (consistency with prior carves)
 
-Examples that do NOT warrant `/research`:
+Examples that do NOT meet the criterion (decomposition unaffected):
 - WD-internal technology choices (those surface in `/work-plan` later)
 - Implementation details (deferred to the feature pipeline)
+- Performance tuning decisions (don't change WD shape)
+- Algorithmic alternatives within a single WD (WD-local concern)
 
 ### 2c — Produce the seam analysis (internal — do not display yet)
 
@@ -287,7 +297,37 @@ If "Proceed to Phase B": continue to Step 4.
 Work through the coordination surfaces from Step 3 **one at a time**.
 Architect passes require user deliberation and cannot be parallelized.
 
-For each surface, in order:
+### When does an artifact belong in Phase B?
+
+The test is **decidability**: an artifact belongs in Phase B if its
+shape cannot be decided correctly from any single WD's perspective
+alone. Phase B authoring brings input from all future producers and
+consumers of the artifact at once, settling the shape before any of
+them plan.
+
+Concrete signals an artifact belongs in Phase B:
+- **Multi-producer.** Two or more WDs will emit data matching the
+  artifact's contract (the columnar telemetry signal schema is the
+  canonical example — both memtable and reader emit signals; neither
+  alone has the full picture).
+- **Multi-consumer with shape ambiguity.** Multiple WDs will consume
+  the artifact AND there's no canonical author whose perspective is
+  authoritative. (Bilateral producer→consumer relationships generally
+  do not need Phase B — the producer authors during `/work-plan` and
+  consumers reference via `artifact_deps`.)
+- **Cross-WD invariant.** The artifact enforces a property that must
+  hold across multiple WDs (e.g., "all WDs must use the same encoding
+  for IDs"). Local authoring would bake in one WD's needs and miss the
+  others'.
+
+When the test fails — the shape *is* decidable from one WD's
+perspective — let it sequence. The producing WD authors during
+`/work-plan`; downstream WDs reference via `artifact_deps` with
+`required_state: APPROVED`. This is the Group Envelope (Gap 3) flow
+and it's preferable when applicable: less coordination, less
+authoring-while-decomposing, simpler sequencing.
+
+For each surface that passes the decidability test, in order:
 
 ### Breakdown ADR (if seam shape was unclear)
 
@@ -373,6 +413,29 @@ For each final WD, determine:
   artifacts whose shape is already settled (typically Phase B outputs
   that this WD is the author-of-record for).
 
+### Choosing `required_state` for `wd:` deps
+
+`wd:` deps take a `required_state`. Pick deliberately — the default
+choice has real planning consequences:
+
+- **`required_state: SPECIFIED`** — downstream WD can be PLANNED as
+  soon as the upstream's spec is APPROVED (i.e., upstream `/work-plan`
+  finished, even if implementation hasn't). Allows planning to overlap
+  implementation: WD-03 can have its spec authored against WD-01's
+  approved spec while WD-01 is still being implemented. Use this when
+  the downstream consumes the upstream's *spec contract*, not its
+  implemented behavior.
+
+- **`required_state: COMPLETE`** — downstream WD cannot start planning
+  until upstream is fully implemented. Strict sequential. Use this when
+  the downstream needs the upstream's runtime behavior (e.g.,
+  integration tests against the real implementation, not the spec).
+
+Default: prefer `SPECIFIED` for spec-consumer relationships; reach for
+`COMPLETE` only when there's a runtime-coupling reason. The Group
+Envelope (Gap 3) reads `artifact_deps` to feed `/work-plan` — using
+`SPECIFIED` extends the parallelism the envelope enables.
+
 Present the final decomposition:
 
 ```
@@ -427,11 +490,19 @@ group: <group-slug>
 status: DRAFT
 domains: [<domain1>, <domain2>]
 artifact_deps:
+  # spec refs use `path:`. Either form is accepted:
+  #   - slash form  : "<domain>/<spec-name>"  (matches .spec/domains/<...>)
+  #   - ID form     : "<domain>.<spec-name>"  (matches the spec's id field)
   - { type: spec, path: "<domain>/<spec-name>", required_state: APPROVED }
+  # adr refs use `slug:` (matches .decisions/<slug>/adr.md)
   - { type: adr, slug: "<decision-slug>", required_status: accepted }
+  # wd refs use `ref:` (must point to a WD in the same group; cross-group
+  # coordination uses external_deps: on work.md instead)
+  - { type: wd, ref: "WD-<NN>", required_state: SPECIFIED }
 produces:
   - { type: spec, path: "<domain>/<spec-name>" }
   - { type: spec, path: "<domain>/<interface-name>", kind: interface-contract }
+  - { type: adr, slug: "<decision-slug>" }
 ---
 
 ## Summary
@@ -447,17 +518,26 @@ produces:
 **Numbering:** WD-01, WD-02, etc. — sequential, zero-padded to 2 digits.
 
 **artifact_deps rules:**
-- Only list artifacts this WD needs that don't yet exist or aren't in the
-  required state. Don't list artifacts that already exist and are APPROVED.
-- `type: spec` — path is relative to `.spec/domains/`, must include domain prefix
-- `type: adr` — slug matches `.decisions/<slug>/adr.md`
-- `type: kb` — path matches `.kb/<path>.md`
-- `type: wd` — ref is a WD ID in the same group (e.g., "WD-01"). Use for
-  code-level dependencies where one WD's implementation must complete before
-  another can start. Unlike artifact deps, wd deps express ordering constraints
-  that aren't mediated by a spec or ADR artifact.
-- spec, adr, and wd deps must include `required_state` or `required_status`
-- kb deps are existence-only (no state check)
+- Only list artifacts this WD needs whose state is part of the contract.
+  Always-APPROVED foundational specs that every WD reads are listed by
+  Phase A as "existing artifacts that apply" — they don't need per-WD
+  declaration unless the WD specifically gates on them.
+- `type: spec` uses `path:`. Both forms accepted:
+  - **slash form** — `"<domain>/<spec-name>"`, matches `.spec/domains/<...>.md`
+  - **ID form** — `"<domain>.<spec-name>"`, matches the spec's `id` field in
+    `.spec/registry/manifest.json`
+  Resolver and validator both accept either via `work_check_spec_dep`.
+- `type: adr` uses `slug:` — matches `.decisions/<slug>/adr.md` (single token,
+  no domain prefix).
+- `type: kb` uses `path:` — matches `.kb/<path>.md`.
+- `type: wd` uses `ref:` — a WD ID in the **same group** (e.g., `"WD-01"`).
+  Cross-group coordination uses `external_deps:` on `work.md` instead; the
+  validator rejects cross-group `wd:` refs with a pointer at `external_deps`.
+- `spec`, `adr`, `wd` deps must include `required_state` or `required_status`.
+  See "Choosing required_state for wd: deps" in Step 5 — `SPECIFIED` allows
+  parallel planning; `COMPLETE` forces sequential. Don't reach for `COMPLETE`
+  by reflex.
+- `kb` deps are existence-only (no state check).
 
 **produces rules:**
 - **Optional.** Leave empty (`produces: []`) for any WD whose outputs aren't

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -220,6 +220,10 @@ Draft:
 - **Existing artifacts that apply** — group-level ADRs/specs already in
   `.decisions/` or `.spec/` that constrain this work (don't re-author
   them).
+- **Cross-group blockers** — if this group can't start until another
+  work group finishes, that's an `external_deps:` on `work.md`, not a
+  coordination surface to settle here. Record it; Phase C will add the
+  frontmatter. See the work.md template in `/work` for shape.
 
 ---
 

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -168,8 +168,26 @@ Read the WD file (`.work/<group-slug>/WD-<nn>.md`). Build `brief.md` from:
 ## Constraints
 <WD Implementation Notes section content>
 
-## Artifact Dependencies (from work group)
-<List each artifact_dep with its current state>
+## Group Envelope (AUTHORITATIVE — from work group Phase B)
+
+Group-level artifacts settled during `/work-decompose` Phase B. **These are
+authoritative for WD-local analysis** — domain analysis must defer to them
+rather than re-deciding. If WD-local work would contradict an envelope item,
+that's an escalation back to `/work-decompose`, not a local override.
+
+For each artifact in the WD's `artifact_deps:`, write one entry:
+- **spec `<domain>/<name>`** — state: APPROVED — <title from spec frontmatter>
+  <one-sentence summary of what the spec settles>
+- **adr `<slug>`** — status: accepted — <title from adr.md H1>
+  <one-sentence summary of the decision>
+- **kb `<path>`** — <title from entry frontmatter>
+
+Also list explicit scope declarations from `work.md`:
+- **out_of_scope:** <items from work.md's out_of_scope frontmatter, if any>
+- **external_deps:** <entries from work.md's external_deps frontmatter, if any>
+
+If the WD has no artifact_deps and no group-level scope declarations, write:
+"No group envelope — this WD operates standalone within the work group."
 
 ## Produced Artifacts (expected outputs)
 <List each produces entry>
@@ -234,8 +252,20 @@ WHAT the system must do as a result. Without specs, the adversarial
 hardening and audit pipeline have nothing to falsify. Do not skip or
 bypass spec authoring for any WD type.
 
-Read `domains.md` to identify the specs that need to be authored. For
-each spec to produce, **in sequence**:
+Read `domains.md` to identify the specs that need to be authored.
+
+**Dedupe against the group envelope first.** Read the WD file's
+`artifact_deps:` from `.work/<group-slug>/WD-<nn>.md`. For any spec in
+`domains.md` whose identity matches an `artifact_deps` spec entry in
+APPROVED state, do NOT author it — the group already owns that spec and
+WD-local re-authoring would create divergent copies. Log the skip:
+
+```
+  ⊘ <spec-id> — deferred to group-level spec <ref> (APPROVED)
+```
+
+Authoring proceeds only for specs not already covered by the envelope.
+For each remaining spec to produce, **in sequence**:
 
 1. Invoke `/spec-author "<feature-id>" "<title>"` as a separate subagent.
    Each invocation gets a clean context but reads previously registered
@@ -255,6 +285,10 @@ Spec authoring: <completed>/<total>
   ✓ F24 — Pool-Aware Block Size Configuration (APPROVED)
   → F25 — Byte-Budget Block Cache (authoring...)
 ```
+
+If every spec in `domains.md` is covered by the envelope, Step 5b emits a
+no-op log line and Step 6 proceeds to finalize the WD — this is legitimate
+when Phase B settled the full spec surface for this WD.
 
 ---
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -88,6 +88,33 @@ Read the goal and privately identify unknowns across:
 - After each answer, update your internal model — skip questions the answer
   already covers
 
+### Lead with tradeoff analysis when the choice is non-obvious
+
+`AskUserQuestion` presents options with short labels and one-sentence
+descriptions. That works when the user can pick from labels alone. It
+does NOT work when the choice has implications the user can't see in a
+sentence — they'll either pick the wrong option or come back asking
+"what's the tradeoff?", forcing a retrofit.
+
+Default rule: **before any AskUserQuestion whose options have non-trivial
+consequences (architecture, scope boundary, dependency model), present
+the tradeoff analysis FIRST as prose, then call AskUserQuestion.**
+
+Concretely, the message preceding the AskUserQuestion should:
+- Name each option's blast radius and reversibility
+- Surface non-obvious second-order effects (e.g., "option B touches
+  shared types; option A doesn't")
+- Note industry precedent if relevant
+- Make a recommendation if you have a defensible one, but frame it as
+  the *user's call*, not yours
+
+This is more text than a bare AskUserQuestion. That's intentional. A
+user who picks an option without understanding the tradeoff is worse
+off than a user who reads two paragraphs and chooses correctly.
+
+Skip the tradeoff prelude only when the choice is genuinely simple
+(e.g., "kebab-case slug okay?" — yes/no, no second-order effects).
+
 ---
 
 ## Step 3 — Confirm work group scope

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -135,6 +135,12 @@ group: <group-slug>
 goal: <one sentence goal>
 status: active
 created: <YYYY-MM-DD>
+# Optional — declare cross-group blockers. Every WD in this group is
+# reported BLOCKED by scripts/work-resolve.sh until every listed group
+# reaches required_state=COMPLETE. Add only if seam analysis surfaces
+# a cross-group dependency; leave out otherwise.
+# external_deps:
+#   - { type: group, ref: "<other-group-slug>", required_state: COMPLETE }
 ---
 
 ## Goal

--- a/tests/scenario-work-cross-group-deps.sh
+++ b/tests/scenario-work-cross-group-deps.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Scenario: cross-group dependencies via work.md external_deps
+#
+# Tests:
+# 1. external_deps{group=B,COMPLETE} with B in mixed state blocks group-A DRAFT
+#    WDs with a clear external reason.
+# 2. Same setup blocks group-A SPECIFIED WDs.
+# 3. Once all group-B WDs are COMPLETE, group-A WDs unblock.
+# 4. external_deps referencing a missing group is flagged as a blocker at
+#    resolve-time and as an error at validate-time.
+# 5. work-validate.sh --group flags malformed external_deps (wrong type,
+#    unsupported required_state, self-reference, missing ref).
+# 6. work-resolve.sh ignores IMPLEMENTING/COMPLETE WDs for the external_deps
+#    gate (doesn't retroactively un-do in-flight or finished work).
+# 7. work-validate.sh rejects a wd: artifact_dep that points at a WD in a
+#    different group — cross-group coordination must use external_deps.
+#
+# Run from repo root: bash tests/scenario-work-cross-group-deps.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-work-cross-group-deps"
+
+# ── Test helpers ─────────────────────────────────────────────────────────────
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ""
+echo "scenario: cross-group dependencies (external_deps)"
+echo "────────────────────────────────────────────────"
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+cleanup
+mkdir -p "$TEST_BASE/project/.work/group-a"
+mkdir -p "$TEST_BASE/project/.work/group-b"
+mkdir -p "$TEST_BASE/project/.claude/scripts"
+
+cp "$REPO_ROOT/scripts/work-resolve.sh"  "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/scripts/work-validate.sh" "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/scripts/work-lib.sh"      "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh"      "$TEST_BASE/project/.claude/scripts/"
+
+cd "$TEST_BASE/project"
+
+write_wd() {
+    local group="$1"
+    local id="$2"
+    local status="$3"
+    cat > ".work/$group/$id.md" << EOF
+---
+id: $id
+title: $id of $group
+group: $group
+status: $status
+domains: [core]
+---
+
+## Summary
+Test $id.
+
+## Acceptance Criteria
+Test.
+EOF
+}
+
+write_group_a_work_md() {
+    local external_deps_block="$1"
+    cat > ".work/group-a/work.md" << EOF
+---
+group: group-a
+goal: Exercise external_deps gate
+status: active
+$external_deps_block
+---
+
+## Goal
+
+Test external_deps behavior.
+EOF
+}
+
+# ── Test 1: DRAFT WD in group-a BLOCKED when group-b not COMPLETE ────────────
+
+echo ""
+echo "── Test 1: DRAFT WD in group-a BLOCKED when group-b not COMPLETE"
+
+write_wd group-b WD-01 DRAFT
+write_wd group-b WD-02 DRAFT
+write_wd group-a WD-01 DRAFT
+write_group_a_work_md 'external_deps:
+  - { type: group, ref: "group-b", required_state: COMPLETE }'
+
+output="$(bash .claude/scripts/work-resolve.sh group-a 2>&1 || true)"
+if echo "$output" | grep -q "BLOCKED" && echo "$output" | grep -q "external group:group-b"; then
+    pass "DRAFT WD blocked by unmet external group dep"
+else
+    fail "DRAFT WD should be BLOCKED with external group reason" "got: $output"
+fi
+
+# ── Test 2: SPECIFIED WD in group-a also BLOCKED by external_deps ────────────
+
+echo ""
+echo "── Test 2: SPECIFIED WD in group-a BLOCKED when group-b not COMPLETE"
+
+write_wd group-a WD-02 SPECIFIED
+output="$(bash .claude/scripts/work-resolve.sh group-a 2>&1 || true)"
+# WD-02 line should be in BLOCKED row
+if echo "$output" | grep -E '^\| WD-02 .* BLOCKED ' >/dev/null && echo "$output" | grep -q "external group:group-b"; then
+    pass "SPECIFIED WD blocked by unmet external group dep"
+else
+    fail "SPECIFIED WD should be BLOCKED by external_deps" "got: $output"
+fi
+
+# ── Test 3: group-b COMPLETE → group-a unblocks ──────────────────────────────
+
+echo ""
+echo "── Test 3: group-a unblocks once all group-b WDs are COMPLETE"
+
+write_wd group-b WD-01 COMPLETE
+write_wd group-b WD-02 COMPLETE
+output="$(bash .claude/scripts/work-resolve.sh group-a 2>&1 || true)"
+if echo "$output" | grep -E '^\| WD-01 .* READY '     >/dev/null \
+   && echo "$output" | grep -E '^\| WD-02 .* SPECIFIED ' >/dev/null \
+   && ! echo "$output" | grep -q "external group:group-b"; then
+    pass "group-a WDs unblock when group-b reaches COMPLETE"
+else
+    fail "group-a should unblock once group-b COMPLETE" "got: $output"
+fi
+
+# ── Test 4: missing referenced group → blocker at resolve, error at validate ─
+
+echo ""
+echo "── Test 4: external_deps pointing at missing group is flagged"
+
+write_group_a_work_md 'external_deps:
+  - { type: group, ref: "group-nonexistent", required_state: COMPLETE }'
+
+output="$(bash .claude/scripts/work-resolve.sh group-a 2>&1 || true)"
+if echo "$output" | grep -q "external group:group-nonexistent" \
+   && echo "$output" | grep -q "not found"; then
+    pass "resolver flags missing external group as a blocker"
+else
+    fail "resolver should report missing group as blocker" "got: $output"
+fi
+
+validate_out="$(bash .claude/scripts/work-validate.sh --group group-a 2>&1 || true)"
+if echo "$validate_out" | grep -q "FAILED" \
+   && echo "$validate_out" | grep -q "group-nonexistent"; then
+    pass "validator flags missing referenced group"
+else
+    fail "validator should fail on missing referenced group" "got: $validate_out"
+fi
+
+# ── Test 5: malformed external_deps caught by validator ──────────────────────
+
+echo ""
+echo "── Test 5: validator rejects malformed external_deps"
+
+# 5a: wrong type
+write_group_a_work_md 'external_deps:
+  - { type: spec, ref: "group-b", required_state: COMPLETE }'
+validate_out="$(bash .claude/scripts/work-validate.sh --group group-a 2>&1 || true)"
+if echo "$validate_out" | grep -q "invalid type 'spec'"; then
+    pass "validator rejects wrong external_deps type"
+else
+    fail "validator should reject type=spec in external_deps" "got: $validate_out"
+fi
+
+# 5b: unsupported required_state
+write_group_a_work_md 'external_deps:
+  - { type: group, ref: "group-b", required_state: SPECIFIED }'
+validate_out="$(bash .claude/scripts/work-validate.sh --group group-a 2>&1 || true)"
+if echo "$validate_out" | grep -q "required_state 'SPECIFIED' unsupported"; then
+    pass "validator rejects unsupported required_state"
+else
+    fail "validator should reject required_state=SPECIFIED" "got: $validate_out"
+fi
+
+# 5c: self-reference
+write_group_a_work_md 'external_deps:
+  - { type: group, ref: "group-a", required_state: COMPLETE }'
+validate_out="$(bash .claude/scripts/work-validate.sh --group group-a 2>&1 || true)"
+if echo "$validate_out" | grep -q "references itself"; then
+    pass "validator rejects self-reference"
+else
+    fail "validator should reject self-reference" "got: $validate_out"
+fi
+
+# 5d: missing ref
+write_group_a_work_md 'external_deps:
+  - { type: group, ref: "", required_state: COMPLETE }'
+validate_out="$(bash .claude/scripts/work-validate.sh --group group-a 2>&1 || true)"
+if echo "$validate_out" | grep -q "missing ref"; then
+    pass "validator rejects missing ref"
+else
+    fail "validator should reject missing ref" "got: $validate_out"
+fi
+
+# ── Test 6: IMPLEMENTING and COMPLETE WDs ignore the external gate ───────────
+
+echo ""
+echo "── Test 6: IMPLEMENTING and COMPLETE WDs are not retroactively blocked"
+
+write_wd group-b WD-01 DRAFT
+write_wd group-b WD-02 DRAFT
+write_group_a_work_md 'external_deps:
+  - { type: group, ref: "group-b", required_state: COMPLETE }'
+write_wd group-a WD-01 DRAFT
+write_wd group-a WD-02 IMPLEMENTING
+write_wd group-a WD-03 COMPLETE
+
+output="$(bash .claude/scripts/work-resolve.sh group-a 2>&1 || true)"
+# WD-01 BLOCKED (DRAFT + unmet external), WD-02 IMPLEMENTING, WD-03 COMPLETE
+if echo "$output" | grep -E '^\| WD-01 .* BLOCKED '      >/dev/null \
+   && echo "$output" | grep -E '^\| WD-02 .* IMPLEMENTING ' >/dev/null \
+   && echo "$output" | grep -E '^\| WD-03 .* COMPLETE '     >/dev/null; then
+    pass "IMPLEMENTING and COMPLETE WDs bypass external gate"
+else
+    fail "IMPLEMENTING/COMPLETE should bypass external gate" "got: $output"
+fi
+
+# ── Test 7: wd: artifact_dep across groups rejected by validator ─────────────
+
+echo ""
+echo "── Test 7: cross-group wd: artifact_dep rejected by validator"
+
+rm -f .work/group-a/WD-*.md .work/group-b/WD-*.md
+write_group_a_work_md ''
+write_wd group-b WD-01 DRAFT
+cat > ".work/group-a/WD-01.md" << 'EOF'
+---
+id: WD-01
+title: Cross-group wd ref
+group: group-a
+status: DRAFT
+domains: [core]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: COMPLETE }
+---
+
+## Summary
+Test.
+
+## Acceptance Criteria
+Test.
+EOF
+
+# In this setup group-a/WD-01 refers to WD-01 which exists in both groups,
+# but within group-a's own scope. Replace with one that truly crosses groups.
+cat > ".work/group-a/WD-01.md" << 'EOF'
+---
+id: WD-A-01
+title: Cross-group wd ref
+group: group-a
+status: DRAFT
+domains: [core]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: COMPLETE }
+---
+
+## Summary
+Test.
+
+## Acceptance Criteria
+Test.
+EOF
+
+# Re-read: group-a has WD-A-01 with a dep on WD-01. Only group-b has a WD-01.
+validate_out="$(bash .claude/scripts/work-validate.sh --group group-a 2>&1 || true)"
+if echo "$validate_out" | grep -q "different group"; then
+    pass "cross-group wd: artifact_dep rejected with guidance"
+else
+    fail "validator should reject cross-group wd: dep" "got: $validate_out"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if (( failed > 0 )); then
+    echo "FAILED  $failed/$total"
+    exit 1
+else
+    echo "ALL PASSED  ($passed/$total)"
+fi

--- a/tests/scenario-work-layer-alignment.sh
+++ b/tests/scenario-work-layer-alignment.sh
@@ -439,6 +439,96 @@ fi
 # Go back to repo root for cleanup
 cd "$REPO_ROOT"
 
+# ── Invariant 10: /work-plan brief.md names the group envelope ──────────────
+#
+# Gap 3 — /work-plan's Step 4a brief template must declare the group envelope
+# as AUTHORITATIVE so /feature-domains can defer to it instead of re-deciding.
+
+echo ""
+echo "── Invariant 10: /work-plan brief.md names Group Envelope"
+
+plan_skill="$REPO_ROOT/skills/work-plan/SKILL.md"
+if grep -q "Group Envelope" "$plan_skill" \
+   && grep -q "AUTHORITATIVE" "$plan_skill" \
+   && grep -qi "phase b" "$plan_skill"; then
+    pass "/work-plan brief template declares Group Envelope (AUTHORITATIVE)"
+else
+    fail "/work-plan must document a Group Envelope section in brief.md" \
+         "expected 'Group Envelope' + 'AUTHORITATIVE' + 'Phase B' in $plan_skill"
+fi
+
+# ── Invariant 11: /feature-domains reads the group envelope ──────────────────
+#
+# Gap 3 — /feature-domains Step 2 must consult the brief.md Group Envelope and
+# classify domains covered by it as `resolved` with source annotation.
+
+echo ""
+echo "── Invariant 11: /feature-domains consumes brief's Group Envelope"
+
+domains_skill="$REPO_ROOT/skills/feature-domains/SKILL.md"
+if grep -q "Group envelope" "$domains_skill" \
+   && grep -q "AUTHORITATIVE" "$domains_skill" \
+   && grep -q "group envelope: <ref>" "$domains_skill"; then
+    pass "/feature-domains Step 2 reads brief Group Envelope as authoritative"
+else
+    fail "/feature-domains must consult Group Envelope in Step 2" \
+         "expected 'Group envelope' + 'AUTHORITATIVE' + source annotation in $domains_skill"
+fi
+
+# ── Invariant 12: /feature-domains escalates envelope contradictions ─────────
+#
+# Gap 3 — when WD-local analysis contradicts a group envelope item, the scout
+# must classify `escalate-decompose` and halt rather than self-resolve.
+
+echo ""
+echo "── Invariant 12: /feature-domains flags envelope contradictions"
+
+if grep -q "escalate-decompose" "$domains_skill" \
+   && grep -q "ESCALATE to /work-decompose" "$domains_skill"; then
+    pass "/feature-domains has escalate-decompose classification + halt path"
+else
+    fail "/feature-domains must handle envelope contradictions via escalate-decompose" \
+         "expected 'escalate-decompose' state + 'ESCALATE to /work-decompose' prompt"
+fi
+
+# ── Invariant 13: Step 3 runs the escalation check before resolution ────────
+#
+# Gap 3 — the escalation halt must fire BEFORE Step 3's per-domain resolution
+# loop, otherwise the scout would commission work against contradicted
+# envelope assumptions.
+
+echo ""
+echo "── Invariant 13: /feature-domains Step 3 checks escalation first"
+
+# Extract lines between "## Step 3" and the next "## Step" heading; the
+# escalation header must appear before the per-domain resolution content.
+step3_block="$(awk '/^## Step 3/,/^## Step [4-9]/' "$domains_skill")"
+if echo "$step3_block" | grep -q "Escalation check (always first)" \
+   && echo "$step3_block" | grep -q "domains-escalated-decompose"; then
+    pass "/feature-domains Step 3 fires escalation check before resolution"
+else
+    fail "/feature-domains Step 3 must start with escalation check" \
+         "expected 'Escalation check (always first)' in Step 3 block"
+fi
+
+# ── Invariant 14: /work-plan Step 5b dedupes against the envelope ───────────
+#
+# Gap 3 — /work-plan must NOT re-author group-level specs already listed in
+# the WD's artifact_deps. This is what keeps group and WD specs from forking.
+
+echo ""
+echo "── Invariant 14: /work-plan Step 5b skips envelope-covered specs"
+
+step5b_block="$(awk '/^## Step 5b/,/^## Step 6/' "$plan_skill")"
+if echo "$step5b_block" | grep -qi "dedupe against the group envelope" \
+   && echo "$step5b_block" | grep -q "artifact_deps" \
+   && echo "$step5b_block" | grep -q "deferred to group-level spec"; then
+    pass "/work-plan Step 5b dedupes spec authoring against artifact_deps"
+else
+    fail "/work-plan Step 5b must skip specs already covered by group envelope" \
+         "expected 'dedupe against the group envelope' + 'artifact_deps' + 'deferred to group-level spec'"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/scenario-work-validate.sh
+++ b/tests/scenario-work-validate.sh
@@ -638,12 +638,19 @@ else
 fi
 
 echo ""
-echo "── Test 17: wd artifact_dep with status mismatch fails"
+echo "── Test 17: wd artifact_dep state mismatch is NOT a validation FAIL"
+#
+# wd: deps describe the eventual ordering between siblings in a group. At
+# any moment some siblings are upstream and some downstream — that's the
+# normal mid-flight state, not a structural error. The resolver surfaces
+# this as BLOCKED with a clear reason; the validator must not double-report.
+# Earlier versions of this test asserted the inverted behavior and made
+# fresh decompose output appear FAILED.
 
 cat > "$TEST_BASE/project/.work/resolve-group/WD-05.md" << 'EOF'
 ---
 id: WD-05
-title: Wants WD-01 COMPLETE but WD-01 is DRAFT
+title: Wants WD-01 COMPLETE but WD-01 is DRAFT (legitimate mid-flight state)
 group: resolve-group
 status: DRAFT
 domains: [auth]
@@ -659,10 +666,11 @@ Test.
 EOF
 
 output="$(bash .claude/scripts/work-validate.sh .work/resolve-group/WD-05.md 2>&1 || true)"
-if echo "$output" | grep -q "FAIL" && echo "$output" | grep -q "wd 'WD-01' has status 'DRAFT', required_status is 'COMPLETE'"; then
-    pass "wd artifact_dep with status mismatch fails"
+if echo "$output" | grep -q "PASS" \
+   && ! echo "$output" | grep -q "has status 'DRAFT'"; then
+    pass "wd state mismatch is not flagged as validation FAIL"
 else
-    fail "wd status mismatch should fail with clear message" "got: $output"
+    fail "validate must not FAIL on wd: state mismatch (resolver's job)" "got: $output"
 fi
 
 rm -rf "$TEST_BASE/project/.work/resolve-group"
@@ -710,6 +718,103 @@ else
 fi
 
 rm -rf "$TEST_BASE/project/.work/produces-group"
+
+# ── Test 19: spec dep accepts slash-path form ───────────────────────────────
+#
+# Surfaced during jlsm dry-run (2026-04-24): single-WD validate previously
+# used spec_file_for_id (ID-only), but resolve + decompose-invariant used
+# work_check_spec_dep's multi-strategy matcher (slash-paths). A WD with
+# `path: "engine/catalog-operations"` would PASS decompose-invariant but
+# FAIL single-WD validate as a "dead reference". Both must agree.
+
+echo ""
+echo "── Test 19: spec dep accepts slash-path form (validate parity with resolve)"
+
+mkdir -p "$TEST_BASE/project/.spec/domains/auth"
+mkdir -p "$TEST_BASE/project/.spec/registry"
+mkdir -p "$TEST_BASE/project/.work/path-style-group"
+
+cat > "$TEST_BASE/project/.spec/domains/auth/jwt-contract.md" << 'EOF'
+---
+{
+  "id": "auth.jwt-contract",
+  "version": 1,
+  "state": "APPROVED",
+  "status": "ACTIVE",
+  "domains": ["auth"]
+}
+---
+
+# auth.jwt-contract — JWT Contract
+
+## Requirements
+R1. JWT tokens must verify via the published public key.
+EOF
+
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    {"id": "auth.jwt-contract", "path": ".spec/domains/auth/jwt-contract.md", "state": "APPROVED"}
+  ]
+}
+EOF
+
+cat > "$TEST_BASE/project/.work/path-style-group/WD-01.md" << 'EOF'
+---
+id: WD-01
+title: Uses slash-path form for spec ref
+group: path-style-group
+status: DRAFT
+domains: [auth]
+artifact_deps:
+  - { type: spec, path: "auth/jwt-contract", required_state: APPROVED }
+---
+
+## Summary
+Test slash-path resolution.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-validate.sh .work/path-style-group/WD-01.md 2>&1 || true)"
+if echo "$output" | grep -q "PASS" \
+   && ! echo "$output" | grep -q "dead reference"; then
+    pass "single-WD validate accepts slash-path spec ref (parity with resolve)"
+else
+    fail "single-WD validate must accept slash-path spec refs" "got: $output"
+fi
+
+# State mismatch should still fire under slash-path form
+cat > "$TEST_BASE/project/.work/path-style-group/WD-02.md" << 'EOF'
+---
+id: WD-02
+title: Slash-path with wrong required_state
+group: path-style-group
+status: DRAFT
+domains: [auth]
+artifact_deps:
+  - { type: spec, path: "auth/jwt-contract", required_state: DRAFT }
+---
+
+## Summary
+Test.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-validate.sh .work/path-style-group/WD-02.md 2>&1 || true)"
+if echo "$output" | grep -q "FAIL" \
+   && echo "$output" | grep -q "state 'APPROVED', required_state is 'DRAFT'"; then
+    pass "single-WD validate state-mismatch under slash-path form"
+else
+    fail "slash-path form must still report state mismatches clearly" "got: $output"
+fi
+
+rm -rf "$TEST_BASE/project/.work/path-style-group"
+rm -rf "$TEST_BASE/project/.spec"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 

--- a/tests/scenario-work-validate.sh
+++ b/tests/scenario-work-validate.sh
@@ -631,7 +631,7 @@ Test.
 EOF
 
 output="$(bash .claude/scripts/work-validate.sh .work/resolve-group/WD-04.md 2>&1 || true)"
-if echo "$output" | grep -q "FAIL" && echo "$output" | grep -q "wd 'WD-99' not found in .work/"; then
+if echo "$output" | grep -q "FAIL" && echo "$output" | grep -q "wd 'WD-99' not found in group"; then
     pass "wd artifact_dep with nonexistent WD fails"
 else
     fail "nonexistent wd reference should fail" "got: $output"

--- a/tests/scenario-work-validate.sh
+++ b/tests/scenario-work-validate.sh
@@ -668,6 +668,49 @@ fi
 rm -rf "$TEST_BASE/project/.work/resolve-group"
 rm -rf "$TEST_BASE/project/.spec"
 
+# ── Test 18: produces: accepts slug: for ADR artifacts ──────────────────────
+#
+# jlsm dry-run (2026-04-24) surfaced a parser asymmetry: work_fm_artifact_deps
+# accepts { type: adr, slug: "..." } / { ref: "..." } / { path: "..." } but
+# work_fm_produces only accepted path:. Real-world ADR produces entries use
+# slug: (matches .decisions/<slug>/adr.md layout), so 78 false-alarm
+# "missing path for adr artifact" errors were raised across jlsm's
+# decisions-backlog group. Both parsers must agree on identifier shape.
+
+echo ""
+echo "── Test 18: produces: slug: accepted for ADR artifacts"
+
+mkdir -p "$TEST_BASE/project/.work/produces-group"
+cat > "$TEST_BASE/project/.work/produces-group/WD-01.md" << 'EOF'
+---
+id: WD-01
+title: ADR-producing WD using slug identifier
+group: produces-group
+status: DRAFT
+domains: [decisions]
+produces:
+  - { type: adr, slug: "token-format" }
+  - { type: adr, ref: "session-storage" }
+  - { type: spec, path: "auth/jwt-token-contract" }
+---
+
+## Summary
+Test.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-validate.sh .work/produces-group/WD-01.md 2>&1 || true)"
+if echo "$output" | grep -q "PASS" \
+   && ! echo "$output" | grep -q "missing path"; then
+    pass "produces: accepts slug: and ref: for ADR entries"
+else
+    fail "produces: with slug: / ref: must validate clean" "got: $output"
+fi
+
+rm -rf "$TEST_BASE/project/.work/produces-group"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Followups to PR #59. Two designed-and-planned fixes (Gap 3, Gap 4) plus three pre-existing bugs and four SKILL.md refinements surfaced empirically by exercising the kit end-to-end against a fresh work group on a local jlsm clone.

## Designed work

**Gap 4 — cross-group dependencies (`b4f4adf`).**
- `work.md` supports optional `external_deps:` frontmatter declaring a sibling work group must reach `required_state: COMPLETE` before this group's DRAFT/SPECIFIED WDs unblock.
- IMPLEMENTING/COMPLETE/SPECIFYING WDs bypass the gate — already-in-flight or finished work isn't retroactively un-done.
- `work-validate.sh` checks shape and referenced-group existence; cross-group `wd:` artifact_deps are rejected (use external_deps).
- Test: `scenario-work-cross-group-deps.sh` (11/11 invariants).

**Gap 3 — /work-plan honours group envelope (`a0da741`).**
- `/work-plan` Step 4a brief template gains AUTHORITATIVE "Group Envelope" section listing artifact_deps + `out_of_scope` + `external_deps`.
- `/feature-domains` Step 2 reads the envelope, classifies covered domains as `resolved` with source "group envelope: <ref>".
- New `escalate-decompose` classification halts the scout when WD-local analysis would contradict an envelope item, pointing back at `/work-decompose`.
- `/work-plan` Step 5b dedupes spec authoring against APPROVED envelope specs.
- Test: 5 new structural invariants in `scenario-work-layer-alignment.sh` (25/25 total).

## Bugs surfaced by the dry-run

**`work_fm_produces` dropped `slug:` (`3a148da`).** Parser asymmetry — `work_fm_artifact_deps` accepts path/slug/ref but `work_fm_produces` only accepted path. jlsm's `decisions-backlog` declares ADR outputs as `{ type: adr, slug: "<slug>" }`, so the parser silently dropped the identifier and validate raised 78 false-alarm errors across 13 WDs. Verified: 78 → 0 after fix.

**Validate vs resolve spec lookup asymmetry (`633cfc8`).** Single-WD validate used ID-only lookup (`spec_file_for_id`); resolve and the decompose-invariant accepted slash-paths via a multi-strategy matcher. A WD with `path: "engine/catalog-operations"` would PASS decompose-invariant but FAIL single-WD validate. Both now share `work_check_spec_dep` with a Strategy 0 ID lookup + path-form fallbacks.

**`wd:` state mismatch was incorrectly a validation FAIL (`633cfc8`).** A freshly-decomposed downstream WD declaring `wd: WD-01, required_state: COMPLETE` while WD-01 was DRAFT raised a hard validation error. But that's the normal mid-flight state — siblings are upstream and downstream of one another by design; the resolver already surfaces this as BLOCKED. Validate no longer double-reports. Test 17 was inverted (it had codified the wrong contract).

## SKILL.md guidance refinements (`9da73fa`)

Five gaps in the SKILL.md contract that were working but implicit:

1. `/work` scoping interview now leads with tradeoff analysis before AskUserQuestion when the choice has non-obvious implications.
2. `/work-decompose` Phase A research-dispatch criterion: dispatch when the answer would change the *shape* of WD chunks, not just internal details.
3. `/work-decompose` Phase B "decidability" test: settle now when the shape isn't decidable from any single WD's perspective alone; bilateral producer→consumer flows can sequence WD-locally.
4. `/work-decompose` Phase C surfaces SPECIFIED-vs-COMPLETE choice for `wd:` deps explicitly (default-by-precedent was COMPLETE, forcing sequential; SPECIFIED unlocks parallel planning).
5. WD template artifact_deps section documents both accepted forms for spec refs (slash-path + ID), same-group constraint for `wd:` refs, and the slug/path/ref distinction.

## Empirical validation

Exercised end-to-end against a local jlsm clone (HEAD pre-existing, 9 work groups, 78 specs, 5 active groups). All 9 jlsm groups now validate clean. Authored a fresh `columnar-storage` group through /work + Phase A/B/C: 5 WDs, 6 cross-WD references, all settled, decompose-invariant + per-WD + group + circular-deps + external-deps all PASS. The Phase B value was concrete: authoring the telemetry interface contract collapsed what was tentatively WD-06 into WD-03 + WD-05 emitting against the now-authoritative schema — exactly the seam-shift the design promised.

## Not in this PR

- **jlsm migration of `implement-membership`** to `external_deps:`. Deferred until this lands and jlsm upgrades the kit.
- **Empirical Gap 3 validation.** Structural tests prove the SKILL.md says the right things; they don't prove the LLM follows them. The first real `/work-plan` run on a WD with a Group Envelope is the actual test.

## Test plan

- [x] All 9 work scenario suites pass
- [x] `scenario-work-cross-group-deps.sh` 11/11 (new)
- [x] `scenario-work-layer-alignment.sh` 25/25 (5 new Gap 3 invariants)
- [x] `scenario-work-validate.sh` 20/20 (3 new tests for symmetric lookup + slug parsing + corrected wd-state-mismatch contract)
- [x] `tests/test-install.sh` 59/59
- [x] MANIFEST ↔ source file checks: 0 missing, 0 stray
- [x] All 9 jlsm groups validate clean
- [x] Fresh /work-decompose run produces clean Phase C invariant pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)