### PR TITLE
feat(spec): natural progression for layered specs + jlsm soak fixes

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -36,6 +36,7 @@
 .claude/skills/spec-verify/SKILL.md
 .claude/skills/spec-author/SKILL.md
 .claude/skills/spec-author/extraction-mode.md
+.claude/skills/spec-split/SKILL.md
 .claude/skills/spec/SKILL.md
 .claude/skills/work/SKILL.md
 .claude/skills/work-decompose/SKILL.md
@@ -121,6 +122,7 @@
 .claude/scripts/spec-resolve.sh
 .claude/scripts/spec-obligations-gc.sh
 .claude/scripts/spec-trace.sh
+.claude/scripts/spec-split.sh
 .claude/scripts/work-lib.sh
 .claude/scripts/work-resolve.sh
 .claude/scripts/work-validate.sh

--- a/install.sh
+++ b/install.sh
@@ -298,6 +298,7 @@ install_file "$SCRIPT_DIR/scripts/spec-stats.sh" "$TARGET/.claude/scripts/spec-s
 install_file "$SCRIPT_DIR/scripts/spec-resolve.sh" "$TARGET/.claude/scripts/spec-resolve.sh"
 install_file "$SCRIPT_DIR/scripts/spec-obligations-gc.sh" "$TARGET/.claude/scripts/spec-obligations-gc.sh"
 install_file "$SCRIPT_DIR/scripts/spec-trace.sh" "$TARGET/.claude/scripts/spec-trace.sh"
+install_file "$SCRIPT_DIR/scripts/spec-split.sh" "$TARGET/.claude/scripts/spec-split.sh"
 install_file "$SCRIPT_DIR/scripts/work-lib.sh" "$TARGET/.claude/scripts/work-lib.sh"
 install_file "$SCRIPT_DIR/scripts/work-resolve.sh" "$TARGET/.claude/scripts/work-resolve.sh"
 install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/work-validate.sh"
@@ -326,6 +327,7 @@ chmod +x "$TARGET/.claude/scripts/spec-stats.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-obligations-gc.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-trace.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/spec-split.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
@@ -408,6 +410,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/spec-resolve.sh:*)",
       "Bash(bash .claude/scripts/spec-obligations-gc.sh:*)",
       "Bash(bash .claude/scripts/spec-trace.sh:*)",
+      "Bash(bash .claude/scripts/spec-split.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
@@ -518,6 +521,7 @@ HOOKJSON
       "Bash(bash .claude/scripts/spec-resolve.sh:*)",
       "Bash(bash .claude/scripts/spec-obligations-gc.sh:*)",
       "Bash(bash .claude/scripts/spec-trace.sh:*)",
+      "Bash(bash .claude/scripts/spec-split.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1334,6 +1334,146 @@ if [[ -d ".spec/domains" ]] && command -v jq >/dev/null 2>&1; then
     mv "$TMPDIR_SCAN/aging-obligations.capped.txt" "$TMPDIR_SCAN/aging-obligations.txt"
 fi
 
+# ── Analysis 20: Subdivision candidates (mature specs with multiple concerns) ─
+# Identify specs that have grown past one file's worth of behavior AND show
+# multiple distinct concerns. Heuristic signals:
+#
+#   1. Size: >= 50 R-numbered requirements OR >= 15K tokens (~60 KB) — early
+#      signal, well under the 25K Read cap. Specs below either threshold are
+#      not yet mature enough to need subdivision; flagging them would waste
+#      reviewer attention.
+#   2. Section structure: >= 2 distinct section headers (`## <Concern>` or
+#      `### <Concern>`) inside the machine section. A single section means
+#      one tightly-coupled concern — subdivision would fragment a coherent
+#      contract.
+#   3. Distribution: no single section holds >= 90% of the requirements.
+#      Heavy concentration in one section means the spec is mature but
+#      mostly about one thing; subdivision wouldn't meaningfully improve
+#      the structure.
+#   4. Not already a child: skip specs with `parent_spec` set — they are
+#      already part of a layered family (a sub-domain split is possible
+#      but should be requested explicitly, not auto-flagged).
+#
+# Output: SUBDIVISION_CANDIDATE|<spec_id>|<domain>|<reqs>|<tokens_k>|<sections>|<largest_section_count>|<score>
+# Score = reqs + (tokens_k × 2) + (sections × 5) — higher is more
+# candidate-worthy. Used to sort the report; not exposed to users directly.
+
+> "$TMPDIR_SCAN/spec-subdivision-candidates.txt"
+
+if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
+    SUBDIV_MANIFEST=".spec/registry/manifest.json"
+
+    # Tunable thresholds (could be overridden via env later if needed).
+    SUBDIV_MIN_REQS=50
+    SUBDIV_MIN_TOKENS_K=15
+    SUBDIV_MIN_SECTIONS=2
+    SUBDIV_MAX_TOP_SHARE_PCT=90
+
+    while IFS= read -r fid; do
+        [[ -z "$fid" ]] && continue
+
+        spec_state=$(spec_manifest_state "$SUBDIV_MANIFEST" "$fid")
+        # INVALIDATED specs aren't candidates — they're historical reference.
+        [[ "$spec_state" == "INVALIDATED" ]] && continue
+
+        spec_file=$(spec_file_for_id "$SUBDIV_MANIFEST" "$fid")
+        [[ -z "$spec_file" || ! -f "$spec_file" ]] && continue
+
+        # Skip child specs (already in a layered family).
+        spec_parent=$(fm "$spec_file" '.parent_spec // ""')
+        [[ -n "$spec_parent" && "$spec_parent" != "null" ]] && continue
+
+        # Pull machine section once; do all measurements on it.
+        body=$(machine_section "$spec_file")
+        [[ -z "$body" ]] && continue
+
+        # Size in tokens (1 token ≈ 4 chars).
+        body_chars=${#body}
+        body_tokens_k=$(( body_chars / 4 / 1000 ))
+
+        # Count R-numbered requirements (RN, RNa form supported).
+        reqs_count=$(grep -cE '^R[0-9]+[a-z]?\.' <<< "$body" || true)
+
+        # Below either size threshold → not a candidate.
+        if (( reqs_count < SUBDIV_MIN_REQS )) && (( body_tokens_k < SUBDIV_MIN_TOKENS_K )); then
+            continue
+        fi
+
+        # Identify section headers within the machine section. Both `## ` and
+        # `### ` forms accepted — Pass 1 of /spec-author often nests at H3.
+        # If a header line contains "Notes" or "Narrative" it's not a concern
+        # boundary; skip those.
+        mapfile -t section_lines < <(
+            grep -nE '^#{2,3}[[:space:]]+[A-Za-z]' <<< "$body" \
+            | grep -viE 'notes|narrative|design|history|appendix' \
+            || true
+        )
+        section_count=${#section_lines[@]}
+
+        # Need at least N distinct sections to be a candidate.
+        if (( section_count < SUBDIV_MIN_SECTIONS )); then
+            continue
+        fi
+
+        # Compute per-section requirement counts. A requirement belongs to the
+        # most recent section header above it. Walk the body once.
+        declare -A section_req_count=()
+        current_section=""
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^#{2,3}[[:space:]]+([A-Za-z].*)$ ]]; then
+                hdr="${BASH_REMATCH[1]}"
+                # Skip non-concern headers we already filtered for the count.
+                if echo "$hdr" | grep -qiE 'notes|narrative|design|history|appendix'; then
+                    current_section=""
+                else
+                    current_section="$hdr"
+                    section_req_count["$current_section"]=${section_req_count["$current_section"]:-0}
+                fi
+            elif [[ -n "$current_section" ]] && [[ "$line" =~ ^R[0-9]+[a-z]?\. ]]; then
+                section_req_count["$current_section"]=$(( ${section_req_count["$current_section"]:-0} + 1 ))
+            fi
+        done <<< "$body"
+
+        # Find the largest section's requirement count.
+        largest_count=0
+        for count in "${section_req_count[@]}"; do
+            (( count > largest_count )) && largest_count=$count
+        done
+
+        # If one section holds ≥ MAX_TOP_SHARE_PCT of all reqs, the spec is
+        # really one concern with side notes — not a subdivision candidate.
+        if (( reqs_count > 0 )); then
+            top_share_pct=$(( largest_count * 100 / reqs_count ))
+            if (( top_share_pct >= SUBDIV_MAX_TOP_SHARE_PCT )); then
+                unset section_req_count
+                continue
+            fi
+        fi
+
+        # Score the candidate (used for ranking in the report).
+        score=$(( reqs_count + body_tokens_k * 2 + section_count * 5 ))
+
+        # Domains for display.
+        spec_domains=$(spec_manifest_domains_for "$SUBDIV_MANIFEST" "$fid" \
+                       | tr '\n' ',' | sed 's/,$//')
+
+        echo "SUBDIVISION_CANDIDATE|$fid|$spec_domains|$reqs_count|$body_tokens_k|$section_count|$largest_count|$score" \
+             >> "$TMPDIR_SCAN/spec-subdivision-candidates.txt"
+
+        unset section_req_count
+    done < <(spec_manifest_ids "$SUBDIV_MANIFEST")
+
+    # Sort by score descending (top candidates first); cap at 20.
+    if [[ -s "$TMPDIR_SCAN/spec-subdivision-candidates.txt" ]]; then
+        sort -t'|' -k8 -rn "$TMPDIR_SCAN/spec-subdivision-candidates.txt" \
+             -o "$TMPDIR_SCAN/spec-subdivision-candidates.txt"
+        head -20 "$TMPDIR_SCAN/spec-subdivision-candidates.txt" \
+             > "$TMPDIR_SCAN/spec-subdivision-candidates.capped.txt"
+        mv "$TMPDIR_SCAN/spec-subdivision-candidates.capped.txt" \
+           "$TMPDIR_SCAN/spec-subdivision-candidates.txt"
+    fi
+fi
+
 # ── Write summary file ──────────────────────────────────────────────────────
 
 SCAN_DATE="$(date +%Y-%m-%d)"
@@ -1754,6 +1894,23 @@ if [[ -s "$TMPDIR_SCAN/aging-obligations.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# Subdivision candidates (Analysis 20)
+if [[ -s "$TMPDIR_SCAN/spec-subdivision-candidates.txt" ]]; then
+    echo "## Subdivision Candidates" >> "$SUMMARY_FILE"
+    echo "Specs that have grown past one file's worth of behavior AND show multiple distinct concerns." >> "$SUMMARY_FILE"
+    echo "These are candidates for natural subdivision via \`/spec-split <id>\` — the parent stays a full" >> "$SUMMARY_FILE"
+    echo "spec retaining cross-cutting requirements; concern-specific reqs move to child specs." >> "$SUMMARY_FILE"
+    echo "Decline if the spec's concerns are interlocked rather than separable; subdivision fragments" >> "$SUMMARY_FILE"
+    echo "a coherent contract when forced." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Spec | Domain | Reqs | ~Tokens (K) | Sections | Largest section | Suggested |" >> "$SUMMARY_FILE"
+    echo "|------|--------|------|-------------|----------|-----------------|-----------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ sid doms reqs tok_k sects largest _; do
+        echo "| $sid | $doms | $reqs | $tok_k | $sects | $largest reqs | \`/spec-split $sid\` |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/spec-subdivision-candidates.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # ── Report ───────────────────────────────────────────────────────────────────
 
 echo "Scan complete: $COMMIT_COUNT commits analyzed"
@@ -1786,6 +1943,7 @@ echo "  Work artifact drift: $(wc -l < "$TMPDIR_SCAN/work-drift.txt" 2>/dev/null
 echo "  Spec annotation gaps: $(wc -l < "$TMPDIR_SCAN/spec-annotation-gaps.txt" 2>/dev/null || echo 0)"
 echo "  Unannotated APPROVED specs: $(wc -l < "$TMPDIR_SCAN/spec-unannotated.txt" 2>/dev/null || echo 0)"
 echo "  Aging obligations: $(wc -l < "$TMPDIR_SCAN/aging-obligations.txt" 2>/dev/null || echo 0)"
+echo "  Subdivision candidates: $(wc -l < "$TMPDIR_SCAN/spec-subdivision-candidates.txt" 2>/dev/null || echo 0)"
 
 # ── Update curation state ─────────────────────────────────────────────────
 

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1221,15 +1221,17 @@ if [[ -f ".spec/registry/manifest.json" ]] && command -v jq >/dev/null 2>&1; the
 
             # Case: no annotations at all — spec is entirely unannotated.
             # spec-trace emits "**No annotations found.**" in the markdown body.
-            if echo "$trace_out" | grep -q '\*\*No annotations found\.\*\*'; then
+            # Use here-strings so SIGPIPE under pipefail cannot flip results
+            # on long /spec-trace output (grep -q / -m1 close stdin early).
+            if grep -q '\*\*No annotations found\.\*\*' <<< "$trace_out"; then
                 echo "UNANNOTATED|$sid" >> "$TMPDIR_SCAN/spec-unannotated.txt"
                 continue
             fi
 
             # Extract "No implementation annotations:" and "No test annotations:" lines.
-            no_impl="$(echo "$trace_out" | grep -m1 '^\*\*No implementation annotations:\*\*' \
+            no_impl="$(grep -m1 '^\*\*No implementation annotations:\*\*' <<< "$trace_out" \
                 | sed 's/^\*\*No implementation annotations:\*\*[[:space:]]*//' || true)"
-            no_test="$(echo "$trace_out" | grep -m1 '^\*\*No test annotations:\*\*' \
+            no_test="$(grep -m1 '^\*\*No test annotations:\*\*' <<< "$trace_out" \
                 | sed 's/^\*\*No test annotations:\*\*[[:space:]]*//' || true)"
 
             if [[ -n "$no_impl" ]]; then

--- a/scripts/kb-search.sh
+++ b/scripts/kb-search.sh
@@ -105,10 +105,12 @@ while IFS= read -r cat_index; do
         stem="${subj_file%.md}"
         key="$topic/$category/$stem"
 
-        # Count query token hits in category index
+        # Count query token hits in category index. Use here-strings so
+        # SIGPIPE under pipefail cannot flip the result on a large KB
+        # category index (`grep -q` closes stdin after first match).
         hits=0
         for token in "${QUERY_TOKENS[@]}"; do
-            if echo "$content_lower" | grep -q "$token" 2>/dev/null; then
+            if grep -q "$token" <<< "$content_lower" 2>/dev/null; then
                 hits=$((hits + 1))
             fi
         done
@@ -120,7 +122,7 @@ while IFS= read -r cat_index; do
             fm=$(awk '/^---$/{c++; if(c==2) exit} c>=1{print}' "$subj_path" 2>/dev/null || true)
             fm_lower=$(echo "$fm" | tr '[:upper:]' '[:lower:]')
             for token in "${QUERY_TOKENS[@]}"; do
-                if echo "$fm_lower" | grep -q "$token" 2>/dev/null; then
+                if grep -q "$token" <<< "$fm_lower" 2>/dev/null; then
                     hits=$((hits + 1))
                 fi
             done

--- a/scripts/spec-lib.sh
+++ b/scripts/spec-lib.sh
@@ -82,6 +82,17 @@ count_tokens() {
 # Supports both manifest schema versions:
 #   v1 (legacy): {"features": {"F01": {"latest_file": "...", ...}}}
 #   v2 (post-migration): {"schema_version": 2, "specs": [{"id": "...", "path": "..."}]}
+#
+# Resolution order:
+#   1. Manifest lookup (exact ID match) — source of truth for any spec the
+#      project has explicitly registered. Most specs are registered.
+#   2. ID-computed path fallback — for nested specs whose parent is registered
+#      but whose entry has not been added to the manifest yet (e.g. during a
+#      /spec-split pilot). The path is deterministic from the ID:
+#          a.b.c.d  →  domains/a/b/c/d.md
+#      First component is the top-level domain dir; intermediate components
+#      become subdirectories; last component is the filename.
+#
 # Returns absolute path or empty string.
 spec_file_for_id() {
   local manifest="$1"
@@ -97,15 +108,87 @@ spec_file_for_id() {
       (.features[$id].latest_file // "")
     end
   ' "$manifest")
-  [[ -z "$rel" ]] && echo "" && return 0
-  # v2 manifest stores paths relative to the repo root (e.g., ".spec/domains/...").
-  # v1 stores paths relative to the .spec/ directory. Detect which form by checking
-  # if the path already starts with ".spec/" — if so, resolve against repo root.
-  if [[ "$rel" == .spec/* ]]; then
-    echo "$spec_dir/${rel#.spec/}"
-  else
-    echo "$spec_dir/$rel"
+  if [[ -n "$rel" ]]; then
+    # v2 manifest stores paths relative to the repo root (e.g., ".spec/domains/...").
+    # v1 stores paths relative to the .spec/ directory. Detect which form by checking
+    # if the path already starts with ".spec/" — if so, resolve against repo root.
+    if [[ "$rel" == .spec/* ]]; then
+      echo "$spec_dir/${rel#.spec/}"
+    else
+      echo "$spec_dir/$rel"
+    fi
+    return 0
   fi
+  # ── Fallback: compute path from a hierarchical ID (a.b[.c[.d...]] → file).
+  # Only applies to domain.slug-shaped IDs with at least one dot. Legacy FXX
+  # IDs and bare names without dots cannot be resolved this way and return
+  # empty (preserves existing behavior on misses).
+  if [[ "$fid" == *.* && "$fid" != F[0-9]* ]]; then
+    local computed
+    # First component is the top-level domain (under domains/).
+    # Remaining components map dots to slashes; last component gets `.md`.
+    local top="${fid%%.*}"
+    local rest="${fid#*.}"
+    rest="${rest//./\/}"
+    computed="$spec_dir/domains/$top/${rest}.md"
+    if [[ -f "$computed" ]]; then
+      echo "$computed"
+      return 0
+    fi
+  fi
+  echo ""
+}
+
+# ── Walk the parent_spec chain for a spec, emit each ancestor ID ─────────────
+# Reads parent_spec from each spec's frontmatter (single string or null).
+# Emits IDs from immediate parent up to the root. Stops at:
+#   - empty/null parent_spec (root reached)
+#   - cycle detection (an ID seen twice — emits a single error to stderr,
+#     stops emitting further IDs but does NOT exit; callers can ignore or
+#     surface as they wish)
+#
+# Args: <manifest> <spec-id>
+# Output: parent IDs on stdout, one per line (closest first)
+spec_walk_parent_chain() {
+  local manifest="$1"
+  local fid="$2"
+  local seen=":$fid:"  # ":id1:id2:" — colon-bookended for safe substring match
+  local depth=0
+  while (( depth < 32 )); do  # hard depth cap as cycle backstop
+    local file parent
+    file=$(spec_file_for_id "$manifest" "$fid")
+    [[ -z "$file" || ! -f "$file" ]] && return 0
+    parent=$(fm "$file" '.parent_spec // ""')
+    [[ -z "$parent" || "$parent" == "null" ]] && return 0
+    # Cycle detection
+    if [[ "$seen" == *":$parent:"* ]]; then
+      echo "[spec-lib] ERROR: parent_spec cycle detected at $parent (chain: $seen)" >&2
+      return 0
+    fi
+    echo "$parent"
+    seen="$seen$parent:"
+    fid="$parent"
+    depth=$((depth + 1))
+  done
+  echo "[spec-lib] ERROR: parent_spec chain exceeded depth 32 (chain: $seen)" >&2
+}
+
+# ── List children of a spec by scanning the manifest ────────────────────────
+# Computed at scan time (we don't store children_specs to avoid bidirectional
+# sync bugs — see decisions-scan.sh:43-50 for the same precedent).
+#
+# Args: <manifest> <parent-id>
+# Output: child IDs on stdout, one per line
+spec_children_for() {
+  local manifest="$1"
+  local pid="$2"
+  jq -r --arg pid "$pid" '
+    if .specs then
+      ((.specs[] | select(.parent_spec == $pid) | .id))
+    else
+      empty
+    end
+  ' "$manifest" 2>/dev/null
 }
 
 # ── Manifest query helpers (v1/v2 schema-agnostic) ───────────────────────────

--- a/scripts/spec-resolve.sh
+++ b/scripts/spec-resolve.sh
@@ -6,6 +6,10 @@
 # Optional env: NEW_SPEC_FILES="path1:path2" — draft specs to check for displacement
 # Optional env: INCLUDE_INVALIDATED=true — include INVALIDATED specs in separate section
 # Optional env: FILTER_KIND="interface-contract" — only include specs with this kind field
+# Optional env: INCLUDE_SIBLINGS=true — when a child spec lands in candidates,
+#                also include its siblings (other children of the same parent).
+#                Used by adversarial paths (/spec-author Pass 2/3) that need
+#                cross-sibling contradiction detection. Default off.
 # Output: markdown bundle on stdout | diagnostics on stderr
 
 set -euo pipefail
@@ -206,7 +210,7 @@ else
     SORTED_FILES=()
 fi
 
-# ── Step 4: Expand transitive requires[], deduplicate ────────────────────────
+# ── Step 4: Expand transitive requires[], parent chain, optional siblings ───
 declare -A SEEN_FILES
 ALL_FILES=()
 
@@ -217,8 +221,51 @@ add_file() {
   ALL_FILES+=("$f")
 }
 
+# Helper: given a spec ID, walk parents and add each to the bundle. Cross-cutting
+# requirements at a parent are part of every child's contract, so when a child
+# lands in candidates, the parent chain MUST be loaded too.
+add_parent_chain() {
+  local fid="$1"
+  while IFS= read -r ancestor_id; do
+    [[ -z "$ancestor_id" ]] && continue
+    ancestor_file=$(spec_file_for_id "$MANIFEST" "$ancestor_id")
+    if [[ -n "$ancestor_file" && -f "$ancestor_file" ]]; then
+      spec_check_crlf "$ancestor_file" 2>/dev/null && add_file "$ancestor_file"
+    else
+      echo "[resolve] Warning: parent_spec $ancestor_id has no resolvable file" >&2
+    fi
+  done < <(spec_walk_parent_chain "$MANIFEST" "$fid")
+}
+
+# Helper: given a parent ID, add its children. Used by INCLUDE_SIBLINGS path.
+add_siblings_via_parent() {
+  local pid="$1"
+  while IFS= read -r child_id; do
+    [[ -z "$child_id" ]] && continue
+    child_file=$(spec_file_for_id "$MANIFEST" "$child_id")
+    if [[ -n "$child_file" && -f "$child_file" ]]; then
+      spec_check_crlf "$child_file" 2>/dev/null && add_file "$child_file"
+    fi
+  done < <(spec_children_for "$MANIFEST" "$pid")
+}
+
 for f in "${SORTED_FILES[@]+"${SORTED_FILES[@]}"}"; do
   add_file "$f"
+  this_id=$(fm "$f" '.id')
+  this_parent=$(fm "$f" '.parent_spec // ""')
+
+  # Parent chain: always include ancestors when a child is selected.
+  if [[ -n "$this_id" ]]; then
+    add_parent_chain "$this_id"
+  fi
+
+  # Siblings: opt-in via INCLUDE_SIBLINGS. When set, every child whose parent
+  # is `this_parent` is added (we do this once per parent — dedup is via
+  # add_file's SEEN_FILES guard).
+  if [[ "${INCLUDE_SIBLINGS:-false}" == "true" && -n "$this_parent" && "$this_parent" != "null" ]]; then
+    add_siblings_via_parent "$this_parent"
+  fi
+
   while IFS= read -r req_id; do
     [[ -z "$req_id" ]] && continue
     req_file=$(spec_file_for_id "$MANIFEST" "$req_id")

--- a/scripts/spec-split.sh
+++ b/scripts/spec-split.sh
@@ -1,0 +1,698 @@
+#!/usr/bin/env bash
+# spec-split.sh — execute a planned spec subdivision
+#
+# Usage:
+#   spec-split.sh --plan <plan.json> [--scan-dirs <csv>] [--dry-run]
+#   spec-split.sh --rollback <log.json>
+#
+# Modes:
+#   default — read a split plan, execute it, write a rollback log.
+#             On any post-write failure (validation, etc.), automatically
+#             replays the rollback log and exits non-zero.
+#   --rollback — replay a rollback log to undo a previously-executed split.
+#                Useful if a manual revert is needed after the fact.
+#   --dry-run — validate the plan and report what would happen, without
+#               touching any file. Always exits 0 if plan is sane.
+#
+# Plan format (JSON):
+#   {
+#     "parent_id": "encryption.primitives-lifecycle",
+#     "children": [
+#       {
+#         "id": "encryption.primitives-lifecycle.key-rotation",
+#         "title": "Key Rotation",
+#         "domains": ["encryption"],
+#         "requirements": ["R12", "R13", "R14", ...]
+#       },
+#       ...
+#     ]
+#   }
+#
+# Cross-cutting requirements are implicit — every R-number in the source
+# spec NOT listed in any child's `requirements` array stays at parent.
+# R-numbers are preserved across the split (no renumbering).
+#
+# What this script does (in order):
+#   1. Validate plan: parent exists, every child's requirements list is
+#      a subset of parent's R-numbers, no overlaps between children, no
+#      missing required JSON fields.
+#   2. Snapshot: capture parent file content + manifest content into
+#      a rollback log JSON written under .spec/.split-log/.
+#   3. Generate per-child file content (carved from parent's body).
+#   4. Generate new parent content (only cross-cutting reqs retained).
+#   5. Write child files, overwrite parent.
+#   6. Update manifest: insert child entries with parent_spec set.
+#   7. Sweep @spec annotations: for each requirement that moved to a
+#      child, rewrite `@spec parent.Rxx` → `@spec parent.child.Rxx` in
+#      project source dirs (auto-detected: src/ lib/ app/ main/ modules/
+#      examples/ benchmarks/ — NOT test/ unless --scan-dirs override).
+#   8. Run spec-validate on parent + every child. On any failure,
+#      replay the rollback log and exit 1.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=spec-lib.sh
+source "$SCRIPT_DIR/spec-lib.sh"
+
+spec_require_deps
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+PLAN_FILE=""
+ROLLBACK_FILE=""
+DRY_RUN=false
+SCAN_DIRS_OVERRIDE=""
+
+usage() {
+  cat <<EOF
+Usage:
+  spec-split.sh --plan <plan.json> [--scan-dirs <csv>] [--dry-run]
+  spec-split.sh --rollback <log.json>
+
+Plan format:
+  {
+    "parent_id": "<spec-id>",
+    "children": [
+      {"id": "<parent-id>.<slug>", "title": "...", "domains": [...],
+       "requirements": ["R12", "R13", ...]}
+    ]
+  }
+EOF
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plan) PLAN_FILE="${2:-}"; shift 2 ;;
+    --rollback) ROLLBACK_FILE="${2:-}"; shift 2 ;;
+    --scan-dirs) SCAN_DIRS_OVERRIDE="${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "ERROR: unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+# ── Project tree resolution ──────────────────────────────────────────────────
+
+SPEC_DIR="$(spec_find_root)" || exit 1
+PROJECT_ROOT="$(dirname "$SPEC_DIR")"
+MANIFEST="$SPEC_DIR/registry/manifest.json"
+[[ ! -f "$MANIFEST" ]] && { echo "ERROR: manifest not found at $MANIFEST" >&2; exit 1; }
+
+SPLIT_LOG_DIR="$SPEC_DIR/.split-log"
+
+# ── Rollback mode ────────────────────────────────────────────────────────────
+
+replay_rollback() {
+  local log="$1"
+  echo "[split] Replaying rollback log: $log" >&2
+  [[ ! -f "$log" ]] && { echo "ERROR: rollback log not found: $log" >&2; return 1; }
+
+  # Restore parent file content (always present in log).
+  local parent_path parent_content
+  parent_path="$(jq -r '.parent_path' "$log")"
+  parent_content="$(jq -r '.parent_snapshot' "$log")"
+  if [[ -n "$parent_path" && -n "$parent_content" ]]; then
+    printf '%s\n' "$parent_content" > "$parent_path"
+    echo "  restored: $parent_path" >&2
+  fi
+
+  # Restore manifest.
+  local manifest_path manifest_content
+  manifest_path="$(jq -r '.manifest_path' "$log")"
+  manifest_content="$(jq -r '.manifest_snapshot' "$log")"
+  if [[ -n "$manifest_path" && -n "$manifest_content" ]]; then
+    printf '%s\n' "$manifest_content" > "$manifest_path"
+    echo "  restored: $manifest_path" >&2
+  fi
+
+  # Delete created child files (in reverse order — innermost first).
+  while IFS= read -r child_path; do
+    [[ -z "$child_path" || "$child_path" == "null" ]] && continue
+    if [[ -f "$child_path" ]]; then
+      rm -f "$child_path"
+      echo "  deleted: $child_path" >&2
+    fi
+  done < <(jq -r '.children_created[]' "$log")
+
+  # Reverse @spec annotation rewrites.
+  while IFS= read -r rewrite; do
+    [[ -z "$rewrite" ]] && continue
+    local file from_text to_text
+    file="$(jq -r '.file' <<< "$rewrite")"
+    from_text="$(jq -r '.to' <<< "$rewrite")"   # "to" was applied; reverse to "from"
+    to_text="$(jq -r '.from' <<< "$rewrite")"
+    if [[ -f "$file" ]]; then
+      # Use a delimiter unlikely to appear in identifiers: |
+      sed -i "s|${from_text}|${to_text}|g" "$file"
+      echo "  unrewrote: $file (${from_text} → ${to_text})" >&2
+    fi
+  done < <(jq -c '.annotation_rewrites[]?' "$log")
+
+  echo "[split] Rollback complete." >&2
+  return 0
+}
+
+if [[ -n "$ROLLBACK_FILE" ]]; then
+  replay_rollback "$ROLLBACK_FILE"
+  exit $?
+fi
+
+# ── Default: plan execution ──────────────────────────────────────────────────
+
+[[ -z "$PLAN_FILE" ]] && usage
+[[ ! -f "$PLAN_FILE" ]] && { echo "ERROR: plan file not found: $PLAN_FILE" >&2; exit 1; }
+jq . "$PLAN_FILE" >/dev/null 2>&1 || { echo "ERROR: plan is not valid JSON: $PLAN_FILE" >&2; exit 1; }
+
+PARENT_ID="$(jq -r '.parent_id // ""' "$PLAN_FILE")"
+[[ -z "$PARENT_ID" ]] && { echo "ERROR: plan missing parent_id" >&2; exit 1; }
+
+PARENT_FILE="$(spec_file_for_id "$MANIFEST" "$PARENT_ID")"
+[[ -z "$PARENT_FILE" || ! -f "$PARENT_FILE" ]] && {
+  echo "ERROR: parent spec not found in registry: $PARENT_ID" >&2
+  exit 1
+}
+
+# ── Parse parent's R-numbers from machine section ────────────────────────────
+
+mapfile -t PARENT_R_NUMBERS < <(machine_section "$PARENT_FILE" \
+  | grep -oE '^R[0-9]+[a-z]?\.' \
+  | sed 's/\.$//' \
+  | sort -u)
+
+declare -A PARENT_R_SET
+for r in "${PARENT_R_NUMBERS[@]}"; do
+  PARENT_R_SET["$r"]=1
+done
+
+if [[ ${#PARENT_R_NUMBERS[@]} -eq 0 ]]; then
+  echo "ERROR: parent spec has no R-requirements: $PARENT_FILE" >&2
+  exit 1
+fi
+
+echo "[split] Parent: $PARENT_ID  ($PARENT_FILE)" >&2
+echo "[split] Source R-numbers: ${#PARENT_R_NUMBERS[@]}  (R$(echo "${PARENT_R_NUMBERS[0]}" | tr -d R) … R$(echo "${PARENT_R_NUMBERS[-1]}" | tr -d R))" >&2
+
+# ── Validate plan against parent ─────────────────────────────────────────────
+
+CHILD_COUNT="$(jq '.children | length' "$PLAN_FILE")"
+if (( CHILD_COUNT < 1 )); then
+  echo "ERROR: plan has no children" >&2
+  exit 1
+fi
+
+declare -A CLAIMED_R
+declare -A CHILD_IDS_SEEN
+
+# Each child entry validation pass.
+for ((i=0; i<CHILD_COUNT; i++)); do
+  child_id="$(jq -r ".children[$i].id // \"\"" "$PLAN_FILE")"
+  child_title="$(jq -r ".children[$i].title // \"\"" "$PLAN_FILE")"
+  child_doms="$(jq -c ".children[$i].domains // []" "$PLAN_FILE")"
+  mapfile -t child_reqs < <(jq -r ".children[$i].requirements[]?" "$PLAN_FILE")
+
+  [[ -z "$child_id" ]] && { echo "ERROR: child $i missing 'id'" >&2; exit 1; }
+  [[ -z "$child_title" ]] && { echo "ERROR: child $i ($child_id) missing 'title'" >&2; exit 1; }
+
+  # Child ID must extend parent ID by exactly one segment.
+  expected_prefix="${PARENT_ID}."
+  if [[ "$child_id" != ${expected_prefix}* ]]; then
+    echo "ERROR: child id '$child_id' must start with '$expected_prefix'" >&2
+    exit 1
+  fi
+  tail_part="${child_id#$expected_prefix}"
+  if [[ "$tail_part" == *.* ]]; then
+    echo "ERROR: child id '$child_id' must add exactly one segment to parent" >&2
+    exit 1
+  fi
+  if [[ -z "$tail_part" ]]; then
+    echo "ERROR: child id '$child_id' equals parent id" >&2
+    exit 1
+  fi
+
+  # Duplicate child IDs in the plan
+  if [[ -n "${CHILD_IDS_SEEN[$child_id]+x}" ]]; then
+    echo "ERROR: duplicate child id in plan: $child_id" >&2
+    exit 1
+  fi
+  CHILD_IDS_SEEN["$child_id"]=1
+
+  # Each requirement must exist in parent + not already be claimed.
+  if (( ${#child_reqs[@]} == 0 )); then
+    echo "ERROR: child '$child_id' has no requirements (empty children are not allowed)" >&2
+    exit 1
+  fi
+  for r in "${child_reqs[@]}"; do
+    if [[ -z "${PARENT_R_SET[$r]+x}" ]]; then
+      echo "ERROR: child '$child_id' requires '$r' which is not in parent's R-numbers" >&2
+      exit 1
+    fi
+    if [[ -n "${CLAIMED_R[$r]+x}" ]]; then
+      echo "ERROR: requirement '$r' claimed by both '${CLAIMED_R[$r]}' and '$child_id'" >&2
+      exit 1
+    fi
+    CLAIMED_R["$r"]="$child_id"
+  done
+
+  echo "[split] Child plan: $child_id ($child_title) — ${#child_reqs[@]} reqs" >&2
+done
+
+# Cross-cutting set = parent reqs not claimed by any child.
+CROSS_CUTTING=()
+for r in "${PARENT_R_NUMBERS[@]}"; do
+  [[ -z "${CLAIMED_R[$r]+x}" ]] && CROSS_CUTTING+=("$r")
+done
+echo "[split] Cross-cutting (stays at parent): ${#CROSS_CUTTING[@]}  ${CROSS_CUTTING[*]:-(none)}" >&2
+
+if (( ${#CROSS_CUTTING[@]} == 0 )); then
+  echo "ERROR: no cross-cutting requirements would remain at parent — every R-number is claimed by a child." >&2
+  echo "       A parent must retain at least one cross-cutting requirement after a split." >&2
+  echo "       Re-examine the plan; consider keeping at least one umbrella invariant at parent." >&2
+  exit 1
+fi
+
+# ── Dry-run exit ─────────────────────────────────────────────────────────────
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "[split] DRY RUN — plan validates. ${#CHILD_COUNT[@]:-} children, ${#CROSS_CUTTING[@]} cross-cutting reqs." >&2
+  exit 0
+fi
+
+# ── Build rollback log first (before any change) ─────────────────────────────
+
+mkdir -p "$SPLIT_LOG_DIR"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ROLLBACK_LOG="$SPLIT_LOG_DIR/${PARENT_ID//./-}-${TIMESTAMP}.json"
+
+PARENT_SNAPSHOT="$(cat "$PARENT_FILE")"
+MANIFEST_SNAPSHOT="$(cat "$MANIFEST")"
+
+# Track files we'll create (for rollback delete) and annotation rewrites.
+CHILDREN_CREATED=()
+declare -A ANNOTATION_REWRITES_FROM=()  # key=index, val=from
+declare -A ANNOTATION_REWRITES_TO=()
+declare -A ANNOTATION_REWRITES_FILE=()
+REWRITE_INDEX=0
+
+# Write initial rollback log (we'll rewrite at the end with full state).
+emit_rollback_log() {
+  jq -n \
+    --arg parent_id "$PARENT_ID" \
+    --arg parent_path "$PARENT_FILE" \
+    --arg parent_snapshot "$PARENT_SNAPSHOT" \
+    --arg manifest_path "$MANIFEST" \
+    --arg manifest_snapshot "$MANIFEST_SNAPSHOT" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson children_created "$(printf '%s\n' "${CHILDREN_CREATED[@]+"${CHILDREN_CREATED[@]}"}" | jq -R . | jq -s .)" \
+    --argjson rewrites "$(
+      if (( REWRITE_INDEX > 0 )); then
+        for ((i=0; i<REWRITE_INDEX; i++)); do
+          jq -n \
+            --arg file "${ANNOTATION_REWRITES_FILE[$i]}" \
+            --arg from "${ANNOTATION_REWRITES_FROM[$i]}" \
+            --arg to "${ANNOTATION_REWRITES_TO[$i]}" \
+            '{file: $file, from: $from, to: $to}'
+        done | jq -s .
+      else
+        echo '[]'
+      fi
+    )" \
+    '{
+      parent_id: $parent_id,
+      parent_path: $parent_path,
+      parent_snapshot: $parent_snapshot,
+      manifest_path: $manifest_path,
+      manifest_snapshot: $manifest_snapshot,
+      timestamp: $timestamp,
+      children_created: $children_created,
+      annotation_rewrites: $rewrites
+    }' > "$ROLLBACK_LOG"
+}
+
+emit_rollback_log
+echo "[split] Rollback log: $ROLLBACK_LOG" >&2
+
+# ── Helper: extract a requirement's full block from parent body ──────────────
+# A requirement block is everything from "RN. " up to (but not including) the
+# next "RN. " line at the same indentation. Empty lines and continuation lines
+# are part of the requirement.
+extract_requirement_block() {
+  local body="$1" rn="$2"
+  awk -v target="$rn" '
+    BEGIN { in_target = 0 }
+    /^R[0-9]+[a-z]?\./ {
+      if (in_target) exit
+      # Match "Rxx." prefix exactly (Rxx followed by .)
+      if (substr($0, 1, length(target) + 1) == target".") {
+        in_target = 1
+      }
+    }
+    in_target { print }
+  ' <<< "$body"
+}
+
+# ── Pull parent metadata for child frontmatter ───────────────────────────────
+
+PARENT_FM="$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$PARENT_FILE")"
+PARENT_VERSION="$(jq -r '.version // 1' <<< "$PARENT_FM")"
+PARENT_DOMAINS="$(jq -c '.domains // []' <<< "$PARENT_FM")"
+PARENT_BODY="$(machine_section "$PARENT_FILE")"
+PARENT_NARRATIVE="$(awk '/^---$/{n++; next} n==2{found=1; next} n>=3{print}' "$PARENT_FILE")"
+PARENT_PRENARRATIVE="$(awk '
+  /^---$/ { delim++; print; next }
+  delim == 2 { exit }
+  { print }
+' "$PARENT_FILE" | awk '
+  BEGIN { d = 0 }
+  /^---$/ { d++; if (d == 2) { exit }; next }
+  d == 1 { next }   # skip frontmatter
+  d == 2 { print }
+')"
+
+# Actually — simpler: pre-narrative is whatever lives between FM close and
+# machine section open. Let me re-extract.
+# Spec layout:
+#   ---           <- d=1
+#   { JSON }
+#   ---           <- d=2
+#   <pre-narrative>
+#                 (often "# Title" + a paragraph)
+#   R1. ...
+#   R2. ...
+#   ---           <- d=3
+#   <post-narrative>
+# Wait — machine_section is delim==2 content, which INCLUDES pre-narrative
+# and R-lines. The pre-narrative is the prose before the first R-line.
+
+# Recompute pre/R/post split from machine_section content.
+PARENT_PRENARRATIVE="$(awk '
+  /^R[0-9]+[a-z]?\./ { exit }
+  { print }
+' <<< "$PARENT_BODY")"
+
+# ── Build child files ────────────────────────────────────────────────────────
+
+new_child_file_for_id() {
+  # ID a.b.c.d → SPEC_DIR/domains/a/b/c/d.md
+  local fid="$1"
+  local top="${fid%%.*}"
+  local rest="${fid#*.}"
+  rest="${rest//./\/}"
+  echo "$SPEC_DIR/domains/$top/${rest}.md"
+}
+
+build_child_file() {
+  local child_id="$1" child_title="$2" child_domains="$3"
+  shift 3
+  local -a reqs=("$@")
+
+  # Body: assemble per-requirement blocks in their order in PARENT_BODY.
+  # Walk parent's R-numbers in source order; if R is in this child's req list,
+  # emit it.
+  declare -A IS_MINE
+  for r in "${reqs[@]}"; do IS_MINE["$r"]=1; done
+
+  local body=""
+  for r in "${PARENT_R_NUMBERS[@]}"; do
+    if [[ -n "${IS_MINE[$r]+x}" ]]; then
+      body+=$(extract_requirement_block "$PARENT_BODY" "$r")
+      body+=$'\n\n'
+    fi
+  done
+
+  # Frontmatter for child.
+  local child_fm
+  child_fm="$(jq -n \
+    --arg id "$child_id" \
+    --argjson version 1 \
+    --arg parent_spec "$PARENT_ID" \
+    --argjson domains "$child_domains" \
+    '{
+      id: $id,
+      version: $version,
+      status: "ACTIVE",
+      state: "DRAFT",
+      domains: $domains,
+      requires: [],
+      invalidates: [],
+      decision_refs: [],
+      kb_refs: [],
+      parent_spec: $parent_spec,
+      _split_from: $parent_spec
+    }')"
+
+  # Compose: FM + title + body + post-narrative stub.
+  cat <<EOF
+---
+$child_fm
+---
+
+# $child_id — $child_title
+
+This spec was carved from \`$PARENT_ID\` during a domain subdivision. The
+parent retains cross-cutting requirements that span multiple sub-domains;
+the requirements below are specific to this concern.
+
+${body%$'\n\n'}
+
+---
+
+## Notes
+EOF
+}
+
+execute_split() {
+  # Step 1: build child files in memory; only write after all are built.
+  local -A CHILD_CONTENT=()
+  local -A CHILD_PATH=()
+
+  for ((i=0; i<CHILD_COUNT; i++)); do
+    local child_id child_title child_doms
+    child_id="$(jq -r ".children[$i].id" "$PLAN_FILE")"
+    child_title="$(jq -r ".children[$i].title" "$PLAN_FILE")"
+    child_doms="$(jq -c ".children[$i].domains" "$PLAN_FILE")"
+    mapfile -t child_reqs < <(jq -r ".children[$i].requirements[]" "$PLAN_FILE")
+
+    local child_path
+    child_path="$(new_child_file_for_id "$child_id")"
+    if [[ -f "$child_path" ]]; then
+      echo "ERROR: child file already exists: $child_path" >&2
+      return 1
+    fi
+
+    CHILD_CONTENT["$child_id"]="$(build_child_file "$child_id" "$child_title" "$child_doms" "${child_reqs[@]}")"
+    CHILD_PATH["$child_id"]="$child_path"
+  done
+
+  # Step 2: build new parent body — only cross-cutting R-numbers retained.
+  local new_parent_body=""
+  if [[ -n "$PARENT_PRENARRATIVE" ]]; then
+    # Trim trailing blank lines but preserve content.
+    new_parent_body+="$PARENT_PRENARRATIVE"
+    new_parent_body+=$'\n'
+  fi
+  for r in "${CROSS_CUTTING[@]}"; do
+    new_parent_body+=$(extract_requirement_block "$PARENT_BODY" "$r")
+    new_parent_body+=$'\n\n'
+  done
+
+  # Step 3: build new parent file (FM unchanged + new body).
+  local new_parent_fm
+  new_parent_fm="$(jq --argjson v "$((PARENT_VERSION + 1))" \
+    '. + {version: $v}' <<< "$PARENT_FM")"
+
+  local post_narrative
+  post_narrative="$(awk '
+    BEGIN { d = 0 }
+    /^---$/ { d++; if (d == 3) { p = 1; next } }
+    p { print }
+  ' "$PARENT_FILE")"
+
+  local new_parent_content
+  new_parent_content="---
+$new_parent_fm
+---
+
+${new_parent_body%$'\n\n'}
+
+---
+
+$post_narrative"
+
+  # Step 4: write children + parent atomically (write to .tmp then mv).
+  for child_id in "${!CHILD_PATH[@]}"; do
+    local child_path="${CHILD_PATH[$child_id]}"
+    mkdir -p "$(dirname "$child_path")"
+    local tmp="$child_path.tmp"
+    printf '%s\n' "${CHILD_CONTENT[$child_id]}" > "$tmp"
+    mv "$tmp" "$child_path"
+    CHILDREN_CREATED+=("$child_path")
+    echo "  created: $child_path" >&2
+  done
+
+  # Overwrite parent.
+  local parent_tmp="$PARENT_FILE.tmp"
+  printf '%s\n' "$new_parent_content" > "$parent_tmp"
+  mv "$parent_tmp" "$PARENT_FILE"
+  echo "  rewrote: $PARENT_FILE (cross-cutting only, ${#CROSS_CUTTING[@]} reqs)" >&2
+
+  # Step 5: update manifest with child entries.
+  local manifest_tmp="$MANIFEST.tmp"
+  cp "$MANIFEST" "$manifest_tmp"
+  for ((i=0; i<CHILD_COUNT; i++)); do
+    local child_id child_doms child_path child_rel
+    child_id="$(jq -r ".children[$i].id" "$PLAN_FILE")"
+    child_doms="$(jq -c ".children[$i].domains" "$PLAN_FILE")"
+    child_path="${CHILD_PATH[$child_id]}"
+    child_rel=".spec/${child_path#$SPEC_DIR/}"
+
+    local next_tmp
+    next_tmp="$(mktemp)"
+    jq --arg id "$child_id" \
+       --arg path "$child_rel" \
+       --arg parent "$PARENT_ID" \
+       --argjson doms "$child_doms" \
+       '
+        .specs = ((.specs // []) | map(select(.id != $id)) + [{
+          id: $id,
+          path: $path,
+          state: "DRAFT",
+          version: 1,
+          domains: $doms,
+          parent_spec: $parent,
+          requires: [],
+          invalidates: [],
+          decision_refs: [],
+          kb_refs: []
+        }])
+        | .spec_count = (.specs | length)
+        | .generated_at = (now | todate)
+       ' "$manifest_tmp" > "$next_tmp" && mv "$next_tmp" "$manifest_tmp"
+  done
+  mv "$manifest_tmp" "$MANIFEST"
+  echo "  manifest: added $CHILD_COUNT child entries" >&2
+
+  # Step 6: sweep @spec annotations for moved requirements.
+  rewrite_annotations
+}
+
+# ── Annotation rewrite sweep ─────────────────────────────────────────────────
+
+rewrite_annotations() {
+  # Resolve scan dirs.
+  local scan_dirs=()
+  if [[ -n "$SCAN_DIRS_OVERRIDE" ]]; then
+    IFS=',' read -ra user_dirs <<< "$SCAN_DIRS_OVERRIDE"
+    for d in "${user_dirs[@]}"; do
+      [[ -d "$PROJECT_ROOT/$d" ]] && scan_dirs+=("$PROJECT_ROOT/$d")
+    done
+  else
+    for cand in src lib app main modules examples benchmarks; do
+      [[ -d "$PROJECT_ROOT/$cand" ]] && scan_dirs+=("$PROJECT_ROOT/$cand")
+    done
+  fi
+  if (( ${#scan_dirs[@]} == 0 )); then
+    echo "[split] No source dirs to scan for @spec annotations — skipping rewrite." >&2
+    return 0
+  fi
+  echo "[split] @spec rewrite scan: ${scan_dirs[*]}" >&2
+
+  # For each child, for each moved requirement, rewrite annotations.
+  for ((i=0; i<CHILD_COUNT; i++)); do
+    local child_id
+    child_id="$(jq -r ".children[$i].id" "$PLAN_FILE")"
+    mapfile -t reqs < <(jq -r ".children[$i].requirements[]" "$PLAN_FILE")
+
+    for r in "${reqs[@]}"; do
+      local from_anno="@spec ${PARENT_ID}.${r}"
+      local to_anno="@spec ${child_id}.${r}"
+
+      # Find files containing the from_anno literal. Skip conventional test
+      # directories — annotations live in production code; test annotations
+      # mirror them but are not part of the kit's rewrite mandate (the
+      # rewrite scope guarantee is "production source dirs"). Override via
+      # --scan-dirs if a project keeps annotated tests under test/.
+      mapfile -t hits < <(
+        grep -rln --binary-files=without-match -F "$from_anno" "${scan_dirs[@]}" \
+          --include='*.java' --include='*.py' --include='*.js' \
+          --include='*.ts' --include='*.go' --include='*.rs' \
+          --include='*.kt' --include='*.scala' --include='*.c' \
+          --include='*.cpp' --include='*.h' --include='*.hpp' \
+          --include='*.cs' --include='*.rb' --include='*.swift' \
+          --include='*.m' --include='*.sh' \
+          --exclude-dir='test' --exclude-dir='tests' \
+          --exclude-dir='__tests__' --exclude-dir='spec' \
+          --exclude-dir='node_modules' --exclude-dir='vendor' \
+          --exclude-dir='target' --exclude-dir='build' --exclude-dir='dist' \
+          2>/dev/null || true
+      )
+
+      for hit in "${hits[@]}"; do
+        [[ -z "$hit" ]] && continue
+        # Use sed with | delimiter (file paths may contain /).
+        # Anchor: from_anno followed by a non-identifier character or EOL,
+        # so we don't accidentally match `parent.R1` when intending `parent.R12`.
+        sed -i -E "s|${from_anno}([^A-Za-z0-9])|${to_anno}\1|g; s|${from_anno}\$|${to_anno}|g" "$hit"
+        ANNOTATION_REWRITES_FILE[$REWRITE_INDEX]="$hit"
+        ANNOTATION_REWRITES_FROM[$REWRITE_INDEX]="$from_anno"
+        ANNOTATION_REWRITES_TO[$REWRITE_INDEX]="$to_anno"
+        REWRITE_INDEX=$((REWRITE_INDEX + 1))
+        echo "  @spec rewrite: $hit  ($from_anno → $to_anno)" >&2
+      done
+    done
+  done
+
+  # Update rollback log with the rewrite list.
+  emit_rollback_log
+}
+
+# ── Validation gate ──────────────────────────────────────────────────────────
+
+validate_after_split() {
+  echo "[split] Validating parent + children…" >&2
+  local fail=0
+
+  if ! bash "$SCRIPT_DIR/spec-validate.sh" "$PARENT_FILE" >/dev/null 2>&1; then
+    bash "$SCRIPT_DIR/spec-validate.sh" "$PARENT_FILE" >&2 || true
+    fail=1
+  fi
+
+  for ((i=0; i<CHILD_COUNT; i++)); do
+    local child_id child_path
+    child_id="$(jq -r ".children[$i].id" "$PLAN_FILE")"
+    child_path="$(spec_file_for_id "$MANIFEST" "$child_id")"
+    if [[ -z "$child_path" || ! -f "$child_path" ]]; then
+      echo "FAIL: child $child_id not resolvable post-split" >&2
+      fail=1
+      continue
+    fi
+    if ! bash "$SCRIPT_DIR/spec-validate.sh" "$child_path" >/dev/null 2>&1; then
+      bash "$SCRIPT_DIR/spec-validate.sh" "$child_path" >&2 || true
+      fail=1
+    fi
+  done
+
+  return $fail
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+if ! execute_split; then
+  echo "[split] Execution failed — replaying rollback…" >&2
+  replay_rollback "$ROLLBACK_LOG" || true
+  exit 1
+fi
+
+# Re-emit final rollback log with annotation rewrites included.
+emit_rollback_log
+
+if ! validate_after_split; then
+  echo "[split] Post-split validation failed — replaying rollback…" >&2
+  replay_rollback "$ROLLBACK_LOG"
+  echo "[split] Rolled back; rollback log preserved at $ROLLBACK_LOG for inspection." >&2
+  exit 1
+fi
+
+echo "[split] Done. Parent: $PARENT_ID  ·  Children: $CHILD_COUNT  ·  Cross-cutting reqs: ${#CROSS_CUTTING[@]}" >&2
+echo "[split] Rollback log: $ROLLBACK_LOG (preserved for one release; safe to delete after)" >&2

--- a/scripts/spec-trace.sh
+++ b/scripts/spec-trace.sh
@@ -30,10 +30,12 @@ FORMAT="${SPEC_TRACE_FORMAT:-summary}"
 }
 
 # Validate spec ID format: legacy FXX (zero-padded 2+ digits) OR domain.slug
-# (lowercase letter + hyphenated segments separated by a single dot).
-if ! echo "$SPEC_ID" | grep -qE '^(F[0-9]{2,}|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)$'; then
+# (lowercase letter + hyphenated segments separated by one or more dots —
+# multi-dot IDs are nested specs, e.g. encryption.primitives-lifecycle.key-rotation).
+if ! echo "$SPEC_ID" | grep -qE '^(F[0-9]{2,}|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)$'; then
   echo "ERROR: Invalid spec ID '$SPEC_ID'." >&2
   echo "  Expected: legacy FXX (e.g. F01, F13) OR domain.slug (e.g. schema.field-access)" >&2
+  echo "  Nested IDs allowed: encryption.primitives-lifecycle.key-rotation" >&2
   exit 1
 fi
 

--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -163,12 +163,15 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
   done < <(fm "$FILE" '.kb_refs // [] | .[]')
 
   # ── Check 9b: APPROVED specs must not have unresolved conflict markers
+  # Use here-strings (not `echo "$var" | grep`) so SIGPIPE under pipefail
+  # cannot flip the result on very large machine sections — observed at
+  # 134 KB on encryption.primitives-lifecycle in jlsm.
   if [[ "$STATE" == "APPROVED" ]]; then
     spec_body=$(machine_section "$FILE")
-    if echo "$spec_body" | grep -qE '\[UNRESOLVED\]' 2>/dev/null; then
+    if grep -qE '\[UNRESOLVED\]' <<< "$spec_body" 2>/dev/null; then
       ERRORS+=("APPROVED spec has [UNRESOLVED] markers — should be DRAFT")
     fi
-    if echo "$spec_body" | grep -qE '\[CONFLICT\]' 2>/dev/null; then
+    if grep -qE '\[CONFLICT\]' <<< "$spec_body" 2>/dev/null; then
       ERRORS+=("APPROVED spec has [CONFLICT] markers — should be DRAFT")
     fi
   fi
@@ -183,8 +186,9 @@ if (( delim_count < 3 )); then
 fi
 
 # ── Check 11: numbered requirements exist in machine section
+# Here-string instead of pipe — see 9b above for SIGPIPE rationale.
 machine=$(machine_section "$FILE")
-if ! echo "$machine" | grep -qE '^R[0-9]+\.'; then
+if ! grep -qE '^R[0-9]+\.' <<< "$machine"; then
   ERRORS+=("No numbered requirements found in machine section (expected R1. R2. format)")
 fi
 

--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -77,12 +77,15 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
     echo "[validate] Warning: manifest not found, skipping requires check" >&2
   fi
 
-  # ── Spec ID format patterns (legacy FXX or new domain.slug) ───────────────
-  # Spec ID alone:           F01  OR  schema.field-access
-  # Spec requirement ref:    F01.R3  OR  schema.field-access.R3
-  #                          (letter-suffix RNs like R51a are supported)
-  spec_id_re='^(F[0-9]+|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)$'
-  spec_ref_re='^(F[0-9]+|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)\.R[0-9]+[a-z]?$'
+  # ── Spec ID format patterns (legacy FXX or domain.slug, optionally nested) ──
+  # Spec ID alone:           F01  OR  schema.field-access  OR
+  #                          encryption.primitives-lifecycle.key-rotation
+  # Spec requirement ref:    F01.R3  OR  schema.field-access.R3  OR
+  #                          encryption.primitives-lifecycle.key-rotation.R3
+  #                          (letter-suffix RNs like R51a are supported;
+  #                           multi-dot IDs are nested specs.)
+  spec_id_re='^(F[0-9]+|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)$'
+  spec_ref_re='^(F[0-9]+|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)\.R[0-9]+[a-z]?$'
 
   # ── Check 7: invalidates[] format AND target existence
   while IFS= read -r inv; do
@@ -140,6 +143,55 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
       fi
     fi
   done < <(fm "$FILE" '.revived_by // [] | .[]')
+
+  # ── Check 7f: parent_spec resolves + ID-prefix consistency + acyclic ────────
+  # parent_spec is a single-string field. When set:
+  #   1. The parent must exist in the manifest.
+  #   2. The child's ID must be the parent's ID + "." + a single hierarchical
+  #      segment (so encryption.primitives-lifecycle.key-rotation may declare
+  #      encryption.primitives-lifecycle as parent, but NOT encryption.foo).
+  #   3. The chain walked via parent_spec MUST be acyclic. spec_walk_parent_chain
+  #      surfaces any cycle on stderr; we verify by counting hops vs depth cap.
+  PARENT_SPEC=$(fm "$FILE" '.parent_spec // ""')
+  if [[ -n "$PARENT_SPEC" && "$PARENT_SPEC" != "null" ]]; then
+    # Format check
+    if ! echo "$PARENT_SPEC" | grep -qE "$spec_id_re"; then
+      ERRORS+=("Invalid parent_spec format: '$PARENT_SPEC' (expected FXX or domain.slug[.subdomain...])")
+    elif [[ -f "$MANIFEST" ]]; then
+      # Existence check
+      par_file=$(spec_file_for_id "$MANIFEST" "$PARENT_SPEC")
+      if [[ -z "$par_file" || ! -f "$par_file" ]]; then
+        ERRORS+=("Unresolvable parent_spec: $PARENT_SPEC (not in registry)")
+      else
+        # ID-prefix check: child ID must be parent ID + "." + one segment
+        SELF_ID=$(fm "$FILE" '.id // ""')
+        if [[ -n "$SELF_ID" ]]; then
+          expected_prefix="${PARENT_SPEC}."
+          if [[ "$SELF_ID" != ${expected_prefix}* ]]; then
+            ERRORS+=("ID prefix mismatch: '$SELF_ID' must start with '$expected_prefix' to declare parent_spec '$PARENT_SPEC'")
+          else
+            # Trailing portion after the prefix must be a single hierarchical
+            # segment (one or more lowercase-hyphenated words separated by dots
+            # is valid for grandchildren — actually, wait, exactly one segment
+            # for an immediate parent). We enforce ONE segment because
+            # parent_spec is the *immediate* parent.
+            tail_part="${SELF_ID#${expected_prefix}}"
+            if [[ "$tail_part" == *.* ]]; then
+              ERRORS+=("ID-segment mismatch: '$SELF_ID' has more than one segment beyond parent_spec '$PARENT_SPEC' — parent_spec must point to the IMMEDIATE parent (e.g. for a.b.c.d, parent_spec must be a.b.c, not a.b)")
+            elif [[ -z "$tail_part" ]]; then
+              ERRORS+=("ID equals parent_spec — '$SELF_ID' cannot declare itself as its own parent")
+            fi
+          fi
+        fi
+        # Acyclic check: walk the chain; spec_walk_parent_chain emits an
+        # error to stderr if it detects a cycle or exceeds depth.
+        chain_err=$(spec_walk_parent_chain "$MANIFEST" "$SELF_ID" 2>&1 >/dev/null || true)
+        if echo "$chain_err" | grep -q "ERROR:"; then
+          ERRORS+=("parent_spec chain invalid for '$SELF_ID': $(echo "$chain_err" | head -1 | sed 's/^\[spec-lib\] //')")
+        fi
+      fi
+    fi
+  fi
 
   # ── Check 7e: displacement_reason present when displaced_by is non-empty (warning)
   DISPLACED_BY_COUNT=$(fm "$FILE" '.displaced_by // [] | length')

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -386,6 +386,42 @@ For each aging obligation, use AskUserQuestion with options:
   design narrative explaining the closure
 - **"Skip for now"** — defer to next /curate pass
 
+### 2o — Subdivision candidates (mature specs that may want to subdivide)
+
+**Guard:** Only run this step if "Subdivision Candidates" section exists in
+the scan summary. If absent, skip entirely.
+
+From "Subdivision Candidates" in the scan summary:
+
+1. Each row shows a spec that has grown past one file's worth of behavior
+   (≥50 reqs OR ≥15K tokens) AND shows multiple distinct concerns
+   (≥2 section headers, no single section dominating).
+2. Subdivision is a **natural progression** for these specs — the parent
+   stays a full spec retaining cross-cutting requirements, while concern-
+   specific reqs move to child specs. The detection is heuristic; a spec
+   that looks subdividable on paper may turn out to be a single tightly-
+   coupled concern that just happens to have multiple section headers.
+3. The script already filters out specs where one section holds ≥90% of
+   the requirements (those are mature-but-singular and not real candidates).
+
+For each candidate, use AskUserQuestion with options:
+- **"Subdivide via /spec-split"** → run `/spec-split <spec-id>`. The skill
+  will propose concern boundaries from the spec's existing section
+  structure, confirm with you (with edit option), and execute the split
+  with @spec annotation rewrites + automatic rollback on validation
+  failure.
+- **"Decline — concerns are interlocked"** → mark this spec as a recent
+  decline so a future /curate pass doesn't surface it again immediately.
+  Add a one-line note to the spec's design narrative explaining why it
+  shouldn't subdivide (e.g. "single algorithm, requirement clusters
+  reflect implementation phases, not separable concerns").
+- **"Defer"** → the spec is a candidate but you're not ready to subdivide
+  this session. It will resurface at the next /curate run.
+
+The "Decline — concerns are interlocked" option is important. Subdivision
+fragments a coherent contract when forced; it should never be automatic.
+Honest declines are a feature, not a failure.
+
 ---
 
 ## Step 3 — Present findings as a numbered pick list

--- a/skills/spec-author/SKILL.md
+++ b/skills/spec-author/SKILL.md
@@ -84,6 +84,30 @@ job, not this skill's.
    - This information does not change the authoring flow — it adds awareness
      of who will consume the spec being authored.
 
+6. **Layered-spec family load (if amending a child spec):** If the target
+   spec already exists in the manifest AND its frontmatter has a non-empty
+   `parent_spec`, this is a child in a layered family. Adversarial review
+   needs the parent (cross-cutting requirements) AND all siblings (cross-
+   sibling contradictions) loaded as full files, not summaries. Re-run the
+   resolver with sibling inclusion:
+
+   ```bash
+   EXPLICIT_SPEC_IDS="<target-spec-id>" INCLUDE_SIBLINGS=true \
+     bash .claude/scripts/spec-resolve.sh "<feature description>" 16000
+   ```
+
+   `spec-resolve.sh` auto-includes the parent chain when a child is
+   selected; `INCLUDE_SIBLINGS=true` adds every other child of the same
+   parent. The resulting bundle becomes Pass 2 / Pass 3's "resolved
+   context bundle" instead of the pre-flight default — falsification
+   subagents need this richer family view to spot contradictions across
+   the family.
+
+   Also re-run the work-group context query against the family's domains
+   (Step 5) so consumers of any sibling are surfaced.
+
+   If the target is a top-level spec (no `parent_spec`), skip this step.
+
 ---
 
 ## Pass 1 — Structured authoring
@@ -531,6 +555,56 @@ For each finding, provide:
 
 The user decides what to include, adjust, or drop. Apply their decisions
 to the spec.
+
+### Just-in-time subdivision signal (after arbitration applied)
+
+After applying the user's arbitration decisions, evaluate the spec's
+post-amendment shape against the natural-progression heuristic. The
+goal is a non-blocking heads-up — if this amendment has tipped the
+spec into "multiple distinct concerns at scale" territory,
+`/spec-split` is now an option.
+
+Mechanical check (apply mentally — no script needed):
+
+1. Count R-numbered requirements (lines matching `^R[0-9]+`).
+2. Count distinct concern-style section headers in the machine section
+   (`## <Concern>` or `### <Concern>` — exclude headers named
+   "Notes", "Narrative", "Design", "History", "Appendix").
+3. For each section, count the requirements under it. Track the
+   largest section's count.
+4. Apply the same thresholds `/curate` uses (so detection here matches
+   what /curate would flag at the next housekeeping pass):
+
+   - Reqs ≥ 50 OR machine-section size ≥ ~15K tokens (~60 KB)
+   - Section count ≥ 2
+   - Largest section's share < 90% of total reqs (otherwise the spec
+     is large-but-singular, not a real subdivision candidate)
+   - Spec does NOT already have `parent_spec` set (skip — already
+     part of a layered family)
+
+If all thresholds match, surface alongside the Pass 2 findings with
+this exact framing — note its non-blocking nature explicitly so the
+user knows it's information, not a request:
+
+```
+── Just-in-time subdivision signal ───────────────
+This spec now sits in subdivision territory:
+  N requirements across M concern sections
+  Largest section: <section name>  (K reqs, P% of total)
+
+After this amendment lands, consider:
+  /spec-split <spec-id>
+
+This is a heads-up, not a blocker. Proceed to Pass 3 normally. The
+candidate will also surface at the next /curate run.
+```
+
+If the thresholds do NOT match, do not surface anything — silence is
+the default when subdivision isn't applicable. Don't draw attention
+to the absence of the signal.
+
+This signal does NOT block Pass 3. It does NOT modify any file. It
+just informs the user that natural subdivision has become an option.
 
 ---
 

--- a/skills/spec-split/SKILL.md
+++ b/skills/spec-split/SKILL.md
@@ -1,0 +1,295 @@
+---
+description: "Subdivide a mature spec into a parent + child sub-domain specs"
+argument-hint: "<spec-id>"
+---
+
+# /spec-split <spec-id>
+
+Subdivide a mature spec into a parent + concern-specific children. The
+parent stays a full spec — it retains R-numbered cross-cutting
+requirements that span all children — while each child owns the
+requirements for its concern. Subdivision is a **natural progression**
+for a domain that has accumulated multiple distinct concerns. It is
+not a remediation step.
+
+Typical entry points:
+- `/curate` flagged this spec as a subdivision candidate.
+- `/spec-author` Pass 2 surfaced a just-in-time signal during an
+  amendment.
+- You ran `/spec-split` directly because you know the spec has grown
+  past coherence into multiple concerns.
+
+For the conceptual model and file layout, see `.spec/CLAUDE.md`
+"Layered specs" section.
+
+---
+
+## Step 1 — Resolve the parent spec
+
+Resolve `<spec-id>` to its file via the registry:
+
+```bash
+SPEC_PATH="$(jq -r --arg id "$1" '.specs[] | select(.id == $id) | .path' .spec/registry/manifest.json)"
+```
+
+If empty: report "spec not found in registry" and stop.
+
+Read the spec file. Display the spec's current state:
+
+```
+Spec: <spec-id>
+  Version: <version>
+  State: <state>
+  Total requirements: <N>
+  File size: <K> tokens (~<KB> KB)
+  Children today: <list of any existing children, or "none">
+```
+
+If the spec already has children listed in the manifest with
+`parent_spec == <spec-id>`, this is a re-split — proceed but tell the
+user the existing children will not be moved.
+
+---
+
+## Step 2 — Identify natural concern boundaries
+
+Read the spec's machine section. Group requirements by:
+
+1. **Section headers** — many specs already have `## <Concern>`
+   subsections under the machine section (Pass 1 of `/spec-author`
+   produces these by behavioral category). Each such header is a
+   candidate concern boundary.
+2. **Behavioral category** — even without explicit headers, requirements
+   often cluster by what aspect of behavior they describe: lifecycle,
+   validation, error handling, persistence, etc.
+3. **Subject-token clusters** — requirements that share dominant
+   subject tokens (e.g. "rotation", "DEK", "revocation") tend to
+   cluster.
+4. **Cross-references** — requirements that frequently cite each other
+   are coupled and should usually live together. Requirements that
+   sit alone (no internal cross-refs) are candidates for cross-cutting
+   placement at parent.
+
+Identify cross-cutting requirements as those that:
+- Are referenced by requirements in multiple proposed concern groups,
+  OR
+- State umbrella invariants that any concern's behavior must respect
+  (e.g. "all DEKs must be wrappable under their tenant root key"),
+  OR
+- Define glossary-like contracts the children build on top of.
+
+**Output:** an internal proposal (don't surface yet) with:
+
+- A list of concern groups, each with: a slug, a 2-5 word title, a
+  one-sentence summary, and the list of R-numbers it claims.
+- A list of cross-cutting R-numbers that stay at the parent.
+
+If your analysis cannot find at least 2 distinct concerns, **stop and
+tell the user**: "This spec doesn't subdivide cleanly — its
+requirements form a single coupled concern. Subdivision would fragment
+the coherent contract. Recommend leaving it as-is or amending the
+content rather than splitting." Do NOT propose a split that doesn't
+hold together.
+
+---
+
+## Step 3 — Present the proposal and confirm
+
+Display the proposed split:
+
+```
+── Proposed subdivision ─────────────────────────
+Parent: <spec-id>
+  Cross-cutting (stays at parent): R<n>, R<n>, R<n>  (<count> reqs)
+
+Children:
+  <slug-1> — <title>             (<count> reqs)
+    Requirements: R<n>, R<n>, R<n>, ...
+    Summary: <one-line description>
+
+  <slug-2> — <title>             (<count> reqs)
+    Requirements: R<n>, R<n>, R<n>, ...
+    Summary: <one-line description>
+
+Each child becomes:
+  <spec-id>.<slug>
+  .spec/domains/<top>/<rest>/<slug>.md
+
+@spec annotation rewrites:
+  <count> moved requirements → annotations rewritten in source dirs
+  Cross-cutting annotations stay as-is.
+```
+
+**Use AskUserQuestion** with options:
+- "Proceed with this split"
+- "Edit the proposal" — re-prompt the user to adjust concern
+  boundaries or move requirements between groups
+- "Cancel"
+
+If "Edit": ask the user what to change. After their response, regenerate
+the proposal and re-confirm via AskUserQuestion. Loop until they
+approve or cancel.
+
+If "Cancel": stop. No changes made.
+
+---
+
+## Step 4 — Build the split plan and dry-run
+
+Write the confirmed proposal to a JSON plan file:
+
+```bash
+PLAN_FILE=".spec/.split-plan.json"
+cat > "$PLAN_FILE" <<EOF
+{
+  "parent_id": "<spec-id>",
+  "children": [
+    {
+      "id": "<spec-id>.<slug-1>",
+      "title": "<title-1>",
+      "domains": ["<domain>"],
+      "requirements": ["R<n>", "R<n>", ...]
+    },
+    ...
+  ]
+}
+EOF
+```
+
+Run a dry-run first to validate the plan structure:
+
+```bash
+bash .claude/scripts/spec-split.sh --plan "$PLAN_FILE" --dry-run
+```
+
+If the dry-run fails (it shouldn't, since you built the plan from a
+known-valid proposal — but the script enforces stricter invariants),
+surface the error to the user and stop. Common dry-run failures:
+
+- A child id doesn't extend parent by exactly one segment (you put
+  more than one dot in the child's slug). Children at this layer must
+  be immediate children only; deeper nesting requires a separate
+  later split.
+- A requirement was claimed by two children (proposal had a typo).
+- Every requirement was claimed by some child, leaving no
+  cross-cutting set at parent. The script requires at least one
+  cross-cutting requirement.
+
+---
+
+## Step 5 — Execute the split
+
+Run the script for real:
+
+```bash
+bash .claude/scripts/spec-split.sh --plan "$PLAN_FILE"
+```
+
+The script:
+1. Snapshots the parent file + manifest into a rollback log under
+   `.spec/.split-log/<id>-<timestamp>.json`.
+2. Carves child files from the parent's body, preserving R-number
+   identity (R45 stays R45 in its new home).
+3. Rewrites the parent to retain only cross-cutting requirements and
+   bumps its version.
+4. Updates the manifest with child entries, each carrying
+   `parent_spec: <spec-id>`.
+5. Sweeps `@spec parent.Rxx` annotations in source dirs (auto-detected:
+   `src/`, `lib/`, `app/`, `main/`, `modules/`, `examples/`,
+   `benchmarks/` — never `test/`, `tests/`, `__tests__`, `spec/`,
+   `node_modules/`, `vendor/`, `target/`, `build/`, `dist/`). Use
+   `--scan-dirs <csv>` if your project's source layout differs.
+6. Runs `spec-validate.sh` on parent + every child.
+7. **On any post-write validation failure, automatically replays the
+   rollback log** — parent file restored, children deleted, manifest
+   reverted, annotation rewrites reversed. Rollback log is preserved
+   for one release in case manual inspection is needed.
+
+If the script exits non-zero, surface its stderr to the user. Do not
+attempt to "fix" the situation manually — the rollback has already
+restored the prior state. The most common cause is a frontmatter
+field mismatch in the parent or a child; investigate and re-run.
+
+---
+
+## Step 6 — Post-split verification
+
+After a successful split, verify the family by running spec-trace on
+each child:
+
+```bash
+for child_id in <list-of-child-ids>; do
+  bash .claude/scripts/spec-trace.sh "$child_id" 2>/dev/null \
+    | head -20
+done
+```
+
+Confirm each rewritten annotation resolves cleanly. If any child shows
+an annotation that doesn't resolve (typically "no annotations found"
+when there should be some), that's a sign the rewrite missed the file
+because of a non-standard scan dir; re-run with `--scan-dirs` or
+manually annotate.
+
+Display the success summary:
+
+```
+───────────────────────────────────────────────
+✂️  SPEC SPLIT complete · <spec-id>
+───────────────────────────────────────────────
+Parent: <spec-id>  (<count> cross-cutting reqs)
+Children:
+  <slug-1>  →  <count> reqs
+  <slug-2>  →  <count> reqs
+@spec rewrites: <N> annotations across <M> files
+Rollback log: <path>
+───────────────────────────────────────────────
+```
+
+If the split was triggered by `/curate` or `/spec-author` Pass 2,
+remind the user that any open work definitions or follow-up audits
+referencing the parent will now resolve to the parent's cross-cutting
+contract; concern-specific work now references the new child IDs.
+
+---
+
+## When NOT to subdivide
+
+Subdivision fragments a coherent contract. Don't do it when:
+
+- The spec is large but the concern is **indivisible** — every
+  requirement reinforces the same behavior, just with different
+  inputs.
+- The category clusters are **not load-bearing yet** — fewer than ~10
+  requirements per candidate child means subdivision is premature.
+- The parent's requirements are **already structured well** as a
+  single coherent contract, and the size is justified by depth in
+  one concern (e.g. a single complex algorithm).
+
+In any of these cases, decline the split. Tell the user honestly:
+"This spec is mature but its concerns are interlocked — subdividing
+would make adversarial review weaker, not stronger. Keeping it whole
+is correct."
+
+---
+
+## Recursion
+
+A child can itself subdivide later via `/spec-split <child-id>`. The
+mechanics are identical; the file system grows another nesting level.
+There is no hard cap on depth; in practice three levels is unusual
+and four would suggest the domain model itself needs rethinking.
+
+## Errors and recovery
+
+- **Plan validation failed (no cross-cutting reqs)**: a successful
+  split must leave at least one R-number at parent. Move at least
+  one requirement out of the children's lists.
+- **Child file already exists**: a previous split was attempted and
+  the child files weren't cleaned up. Inspect; either remove the
+  stale child files manually or pick different child slugs.
+- **spec-validate failed post-split**: the script auto-rolled back.
+  Read the validate output, fix the issue (typically a frontmatter
+  field), re-run.
+- **Manual rollback after the fact**: every split writes a JSON
+  rollback log at `.spec/.split-log/<id>-<timestamp>.json`. Replay
+  with `bash .claude/scripts/spec-split.sh --rollback <log>`.

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -219,7 +219,12 @@ Stage Completion table — specification mode only:
 
 ### 4c — Update WD status
 
-Edit `.work/<group-slug>/WD-<nn>.md` — set `status: SPECIFYING`.
+Set the WD status with `sed` so the file does not need to be Read first
+(matches the pattern used in `scripts/work-finalize.sh`):
+
+```bash
+sed -i "s/^status:.*$/status: SPECIFYING/" .work/<group-slug>/WD-<nn>.md
+```
 
 The manifest table is automatically synced by `work-resolve.sh` — do not
 update it manually.
@@ -304,9 +309,12 @@ Run /spec-author "<feature-id>" "<title>" to complete adversarial review.
 ```
 Stop and wait for the user to resolve.
 
-**If all specs are APPROVED:** update the WD:
+**If all specs are APPROVED:** update the WD with `sed` (no Read required;
+matches the pattern used in `scripts/work-finalize.sh`):
 
-1. Edit `.work/<group-slug>/WD-<nn>.md` — set `status: SPECIFIED`
+```bash
+sed -i "s/^status:.*$/status: SPECIFIED/" .work/<group-slug>/WD-<nn>.md
+```
 
 The manifest table is automatically synced by `work-resolve.sh` — do not
 update it manually.

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -227,7 +227,12 @@ Stage Completion table — implementation stages only:
 
 ### 4d — Update WD status
 
-Edit `.work/<group-slug>/WD-<nn>.md` — set `status: IMPLEMENTING`.
+Set the WD status with `sed` so the file does not need to be Read first
+(matches the pattern used in `scripts/work-finalize.sh`):
+
+```bash
+sed -i "s/^status:.*$/status: IMPLEMENTING/" .work/<group-slug>/WD-<nn>.md
+```
 
 The manifest table is automatically synced by `work-resolve.sh` — do not
 update it manually.

--- a/spec/CLAUDE.md
+++ b/spec/CLAUDE.md
@@ -56,6 +56,9 @@ R2. ...
 - `decision_refs` — ADR slugs from .decisions/ (cross-reference, not duplication)
 - `kb_refs` — KB paths from .kb/ (topic/category/subject)
 - `open_obligations` — work items that must be addressed
+- `parent_spec` — (optional) immediate parent spec ID for nested specs.
+  Set on children of a layered domain (see "Layered specs" below). Single
+  string; null/omitted on top-level specs.
 
 **Requirement writing rules:**
 - One falsifiable claim per requirement
@@ -103,7 +106,10 @@ is discouraged.
 - Requirement number is `RN` (with optional letter suffix for amendments —
   `R1`, `R27`, `R51a`). No zero-padding.
 - The `<spec-id>.` prefix is mandatory on every reference — bare `R1` is invalid
-- Canonical grep pattern: `@spec\s+(F\d{2,}|[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*)\.R\d+[a-z]?`
+- Spec IDs may be nested (one or more dots) for layered specs — see
+  "Layered specs" below. `@spec encryption.primitives-lifecycle.key-rotation.R45`
+  is valid.
+- Canonical grep pattern: `@spec\s+(F\d{2,}|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)\.R\d+[a-z]?`
 
 ### Placement
 
@@ -145,7 +151,111 @@ def serialize(self, record):
 ### Tooling
 
 - `spec-trace.sh <spec-id>` — finds all `@spec` annotations for a spec
-  (accepts FXX or domain.slug),
+  (accepts FXX or domain.slug, including nested IDs),
   grouped by file, distinguishing implementation vs test locations
 - `spec-verify` uses annotations as discovery hints when verifying requirements
 - Coverage scripts use scoped `<spec-id>.RN` matching (not bare R-numbers)
+
+## Layered specs (parent + children)
+
+A spec can subdivide into a parent + children when a domain matures past
+one file's worth of behavior. The parent stays a full spec — it retains
+R-numbered cross-cutting requirements that genuinely span all children
+(e.g. "all DEKs MUST be wrappable under their tenant root"). Children
+own concern-specific requirements.
+
+This is a **natural progression**, not a remediation step. Specs start
+unsplit; they subdivide when `/curate` or `/spec-author` recognize that
+multiple distinct concerns have accumulated. The explicit
+`/spec-split <spec-id>` skill executes the subdivision.
+
+### File layout
+
+The file system mirrors the ID hierarchy:
+
+```
+.spec/domains/encryption/
+  primitives-lifecycle.md              ← parent (cross-cutting + glossary)
+  primitives-lifecycle/                ← children directory
+    key-rotation.md
+    dek-management.md
+    revocation.md
+```
+
+Recursive — a child can itself subdivide later
+(`primitives-lifecycle/key-rotation/scheduled.md`). Same shape, same
+tooling.
+
+### ID grammar and ID↔path
+
+Spec IDs use one or more dots:
+
+- `encryption` — the top-level domain (no spec, just a directory)
+- `encryption.primitives-lifecycle` — top-level spec in that domain
+- `encryption.primitives-lifecycle.key-rotation` — child spec under
+  `primitives-lifecycle`
+
+The path is **deterministic** from the ID:
+`a.b.c.d` → `.spec/domains/a/b/c/d.md`. First component is the
+top-level domain dir; intermediate components become subdirectories;
+last component is the filename. The manifest still indexes every spec
+explicitly; the ID-computed path is a fallback used by
+`spec_file_for_id()` when a spec is not yet registered.
+
+### Children declare `parent_spec`
+
+A child spec's frontmatter carries a single-string `parent_spec` field
+naming its immediate parent:
+
+```json
+{
+  "id": "encryption.primitives-lifecycle.key-rotation",
+  "parent_spec": "encryption.primitives-lifecycle",
+  ...
+}
+```
+
+Parents do **not** declare children — `children_specs` is computed at
+scan time from the manifest (mirrors the `.decisions/` parent
+precedent; avoids bidirectional-sync bugs). Validation enforces:
+
+- Parent must exist in the manifest.
+- Child ID must be `parent_id` + `.` + exactly one segment (so
+  `encryption.primitives-lifecycle.key-rotation` may declare
+  `encryption.primitives-lifecycle` as parent, but not
+  `encryption.foo`).
+- Parent chain must be acyclic.
+
+### Loading rules
+
+`spec-resolve.sh` is hierarchy-aware:
+
+- When a child lands in candidates, the **entire parent chain is
+  auto-included**. Cross-cutting requirements at a parent are part of
+  every descendant's contract; they cannot be dropped.
+- `INCLUDE_SIBLINGS=true` (env var) opts into loading every sibling
+  (other children of the same parent). Used by adversarial paths
+  (`/spec-author` Pass 2/3) that need cross-sibling contradiction
+  detection.
+
+`@spec` annotations resolve through the same `spec_file_for_id()` —
+no annotation rewriting is needed when subdivision happens at the
+*parent* boundary (cross-cutting requirements that stay at parent
+keep their existing annotations).
+
+### When to subdivide
+
+Subdivision is appropriate when:
+
+- A spec's machine section is approaching the read cap
+  (~25K tokens — well under the kit's pipe-buffer SIGPIPE cliff
+  past 64KB)
+- Multiple distinct behavioral categories have accumulated, each
+  with its own dense requirement set
+- The cross-category reference density is low (each category is
+  largely self-contained)
+
+Subdivision is **not** appropriate for specs that are large because
+of one tightly-coupled concern (the size is real but the concern is
+indivisible). `/curate`'s subdivision detector surfaces candidates;
+the user approves or skips per spec.

--- a/tests/scenario-curate-subdivision-candidates.sh
+++ b/tests/scenario-curate-subdivision-candidates.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# Scenario: /curate subdivision-candidate detector.
+#
+# Validates the PR 3 piece of the spec-layering plan: curate-scan.sh's
+# Analysis 20 should flag specs that have grown past one file's worth of
+# behavior AND show multiple distinct concerns, but should NOT false-positive
+# on specs that are large-but-singular or already part of a layered family.
+#
+# Layered cover:
+#
+#   1. Mature multi-concern spec triggers — synthetic spec with ≥50 reqs
+#      and ≥2 section headers AND no dominant section is flagged.
+#   2. Small spec does not trigger — even with multiple sections, if reqs
+#      are below the size threshold it's not a candidate.
+#   3. Single-section large spec does not trigger — large but tightly
+#      coupled (one concern with many requirements) shouldn't be
+#      surfaced as a subdivision candidate.
+#   4. Dominant-section spec does not trigger — multi-section but one
+#      section holds ≥90% of reqs (large-but-singular) shouldn't trigger.
+#   5. Child spec (parent_spec set) does not trigger — already part of a
+#      layered family.
+#   6. Output table format — when a candidate is flagged, the markdown
+#      summary contains a row with the right columns.
+#
+# Run from repo root: bash tests/scenario-curate-subdivision-candidates.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: /curate subdivision-candidate detector"
+echo "────────────────────────────────────────────────"
+
+# Synthetic project tree.
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine-curate-subdiv.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.spec/registry" "$PROJ/.spec/domains/encryption" "$PROJ/.spec/domains/storage" "$PROJ/.spec/domains/util" "$PROJ/.curate"
+cd "$PROJ"
+
+# Initialize empty git repo so curate-scan's git operations don't crash.
+git init -q
+git config user.email test@example.com
+git config user.name "Test"
+git commit -q --allow-empty -m "initial"
+
+# ── Build synthetic specs ────────────────────────────────────────────────────
+
+# (a) Mature multi-concern spec — should trigger.
+build_spec_mature() {
+  local file="$1" id="$2"
+  {
+    cat <<EOF
+---
+{
+  "id": "$id",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["encryption"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+
+# $id
+
+Cross-cutting overview.
+
+R1. Cross-cutting wrap invariant.
+R2. Cross-cutting audit invariant.
+R3. Cross-cutting tenant boundary.
+
+## Key Rotation
+
+R10. Key rotation must run at most every 90 days.
+R11. Rotation must use a fresh DEK.
+R12. Rotation must publish the new key version to the audit log.
+R13. Rotation must succeed atomically.
+R14. Rotation must not block read traffic.
+R15. Rotation must record metrics.
+R16. Rotation must be idempotent.
+R17. Rotation must verify pre-conditions.
+R18. Rotation must log warnings on retry.
+R19. Rotation must respect cooldown.
+R20. Rotation must surface failures.
+R21. Rotation must not regress in version.
+R22. Rotation must allow opt-out.
+R23. Rotation must export status.
+R24. Rotation must integrate with KMS.
+R25. Rotation must support dual-write window.
+
+## DEK Management
+
+R30. DEKs must be stored encrypted at rest.
+R31. DEK access must be audited.
+R32. DEKs must be disposed within 24h of last use.
+R33. DEKs must be unique per object.
+R34. DEKs must support cipher upgrade.
+R35. DEKs must verify tenant binding.
+R36. DEKs must reject reuse.
+R37. DEKs must surface lookup failures.
+R38. DEKs must support cache invalidation.
+R39. DEKs must be observable.
+R40. DEKs must record creation timestamp.
+R41. DEKs must serialize predictably.
+R42. DEKs must support sub-key derivation.
+R43. DEKs must validate length.
+R44. DEKs must reject zero values.
+R45. DEKs must support recovery.
+R46. DEKs must report TTL.
+R47. DEKs must allow inspection.
+R48. DEKs must error on corruption.
+
+## Revocation
+
+R55. Revocation must be effective immediately.
+R56. Revocation must propagate to caches.
+R57. Revocation must record reason.
+R58. Revocation must support audit playback.
+R59. Revocation must reject in-flight reads gracefully.
+R60. Revocation must enable mass operations.
+R61. Revocation must integrate with KMS.
+R62. Revocation must record audit events.
+R63. Revocation must support tenant batch.
+R64. Revocation must guard against replay.
+R65. Revocation must signal to consumers.
+R66. Revocation must drain pending operations.
+R67. Revocation must record the operator identity.
+R68. Revocation must reject malformed requests.
+R69. Revocation must surface partial failures.
+R70. Revocation must reject when tenant is frozen.
+R71. Revocation must integrate with audit pipeline.
+
+---
+
+## Notes
+Original lifecycle spec covering rotation + DEK + revocation together.
+EOF
+  } > "$file"
+}
+
+# (b) Small spec — should NOT trigger.
+build_spec_small() {
+  local file="$1" id="$2"
+  {
+    cat <<EOF
+---
+{
+  "id": "$id",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["util"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+
+# $id
+
+## A
+R1. Small spec.
+## B
+R2. Still small.
+
+---
+## Notes
+EOF
+  } > "$file"
+}
+
+# (c) Single-section large spec — should NOT trigger.
+build_spec_one_section() {
+  local file="$1" id="$2"
+  {
+    cat <<EOF
+---
+{
+  "id": "$id",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["storage"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+
+# $id
+
+Single tightly-coupled concern.
+
+## Format Specification
+EOF
+    for i in $(seq 1 60); do
+      printf "R%d. Format requirement %d describing layout invariant.\n" "$i" "$i"
+    done
+    cat <<'EOF'
+
+---
+
+## Notes
+EOF
+  } > "$file"
+}
+
+# (d) Dominant-section spec — should NOT trigger (one section holds ≥90% reqs).
+build_spec_dominant() {
+  local file="$1" id="$2"
+  {
+    cat <<EOF
+---
+{
+  "id": "$id",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["storage"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+
+# $id
+
+## Main Concern
+EOF
+    for i in $(seq 1 55); do
+      printf "R%d. Main concern requirement %d.\n" "$i" "$i"
+    done
+    cat <<EOF
+
+## Side Note
+R56. A small side note.
+R57. Another small side note.
+
+---
+
+## Notes
+EOF
+  } > "$file"
+}
+
+# (e) Child spec (parent_spec set) — should NOT trigger.
+build_spec_child() {
+  local file="$1" id="$2" parent="$3"
+  {
+    cat <<EOF
+---
+{
+  "id": "$id",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["encryption"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": [],
+  "parent_spec": "$parent"
+}
+---
+
+# $id
+
+## Child Section A
+EOF
+    for i in $(seq 1 25); do
+      printf "R%d. Child section A requirement %d.\n" "$i" "$i"
+    done
+    cat <<'EOF'
+
+## Child Section B
+EOF
+    for i in $(seq 26 55); do
+      printf "R%d. Child section B requirement %d.\n" "$i" "$i"
+    done
+    cat <<EOF
+
+---
+
+## Notes
+EOF
+  } > "$file"
+}
+
+MATURE_FILE="$PROJ/.spec/domains/encryption/primitives-lifecycle.md"
+SMALL_FILE="$PROJ/.spec/domains/util/small.md"
+ONE_FILE="$PROJ/.spec/domains/storage/format-v3.md"
+DOM_FILE="$PROJ/.spec/domains/storage/big-singular.md"
+mkdir -p "$PROJ/.spec/domains/encryption/primitives-lifecycle"
+CHILD_FILE="$PROJ/.spec/domains/encryption/primitives-lifecycle/child-already.md"
+
+build_spec_mature       "$MATURE_FILE"  "encryption.primitives-lifecycle"
+build_spec_small        "$SMALL_FILE"   "util.small"
+build_spec_one_section  "$ONE_FILE"     "storage.format-v3"
+build_spec_dominant     "$DOM_FILE"     "storage.big-singular"
+build_spec_child        "$CHILD_FILE"   "encryption.primitives-lifecycle.child-already" \
+                                         "encryption.primitives-lifecycle"
+
+# Manifest with all 5 specs.
+cat > "$PROJ/.spec/registry/manifest.json" <<'EOF'
+{
+  "schema_version": 2,
+  "generated_at": "2026-04-27T00:00:00Z",
+  "spec_count": 5,
+  "specs": [
+    {"id":"encryption.primitives-lifecycle",
+     "path":".spec/domains/encryption/primitives-lifecycle.md",
+     "state":"APPROVED","version":1,"domains":["encryption"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"util.small",
+     "path":".spec/domains/util/small.md",
+     "state":"APPROVED","version":1,"domains":["util"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"storage.format-v3",
+     "path":".spec/domains/storage/format-v3.md",
+     "state":"APPROVED","version":1,"domains":["storage"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"storage.big-singular",
+     "path":".spec/domains/storage/big-singular.md",
+     "state":"APPROVED","version":1,"domains":["storage"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"encryption.primitives-lifecycle.child-already",
+     "path":".spec/domains/encryption/primitives-lifecycle/child-already.md",
+     "parent_spec":"encryption.primitives-lifecycle",
+     "state":"APPROVED","version":1,"domains":["encryption"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]}
+  ]
+}
+EOF
+
+# Empty obligations registry (curate-scan reads it).
+echo '{"obligations": []}' > "$PROJ/.spec/registry/_obligations.json"
+
+# Empty curate state.
+echo "Last scanned: " > "$PROJ/.curate/curation-state.md"
+
+# ── Run curate-scan ──────────────────────────────────────────────────────────
+
+echo ""
+echo "── Running curate-scan against synthetic project"
+
+cd "$PROJ"
+SUMMARY_FILE="$PROJ/.curate/scan-summary.md"
+bash "$REPO_ROOT/scripts/curate-scan.sh" >/tmp/curate-out.log 2>&1
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+  pass "curate-scan completed without error"
+else
+  fail "curate-scan exited $rc" "$(tail -10 /tmp/curate-out.log)"
+fi
+
+if [[ -f "$SUMMARY_FILE" ]]; then
+  pass "summary file written"
+else
+  fail "summary file missing: $SUMMARY_FILE"
+  echo ""
+  echo "────────────────────────────────────────────────"
+  echo "FAILED  $failed/$total"
+  exit 1
+fi
+
+# ── Layer 1: mature multi-concern spec triggered ─────────────────────────────
+
+echo ""
+echo "── Layer 1: mature spec is flagged"
+if grep -q '^| encryption.primitives-lifecycle ' "$SUMMARY_FILE"; then
+  pass "encryption.primitives-lifecycle appears in Subdivision Candidates"
+else
+  fail "mature spec NOT flagged" "$(grep -A 5 'Subdivision Candidates' "$SUMMARY_FILE" || echo '(no section)')"
+fi
+
+# Section header present.
+if grep -q '^## Subdivision Candidates' "$SUMMARY_FILE"; then
+  pass "Subdivision Candidates section exists in summary"
+else
+  fail "Subdivision Candidates section missing"
+fi
+
+# ── Layer 2: small spec NOT triggered ────────────────────────────────────────
+
+echo ""
+echo "── Layer 2: small spec is NOT flagged"
+if grep -q '^| util.small ' "$SUMMARY_FILE"; then
+  fail "small spec was incorrectly flagged"
+else
+  pass "small spec is not in Subdivision Candidates"
+fi
+
+# ── Layer 3: single-section large spec NOT triggered ─────────────────────────
+
+echo ""
+echo "── Layer 3: single-section large spec is NOT flagged"
+if grep -q '^| storage.format-v3 ' "$SUMMARY_FILE"; then
+  fail "single-section large spec was incorrectly flagged"
+else
+  pass "single-section spec is not flagged"
+fi
+
+# ── Layer 4: dominant-section spec NOT triggered ─────────────────────────────
+
+echo ""
+echo "── Layer 4: dominant-section spec is NOT flagged (one section ≥90%)"
+if grep -q '^| storage.big-singular ' "$SUMMARY_FILE"; then
+  fail "dominant-section spec was incorrectly flagged"
+else
+  pass "dominant-section spec is not flagged"
+fi
+
+# ── Layer 5: child spec NOT triggered ────────────────────────────────────────
+
+echo ""
+echo "── Layer 5: child spec (parent_spec set) is NOT flagged"
+if grep -q '^| encryption.primitives-lifecycle.child-already ' "$SUMMARY_FILE"; then
+  fail "child spec was incorrectly flagged" "child specs already part of layered family"
+else
+  pass "child spec is not flagged"
+fi
+
+# ── Layer 6: table format ────────────────────────────────────────────────────
+
+echo ""
+echo "── Layer 6: table includes expected columns"
+header_line=$(grep -E '^\| Spec \| Domain \| Reqs' "$SUMMARY_FILE" | head -1)
+if [[ -n "$header_line" ]]; then
+  if echo "$header_line" | grep -q "Suggested"; then
+    pass "table header includes Suggested column"
+  else
+    fail "table header missing 'Suggested'" "got: $header_line"
+  fi
+else
+  fail "subdivision table header not found"
+fi
+
+# Suggested cell should contain `/spec-split <id>` for the mature spec.
+if grep -q '`/spec-split encryption.primitives-lifecycle`' "$SUMMARY_FILE"; then
+  pass "suggested command includes /spec-split <id>"
+else
+  fail "suggested /spec-split command missing or malformed"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+  echo "ALL PASSED  ($passed/$total)"
+  exit 0
+else
+  echo "FAILED  $failed/$total  ($passed passed)"
+  exit 1
+fi

--- a/tests/scenario-pipefail-sigpipe.sh
+++ b/tests/scenario-pipefail-sigpipe.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Scenario: scripts that pipe potentially-large stdin into early-closing
+# tools must use here-strings (`<<< "$var"`) instead of `echo "$var" |`,
+# otherwise SIGPIPE under `set -o pipefail` flips the pipeline result on
+# unusually large inputs.
+#
+# Triggered by a real failure on jlsm 2026-04-27: spec-validate.sh's
+# `echo "$spec_body" | grep -qE '\[UNRESOLVED\]'` check exit-141'd on
+# encryption.primitives-lifecycle once its machine section reached
+# ~134 KB. `grep -q` closed stdin after determining no match was needed,
+# `echo` got SIGPIPE, the pipeline exited 141, pipefail propagated it,
+# and the negated check treated 141 as success — so APPROVED specs
+# could silently pass even with [UNRESOLVED] markers present.
+#
+# Two layers of defence:
+#
+#   1. Structural — for the seven known-large-stdin sites in three
+#      scripts, assert the script uses here-string form. Drift detection
+#      so regressions cannot sneak back in via copy-paste.
+#
+#   2. Runtime — synthesize a spec whose machine section is well over the
+#      pipe buffer (~880 KB), wire up a minimal `.spec/` so spec-validate
+#      runs end-to-end, and confirm validation returns successfully. Under
+#      the bug the script either crashes (rc=141) or returns a wrong
+#      answer; under the fix it succeeds.
+#
+# Run from repo root: bash tests/scenario-pipefail-sigpipe.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: pipefail SIGPIPE on large stdin"
+echo "────────────────────────────────────────────────"
+
+# ── Layer 1: structural — patched lines must use here-strings ────────────────
+
+echo ""
+echo "── Layer 1: known-large-stdin sites use here-strings (drift detection)"
+
+# For each known site, assert the post-fix shape is present (grep -F:
+# the line is matched as a fixed substring) and the pre-fix shape is
+# absent. The pre-fix shape is matched with grep -F too.
+check_site() {
+    local file="$1"; local desc="$2"; local required="$3"; local forbidden="$4"
+    if ! [[ -f "$file" ]]; then
+        fail "$desc" "file missing: $file"
+        return
+    fi
+    if grep -qF "$forbidden" "$file" 2>/dev/null; then
+        fail "$desc" "forbidden substring still present: $forbidden"
+        return
+    fi
+    if ! grep -qF "$required" "$file" 2>/dev/null; then
+        fail "$desc" "required substring missing: $required"
+        return
+    fi
+    pass "$desc"
+}
+
+# spec-validate.sh — three known-dangerous sites
+check_site "$REPO_ROOT/scripts/spec-validate.sh" \
+    "spec-validate Check 9b uses <<< for [UNRESOLVED]" \
+    'grep -qE '"'"'\[UNRESOLVED\]'"'"' <<< "$spec_body"' \
+    'echo "$spec_body" | grep -qE '"'"'\[UNRESOLVED\]'"'"
+
+check_site "$REPO_ROOT/scripts/spec-validate.sh" \
+    "spec-validate Check 9b uses <<< for [CONFLICT]" \
+    'grep -qE '"'"'\[CONFLICT\]'"'"' <<< "$spec_body"' \
+    'echo "$spec_body" | grep -qE '"'"'\[CONFLICT\]'"'"
+
+check_site "$REPO_ROOT/scripts/spec-validate.sh" \
+    "spec-validate Check 11 uses <<< for ^R[0-9]+." \
+    'grep -qE '"'"'^R[0-9]+\.'"'"' <<< "$machine"' \
+    'echo "$machine" | grep -qE '"'"'^R[0-9]+\.'"'"
+
+# kb-search.sh — content_lower (KB index content) is unbounded for big indexes
+check_site "$REPO_ROOT/scripts/kb-search.sh" \
+    "kb-search uses <<< for content_lower token check" \
+    'grep -q "$token" <<< "$content_lower"' \
+    'echo "$content_lower" | grep -q "$token"'
+
+# curate-scan.sh — trace_out is unbounded for large /spec-trace output
+check_site "$REPO_ROOT/scripts/curate-scan.sh" \
+    "curate-scan uses <<< for No annotations check" \
+    'grep -q '"'"'\*\*No annotations found\.\*\*'"'"' <<< "$trace_out"' \
+    'echo "$trace_out" | grep -q '"'"'\*\*No annotations found'"'"
+
+check_site "$REPO_ROOT/scripts/curate-scan.sh" \
+    "curate-scan uses <<< for No implementation annotations" \
+    'grep -m1 '"'"'^\*\*No implementation annotations:\*\*'"'"' <<< "$trace_out"' \
+    'echo "$trace_out" | grep -m1 '"'"'^\*\*No implementation'"'"
+
+check_site "$REPO_ROOT/scripts/curate-scan.sh" \
+    "curate-scan uses <<< for No test annotations" \
+    'grep -m1 '"'"'^\*\*No test annotations:\*\*'"'"' <<< "$trace_out"' \
+    'echo "$trace_out" | grep -m1 '"'"'^\*\*No test annotations'"'"
+
+# ── Layer 2: runtime — spec-validate must not SIGPIPE on a >1MB spec body ────
+
+echo ""
+echo "── Layer 2: spec-validate handles a 1 MB machine section without SIGPIPE"
+
+TMPDIR_TEST="$(mktemp -d -t /tmp/vallorcine/pipefail-XXXXXX 2>/dev/null \
+                || mktemp -d /tmp/vallorcine-pipefail.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Minimal .spec/ scaffolding — spec-validate.sh requires it to exist.
+mkdir -p "$TMPDIR_TEST/.spec/registry" "$TMPDIR_TEST/.spec/domains/test"
+cat > "$TMPDIR_TEST/.spec/registry/manifest.json" <<'EOF'
+{ "schema_version": 2, "specs": [] }
+EOF
+
+LARGE_SPEC="$TMPDIR_TEST/.spec/domains/test/large-spec.md"
+
+{
+    cat <<'EOF'
+---
+{
+  "id": "test.large-spec",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["test"],
+  "requires": [],
+  "invalidates": [],
+  "amends": null,
+  "amended_by": null,
+  "decision_refs": [],
+  "kb_refs": [],
+  "related": [],
+  "title": "synthetic large spec for SIGPIPE regression",
+  "description": "synthetic large spec for SIGPIPE regression"
+}
+---
+
+# Large spec — SIGPIPE regression
+
+Human-readable narrative would normally go here. The requirements list
+below this point lives in the machine section (between the 2nd and 3rd
+`---` lines).
+
+EOF
+    # Generate ~1 MB of unique requirement lines, in the machine section.
+    for i in $(seq 1 8000); do
+        printf "R%d. The system MUST handle requirement number %d with %s\n" \
+            "$i" "$i" "consistent and observable behavior across all states."
+    done
+    cat <<'EOF'
+
+---
+
+## Notes (post-machine narrative)
+EOF
+} > "$LARGE_SPEC"
+
+spec_size=$(wc -c < "$LARGE_SPEC")
+spec_size_kb=$(( spec_size / 1024 ))
+echo "  → synthesized spec: ${spec_size_kb} KB"
+
+if (( spec_size_kb < 256 )); then
+    fail "synthetic spec too small for SIGPIPE check" \
+         "spec is ${spec_size_kb} KB; need ≥256 KB to overflow pipe buffer"
+else
+    pass "synthetic spec exceeds pipe buffer (${spec_size_kb} KB)"
+fi
+
+# Run spec-validate against the synthetic spec from inside a working tree
+# that contains the minimal .spec/ scaffolding.
+val_out=""; val_rc=0
+val_out="$(cd "$TMPDIR_TEST" && bash "$REPO_ROOT/scripts/spec-validate.sh" "$LARGE_SPEC" 2>&1)" || val_rc=$?
+
+if [[ $val_rc -eq 0 ]]; then
+    pass "spec-validate passes on ${spec_size_kb} KB spec (rc=0)"
+elif [[ $val_rc -eq 141 ]]; then
+    fail "spec-validate hit SIGPIPE (rc=141) — fix regressed" \
+         "first lines: $(printf '%s' "$val_out" | head -3 | tr '\n' '|')"
+else
+    fail "spec-validate returned $val_rc — investigate" \
+         "first lines: $(printf '%s' "$val_out" | head -5 | tr '\n' '|')"
+fi
+
+# Bonus assertion: confirm fixture has the requirement count we wrote.
+expected_reqs=8000
+actual_reqs=$(grep -cE '^R[0-9]+\.' "$LARGE_SPEC" || true)
+if (( actual_reqs == expected_reqs )); then
+    pass "synthetic spec has ${expected_reqs} requirements as expected"
+else
+    fail "synthetic spec requirement count mismatch" \
+         "expected $expected_reqs, got $actual_reqs"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+    exit 0
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+    exit 1
+fi

--- a/tests/scenario-spec-author-layered.sh
+++ b/tests/scenario-spec-author-layered.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Scenario: /spec-author Pass 2/3 awareness of layered specs.
+#
+# Validates the PR 4 piece of the spec-layering plan: spec-author's prompt
+# must instruct the LLM to (a) load the parent + siblings when amending a
+# child spec (sibling-aware adversarial review), and (b) surface a
+# just-in-time subdivision signal when a Pass 2 amendment tips the spec
+# into "multiple distinct concerns at scale" territory.
+#
+# These are prose-level prompt invariants — the LLM does the actual work
+# at runtime. Tests here are structural drift detection: the SKILL.md
+# must contain the right instructions so an LLM following them produces
+# the right behavior.
+#
+# Layered cover:
+#
+#   1. Pre-flight has a "Layered-spec family load" step that triggers on
+#      `parent_spec` + sets `INCLUDE_SIBLINGS=true` on spec-resolve.
+#   2. Pre-flight skips the family load when target is a top-level spec.
+#   3. JIT subdivision signal step exists between Pass 2 arbitration and
+#      Pass 3, with the same thresholds /curate uses (≥50 reqs OR ≥15K
+#      tokens, ≥2 sections, largest <90% of total).
+#   4. JIT signal explicitly marks itself as non-blocking — the user
+#      should know this is informational.
+#   5. JIT signal surfaces the concrete `/spec-split <spec-id>` command.
+#
+# Run from repo root: bash tests/scenario-spec-author-layered.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: /spec-author awareness of layered specs"
+echo "────────────────────────────────────────────────"
+
+SA="$REPO_ROOT/skills/spec-author/SKILL.md"
+
+if [[ ! -f "$SA" ]]; then
+  fail "spec-author SKILL.md not found at $SA"
+  exit 1
+fi
+
+# ── Layer 1: Pre-flight has a layered-spec family load step ─────────────────
+
+echo ""
+echo "── Layer 1: Pre-flight loads parent + siblings on child specs"
+
+if grep -qF "Layered-spec family load" "$SA"; then
+  pass "Pre-flight has 'Layered-spec family load' step"
+else
+  fail "Pre-flight missing 'Layered-spec family load' step"
+fi
+
+if grep -qF "INCLUDE_SIBLINGS=true" "$SA"; then
+  pass "INCLUDE_SIBLINGS=true is referenced in pre-flight"
+else
+  fail "INCLUDE_SIBLINGS=true not referenced in pre-flight"
+fi
+
+if grep -qF "EXPLICIT_SPEC_IDS=" "$SA"; then
+  pass "EXPLICIT_SPEC_IDS targeting the spec is in the resolver invocation"
+else
+  fail "EXPLICIT_SPEC_IDS not in the resolver invocation"
+fi
+
+# ── Layer 2: Top-level spec exits the family-load step early ────────────────
+
+echo ""
+echo "── Layer 2: top-level specs skip the family-load step"
+
+if grep -qE "If the target is a top-level spec.*skip" "$SA"; then
+  pass "skill instructs skipping family load for top-level specs"
+else
+  fail "no skip-instruction for top-level specs"
+fi
+
+# ── Layer 3: JIT subdivision signal step exists ─────────────────────────────
+
+echo ""
+echo "── Layer 3: JIT subdivision signal between Pass 2 arbitration and Pass 3"
+
+if grep -qF "Just-in-time subdivision signal" "$SA"; then
+  pass "JIT subdivision signal section is present"
+else
+  fail "JIT subdivision signal section missing"
+fi
+
+# Section ordering: the signal must come AFTER "Pass 2 — Adversarial
+# falsification" and BEFORE "Pass 3 — Depth pass".
+pass2_line=$(grep -n "^## Pass 2 — Adversarial falsification" "$SA" | head -1 | cut -d: -f1 || true)
+jit_line=$(grep -n "Just-in-time subdivision signal" "$SA" | head -1 | cut -d: -f1 || true)
+pass3_line=$(grep -n "^## Pass 3 — Depth pass" "$SA" | head -1 | cut -d: -f1 || true)
+
+if [[ -n "$pass2_line" && -n "$jit_line" && -n "$pass3_line" ]] && \
+   (( pass2_line < jit_line && jit_line < pass3_line )); then
+  pass "JIT signal lives between Pass 2 and Pass 3 (lines $pass2_line < $jit_line < $pass3_line)"
+else
+  fail "JIT signal misplaced" \
+       "Pass 2: $pass2_line, JIT: $jit_line, Pass 3: $pass3_line"
+fi
+
+# ── Layer 4: JIT thresholds match /curate's heuristic ───────────────────────
+
+echo ""
+echo "── Layer 4: thresholds match /curate's subdivision detector"
+
+# The skill must reference the same thresholds /curate uses so that what
+# /spec-author surfaces matches what /curate would flag.
+jit_block=$(awk '
+  /Just-in-time subdivision signal/ { in_block = 1 }
+  in_block { print }
+  in_block && /^## Pass 3/ { exit }
+' "$SA")
+
+for threshold_phrase in \
+  "Reqs ≥ 50" \
+  "≥ ~15K tokens" \
+  "Section count ≥ 2" \
+  "Largest section.*share < 90%" \
+  "parent_spec.*set"; do
+  if echo "$jit_block" | grep -qE "$threshold_phrase"; then
+    pass "threshold mentioned: $threshold_phrase"
+  else
+    fail "threshold missing: $threshold_phrase"
+  fi
+done
+
+# ── Layer 5: JIT signal is explicitly non-blocking ──────────────────────────
+
+echo ""
+echo "── Layer 5: JIT signal explicitly non-blocking"
+
+if echo "$jit_block" | grep -qE "non-blocking|not a blocker|heads-up"; then
+  pass "JIT signal explicitly marked non-blocking"
+else
+  fail "JIT signal not explicitly marked non-blocking" \
+       "expected one of: 'non-blocking', 'not a blocker', 'heads-up'"
+fi
+
+if echo "$jit_block" | grep -qF "/spec-split <spec-id>"; then
+  pass "JIT signal includes /spec-split <spec-id> as the suggested action"
+else
+  fail "JIT signal missing /spec-split command suggestion"
+fi
+
+# ── Layer 6: skill files still parse cleanly ───────────────────────────────
+
+echo ""
+echo "── Layer 6: skill prompts still pass basic structural checks"
+
+# Check the skill still has the key markers — Pass 1, Pass 2, Pass 3 — so
+# we didn't accidentally break the structure while adding the new sections.
+for marker in "## Pre-flight" "## Pass 1" "## Pass 2" "## Pass 3" "## Hard constraints"; do
+  if grep -qF "$marker" "$SA"; then
+    pass "skill structure preserved: $marker"
+  else
+    fail "skill structure broken: $marker is missing"
+  fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+  echo "ALL PASSED  ($passed/$total)"
+  exit 0
+else
+  echo "FAILED  $failed/$total  ($passed passed)"
+  exit 1
+fi

--- a/tests/scenario-spec-layering.sh
+++ b/tests/scenario-spec-layering.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# Scenario: layered specs — parent + children with parent_spec field.
+#
+# Validates the PR 1 schema + read-path scope for the spec-layering
+# initiative. Layered specs let a mature domain subdivide into a parent
+# spec plus child sub-domain specs (recursive). Every node is a full
+# spec; the parent retains cross-cutting R-requirements, children own
+# concern-specific requirements.
+#
+# This test exercises:
+#
+#   1. ID grammar — multi-dot IDs (a.b.c.d) accepted by spec-trace and
+#      spec-validate; bare names without a dot still rejected.
+#   2. spec_file_for_id() — manifest lookup is preferred; ID-computed
+#      path fallback resolves an unregistered child via deterministic
+#      path computation (a.b.c → domains/a/b/c.md).
+#   3. spec-validate.sh new checks — parent_spec resolves to an existing
+#      spec; child ID is prefixed by parent ID + "." + one segment;
+#      parent chain is acyclic.
+#   4. spec-resolve.sh hierarchy-aware loading — when a child lands in
+#      candidates, the parent chain is auto-included. INCLUDE_SIBLINGS=true
+#      pulls in siblings.
+#   5. Backwards compatibility — flat specs without parent_spec still
+#      validate, resolve, and trace as before.
+#
+# Run from repo root: bash tests/scenario-spec-layering.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: layered specs (parent + children)"
+echo "────────────────────────────────────────────────"
+
+# ── Test fixture: synthetic project tree under /tmp/vallorcine/ ──────────────
+
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine-spec-layering.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.spec/registry" "$PROJ/.spec/domains/encryption/primitives-lifecycle"
+SPEC_DIR="$PROJ/.spec"
+MANIFEST="$SPEC_DIR/registry/manifest.json"
+
+# Spec template — minimal valid spec body.
+write_spec() {
+    local file="$1" id="$2" parent="$3" extra_reqs="${4:-}"
+    local parent_field
+    if [[ -n "$parent" ]]; then
+        parent_field=$(printf ', "parent_spec": "%s"' "$parent")
+    else
+        parent_field=""
+    fi
+    cat > "$file" <<EOF
+---
+{
+  "id": "$id",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["encryption"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []$parent_field
+}
+---
+
+# $id
+
+Human narrative.
+
+R1. The $id spec must do its job.
+R2. The spec must be parseable.
+$extra_reqs
+
+---
+
+## Notes
+EOF
+}
+
+# Build minimal manifest.
+build_manifest() {
+    local entries="$1"  # JSON array literal
+    cat > "$MANIFEST" <<EOF
+{
+  "schema_version": 2,
+  "generated_at": "2026-04-27T00:00:00Z",
+  "spec_count": $(echo "$entries" | jq 'length'),
+  "specs": $entries
+}
+EOF
+}
+
+# Build the parent spec.
+PARENT_ID="encryption.primitives-lifecycle"
+PARENT_FILE="$SPEC_DIR/domains/encryption/primitives-lifecycle.md"
+write_spec "$PARENT_FILE" "$PARENT_ID" ""
+
+# Build a child spec.
+CHILD_ID="encryption.primitives-lifecycle.key-rotation"
+CHILD_FILE="$SPEC_DIR/domains/encryption/primitives-lifecycle/key-rotation.md"
+write_spec "$CHILD_FILE" "$CHILD_ID" "$PARENT_ID"
+
+# Build a sibling.
+SIBLING_ID="encryption.primitives-lifecycle.dek-management"
+SIBLING_FILE="$SPEC_DIR/domains/encryption/primitives-lifecycle/dek-management.md"
+write_spec "$SIBLING_FILE" "$SIBLING_ID" "$PARENT_ID"
+
+# Manifest with parent + 2 children registered.
+build_manifest '[
+  {"id": "encryption.primitives-lifecycle",
+   "path": ".spec/domains/encryption/primitives-lifecycle.md",
+   "state": "APPROVED", "version": 1, "domains": ["encryption"],
+   "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []},
+  {"id": "encryption.primitives-lifecycle.key-rotation",
+   "path": ".spec/domains/encryption/primitives-lifecycle/key-rotation.md",
+   "parent_spec": "encryption.primitives-lifecycle",
+   "state": "APPROVED", "version": 1, "domains": ["encryption"],
+   "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []},
+  {"id": "encryption.primitives-lifecycle.dek-management",
+   "path": ".spec/domains/encryption/primitives-lifecycle/dek-management.md",
+   "parent_spec": "encryption.primitives-lifecycle",
+   "state": "APPROVED", "version": 1, "domains": ["encryption"],
+   "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []}
+]'
+
+# ── Layer 1: ID grammar — multi-dot IDs accepted ─────────────────────────────
+
+echo ""
+echo "── Layer 1: ID grammar accepts multi-dot IDs"
+
+cd "$PROJ"
+
+# spec-trace accepts a multi-dot ID (no need to find any matches; just no
+# format error).
+trace_out=$(bash "$REPO_ROOT/scripts/spec-trace.sh" "$CHILD_ID" "$PROJ" 2>&1 || true)
+if echo "$trace_out" | grep -q "Invalid spec ID"; then
+    fail "spec-trace rejects multi-dot ID $CHILD_ID" "output: $trace_out"
+else
+    pass "spec-trace accepts multi-dot ID $CHILD_ID"
+fi
+
+# spec-trace still rejects a bare bareword
+trace_bad=$(bash "$REPO_ROOT/scripts/spec-trace.sh" "barenodot" "$PROJ" 2>&1 || true)
+if echo "$trace_bad" | grep -q "Invalid spec ID"; then
+    pass "spec-trace rejects bareword IDs (no dot)"
+else
+    fail "spec-trace incorrectly accepts bareword 'barenodot'" "output: $trace_bad"
+fi
+
+# spec-trace still accepts FXX
+trace_fxx=$(bash "$REPO_ROOT/scripts/spec-trace.sh" "F01" "$PROJ" 2>&1 || true)
+if echo "$trace_fxx" | grep -q "Invalid spec ID"; then
+    fail "spec-trace rejects legacy F01" "output: $trace_fxx"
+else
+    pass "spec-trace accepts legacy FXX (F01)"
+fi
+
+# spec-trace still accepts single-dot domain.slug
+trace_slug=$(bash "$REPO_ROOT/scripts/spec-trace.sh" "$PARENT_ID" "$PROJ" 2>&1 || true)
+if echo "$trace_slug" | grep -q "Invalid spec ID"; then
+    fail "spec-trace rejects single-dot $PARENT_ID" "output: $trace_slug"
+else
+    pass "spec-trace accepts single-dot domain.slug"
+fi
+
+# ── Layer 2: spec_file_for_id() — manifest + computed-path fallback ──────────
+
+echo ""
+echo "── Layer 2: spec_file_for_id() resolves registered + computed paths"
+
+# We invoke through a shell that sources spec-lib.sh.
+resolve_id() {
+    local fid="$1"
+    bash -c "source '$REPO_ROOT/scripts/spec-lib.sh'; spec_file_for_id '$MANIFEST' '$fid'"
+}
+
+# Registered child resolves via manifest.
+child_path=$(resolve_id "$CHILD_ID")
+if [[ "$child_path" == "$CHILD_FILE" ]]; then
+    pass "spec_file_for_id resolves registered child via manifest"
+else
+    fail "spec_file_for_id failed for registered child" \
+         "expected: $CHILD_FILE, got: $child_path"
+fi
+
+# Unregistered grandchild (no manifest entry) resolves via ID-computed path.
+GRANDCHILD_ID="encryption.primitives-lifecycle.key-rotation.scheduled"
+GRANDCHILD_FILE="$SPEC_DIR/domains/encryption/primitives-lifecycle/key-rotation/scheduled.md"
+mkdir -p "$(dirname "$GRANDCHILD_FILE")"
+write_spec "$GRANDCHILD_FILE" "$GRANDCHILD_ID" "$CHILD_ID"
+gc_path=$(resolve_id "$GRANDCHILD_ID")
+if [[ "$gc_path" == "$GRANDCHILD_FILE" ]]; then
+    pass "spec_file_for_id falls back to ID-computed path for unregistered grandchild"
+else
+    fail "spec_file_for_id ID-computed fallback broken" \
+         "expected: $GRANDCHILD_FILE, got: $gc_path"
+fi
+
+# Truly missing ID (not in manifest, no file at computed path) returns empty.
+miss_path=$(resolve_id "encryption.does-not-exist")
+if [[ -z "$miss_path" ]]; then
+    pass "spec_file_for_id returns empty for unknown ID"
+else
+    fail "spec_file_for_id returned non-empty for missing ID" "got: $miss_path"
+fi
+
+# ── Layer 3: spec-validate — parent_spec checks ──────────────────────────────
+
+echo ""
+echo "── Layer 3: spec-validate enforces parent_spec invariants"
+
+# Happy path: registered child with valid parent_spec passes.
+val_out=$(bash "$REPO_ROOT/scripts/spec-validate.sh" "$CHILD_FILE" 2>&1)
+val_rc=$?
+if (( val_rc == 0 )); then
+    pass "spec-validate passes on valid child with parent_spec"
+else
+    fail "spec-validate failed on valid child" "output: $val_out"
+fi
+
+# Parent (no parent_spec) still validates as today.
+val_par=$(bash "$REPO_ROOT/scripts/spec-validate.sh" "$PARENT_FILE" 2>&1)
+val_par_rc=$?
+if (( val_par_rc == 0 )); then
+    pass "spec-validate passes on parent (no parent_spec)"
+else
+    fail "spec-validate failed on parent" "output: $val_par"
+fi
+
+# Bad: parent_spec points to a missing spec.
+BAD1="$SPEC_DIR/domains/encryption/primitives-lifecycle/bad-missing-parent.md"
+write_spec "$BAD1" "encryption.primitives-lifecycle.bad-missing-parent" \
+           "encryption.does-not-exist"
+val_bad1=$(bash "$REPO_ROOT/scripts/spec-validate.sh" "$BAD1" 2>&1 || true)
+if echo "$val_bad1" | grep -q "Unresolvable parent_spec"; then
+    pass "spec-validate rejects parent_spec pointing at missing spec"
+else
+    fail "spec-validate accepted missing parent_spec" "output: $val_bad1"
+fi
+
+# Bad: child ID does not have parent's prefix.
+BAD2="$SPEC_DIR/domains/encryption/wrong-prefix.md"
+mkdir -p "$(dirname "$BAD2")"
+write_spec "$BAD2" "encryption.wrong-prefix" "encryption.primitives-lifecycle"
+val_bad2=$(bash "$REPO_ROOT/scripts/spec-validate.sh" "$BAD2" 2>&1 || true)
+if echo "$val_bad2" | grep -q "ID prefix mismatch"; then
+    pass "spec-validate rejects ID-prefix mismatch with parent_spec"
+else
+    fail "spec-validate accepted ID-prefix mismatch" "output: $val_bad2"
+fi
+
+# Bad: child ID has more than one segment beyond parent_spec (parent_spec
+# must point at the IMMEDIATE parent).
+BAD3="$SPEC_DIR/domains/encryption/primitives-lifecycle/key-rotation/skip-a-level.md"
+mkdir -p "$(dirname "$BAD3")"
+write_spec "$BAD3" "encryption.primitives-lifecycle.key-rotation.skip-a-level" \
+           "encryption.primitives-lifecycle"  # NOTE: should be .key-rotation
+val_bad3=$(bash "$REPO_ROOT/scripts/spec-validate.sh" "$BAD3" 2>&1 || true)
+if echo "$val_bad3" | grep -q "ID-segment mismatch"; then
+    pass "spec-validate rejects parent_spec skipping a level"
+else
+    fail "spec-validate accepted parent_spec skipping a level" "output: $val_bad3"
+fi
+
+# ── Layer 4: spec-resolve hierarchy-aware loading ────────────────────────────
+
+echo ""
+echo "── Layer 4: spec-resolve auto-includes parent chain + INCLUDE_SIBLINGS"
+
+# Resolve targeting just the child via EXPLICIT_SPEC_IDS. Parent must be
+# included automatically. Sibling must NOT (default INCLUDE_SIBLINGS=false).
+resolve_out=$(cd "$PROJ" && \
+    EXPLICIT_SPEC_IDS="$CHILD_ID" \
+    bash "$REPO_ROOT/scripts/spec-resolve.sh" "key rotation" 8000 2>&1 || true)
+
+if echo "$resolve_out" | grep -q "encryption.primitives-lifecycle.key-rotation"; then
+    pass "spec-resolve includes the explicitly-requested child"
+else
+    fail "spec-resolve missed the explicit child" \
+         "first lines: $(printf '%s' "$resolve_out" | head -10 | tr '\n' '|')"
+fi
+
+# Parent must be in the bundle (auto-included via parent chain).
+if echo "$resolve_out" | grep -qE '^# encryption\.primitives-lifecycle$|"id":\s*"encryption\.primitives-lifecycle"'; then
+    pass "spec-resolve auto-includes parent when child is selected"
+else
+    # The bundle emits `# <id>` headers as the spec body. Loosen check: parent
+    # body must appear somewhere in stdout.
+    if echo "$resolve_out" | grep -q "encryption.primitives-lifecycle"; then
+        # Not enough — that string would also appear in child IDs.
+        # Look for parent's R1 specifically.
+        if echo "$resolve_out" | grep -q "The encryption.primitives-lifecycle spec must do its job"; then
+            pass "spec-resolve auto-includes parent (parent's R1 present)"
+        else
+            fail "spec-resolve did not auto-include parent body" \
+                 "parent body not in output"
+        fi
+    else
+        fail "spec-resolve did not auto-include parent" \
+             "parent ID not in output"
+    fi
+fi
+
+# Sibling must NOT be in default mode.
+if echo "$resolve_out" | grep -q "The encryption.primitives-lifecycle.dek-management spec must do its job"; then
+    fail "spec-resolve included sibling without INCLUDE_SIBLINGS" \
+         "sibling body should not appear in default mode"
+else
+    pass "spec-resolve omits siblings by default"
+fi
+
+# Now with INCLUDE_SIBLINGS=true, sibling MUST be in the bundle.
+resolve_sib=$(cd "$PROJ" && \
+    EXPLICIT_SPEC_IDS="$CHILD_ID" INCLUDE_SIBLINGS=true \
+    bash "$REPO_ROOT/scripts/spec-resolve.sh" "key rotation" 8000 2>&1 || true)
+if echo "$resolve_sib" | grep -q "The encryption.primitives-lifecycle.dek-management spec must do its job"; then
+    pass "spec-resolve includes sibling when INCLUDE_SIBLINGS=true"
+else
+    fail "spec-resolve missed sibling under INCLUDE_SIBLINGS" \
+         "first lines: $(printf '%s' "$resolve_sib" | head -10 | tr '\n' '|')"
+fi
+
+# ── Layer 5: backwards compatibility — flat specs still work ─────────────────
+
+echo ""
+echo "── Layer 5: flat specs (no parent_spec) keep working"
+
+# Build a flat (unrelated) spec in another domain.
+mkdir -p "$SPEC_DIR/domains/storage"
+FLAT_FILE="$SPEC_DIR/domains/storage/format.md"
+write_spec "$FLAT_FILE" "storage.format" ""
+
+# Add to manifest by rebuilding.
+build_manifest '[
+  {"id": "encryption.primitives-lifecycle",
+   "path": ".spec/domains/encryption/primitives-lifecycle.md",
+   "state": "APPROVED", "version": 1, "domains": ["encryption"],
+   "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []},
+  {"id": "encryption.primitives-lifecycle.key-rotation",
+   "path": ".spec/domains/encryption/primitives-lifecycle/key-rotation.md",
+   "parent_spec": "encryption.primitives-lifecycle",
+   "state": "APPROVED", "version": 1, "domains": ["encryption"],
+   "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []},
+  {"id": "encryption.primitives-lifecycle.dek-management",
+   "path": ".spec/domains/encryption/primitives-lifecycle/dek-management.md",
+   "parent_spec": "encryption.primitives-lifecycle",
+   "state": "APPROVED", "version": 1, "domains": ["encryption"],
+   "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []},
+  {"id": "storage.format",
+   "path": ".spec/domains/storage/format.md",
+   "state": "APPROVED", "version": 1, "domains": ["storage"],
+   "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []}
+]'
+
+# Validate the flat spec.
+val_flat=$(bash "$REPO_ROOT/scripts/spec-validate.sh" "$FLAT_FILE" 2>&1)
+val_flat_rc=$?
+if (( val_flat_rc == 0 )); then
+    pass "spec-validate passes on flat spec without parent_spec"
+else
+    fail "spec-validate broke on flat spec" "output: $val_flat"
+fi
+
+# Resolve the flat spec by itself. No parent should be added (storage.format
+# has no parent_spec).
+resolve_flat=$(cd "$PROJ" && \
+    EXPLICIT_SPEC_IDS="storage.format" \
+    bash "$REPO_ROOT/scripts/spec-resolve.sh" "storage format" 8000 2>&1 || true)
+if echo "$resolve_flat" | grep -q "The storage.format spec must do its job"; then
+    pass "spec-resolve handles flat spec normally"
+else
+    fail "spec-resolve broke on flat spec" \
+         "first lines: $(printf '%s' "$resolve_flat" | head -10 | tr '\n' '|')"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+    exit 0
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+    exit 1
+fi

--- a/tests/scenario-spec-split.sh
+++ b/tests/scenario-spec-split.sh
@@ -1,0 +1,475 @@
+#!/usr/bin/env bash
+# Scenario: /spec-split executor + rollback + @spec annotation rewrite.
+#
+# Validates the PR 2 mechanical scope of the spec-layering plan. Tests
+# only the script (`scripts/spec-split.sh`), not the orchestrating skill
+# prompt — the skill is tested manually during the pilot on jlsm.
+#
+# Layered cover:
+#
+#   1. Plan validation — bad plans are rejected before any change is
+#      made (missing required field, child id with wrong prefix, child
+#      claiming an R-number not in parent, two children claiming the
+#      same R-number, every R-number claimed leaving no cross-cutting).
+#
+#   2. Golden split — synthetic parent with 3 categories of requirements;
+#      run the script with a 2-child plan; assert: child files exist
+#      with carved requirements, parent retains only cross-cutting,
+#      manifest has new entries with parent_spec set, spec-validate
+#      passes parent + each child.
+#
+#   3. R-number identity is preserved — moving R45 to a child keeps R45
+#      as the child's R45, NOT renumbered.
+#
+#   4. @spec annotation sweep — synthesized source files containing
+#      `@spec parent.R12` get rewritten to `@spec parent.child.R12` for
+#      moved requirements, but `@spec parent.R5` (cross-cutting, stays
+#      at parent) is left alone.
+#
+#   5. Rollback on validation failure — force a post-split spec-validate
+#      failure (by injecting a malformed child after planned execute)
+#      and assert the rollback fully restores parent + manifest +
+#      annotations.
+#
+#   6. Backwards compatibility — running with no plan exits non-zero
+#      and surfaces the usage message.
+#
+# Run from repo root: bash tests/scenario-spec-split.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: /spec-split executor + rollback + annotation sweep"
+echo "────────────────────────────────────────────────"
+
+# ── Synthetic project tree ──────────────────────────────────────────────────
+
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine-spec-split.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.spec/registry" "$PROJ/.spec/domains/encryption" "$PROJ/modules/jlsm-engine/src"
+SPEC_DIR="$PROJ/.spec"
+MANIFEST="$SPEC_DIR/registry/manifest.json"
+PARENT_ID="encryption.primitives-lifecycle"
+PARENT_FILE="$SPEC_DIR/domains/encryption/primitives-lifecycle.md"
+
+cat > "$PARENT_FILE" <<'EOF'
+---
+{
+  "id": "encryption.primitives-lifecycle",
+  "version": 5,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["encryption"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+
+# encryption.primitives-lifecycle
+
+The umbrella spec for primitive lifecycle behaviour.
+
+R1. All DEKs must be wrappable under their tenant root key.
+R2. Cross-cutting audit invariant.
+R3. Cross-cutting tenant boundary invariant.
+
+R10. Key rotation must run at most every 90 days.
+R11. Rotation must use a fresh DEK.
+R12. Rotation must publish the new key version to the audit log.
+
+R20. DEKs must be stored encrypted at rest.
+R21. DEK access must be audited per request.
+R22. DEKs must be disposed within 24h of last use.
+
+---
+
+## Notes
+Original lifecycle spec covering rotation + DEK management together.
+EOF
+
+# Manifest with the parent registered.
+cat > "$MANIFEST" <<EOF
+{
+  "schema_version": 2,
+  "generated_at": "2026-04-27T00:00:00Z",
+  "spec_count": 1,
+  "specs": [
+    {
+      "id": "encryption.primitives-lifecycle",
+      "path": ".spec/domains/encryption/primitives-lifecycle.md",
+      "state": "APPROVED",
+      "version": 5,
+      "domains": ["encryption"],
+      "requires": [],
+      "invalidates": [],
+      "decision_refs": [],
+      "kb_refs": []
+    }
+  ]
+}
+EOF
+
+# Source code with @spec annotations referencing parent.
+cat > "$PROJ/modules/jlsm-engine/src/Rotator.java" <<'EOF'
+// @spec encryption.primitives-lifecycle.R10 — rotation cadence guard
+public class Rotator {
+    // @spec encryption.primitives-lifecycle.R12
+    void publishVersion() {}
+    // @spec encryption.primitives-lifecycle.R1 — cross-cutting wrap invariant
+    void wrap() {}
+}
+EOF
+
+cat > "$PROJ/modules/jlsm-engine/src/DekStore.java" <<'EOF'
+// @spec encryption.primitives-lifecycle.R20,R21
+public class DekStore {
+    // @spec encryption.primitives-lifecycle.R22 — TTL disposal
+    void purge() {}
+}
+EOF
+
+# A test file (not in scan dirs) — should NOT be rewritten.
+mkdir -p "$PROJ/modules/jlsm-engine/test"
+cat > "$PROJ/modules/jlsm-engine/test/RotatorTest.java" <<'EOF'
+// @spec encryption.primitives-lifecycle.R10 — must NOT be rewritten by default scan
+public class RotatorTest {}
+EOF
+
+# ── Layer 1: plan validation ─────────────────────────────────────────────────
+
+echo ""
+echo "── Layer 1: bad plans rejected"
+
+run_split() {
+  cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-split.sh" "$@" 2>&1
+}
+
+# 1a: missing parent_id
+PLAN1="$TMPDIR_TEST/plan1.json"
+echo '{"children": [{"id": "x", "title": "X", "domains": ["e"], "requirements": ["R1"]}]}' > "$PLAN1"
+out=$(run_split --plan "$PLAN1" || true)
+if echo "$out" | grep -q "missing parent_id"; then
+  pass "rejects plan missing parent_id"
+else
+  fail "did not reject missing parent_id" "got: $out"
+fi
+
+# 1b: child id without parent prefix
+PLAN2="$TMPDIR_TEST/plan2.json"
+cat > "$PLAN2" <<EOF
+{"parent_id":"$PARENT_ID","children":[{"id":"foo.bar","title":"X","domains":["e"],"requirements":["R10"]}]}
+EOF
+out=$(run_split --plan "$PLAN2" || true)
+if echo "$out" | grep -q "must start with"; then
+  pass "rejects child id without parent prefix"
+else
+  fail "did not reject prefix mismatch" "got: $out"
+fi
+
+# 1c: child claims an R-number not in parent
+PLAN3="$TMPDIR_TEST/plan3.json"
+cat > "$PLAN3" <<EOF
+{"parent_id":"$PARENT_ID","children":[
+  {"id":"$PARENT_ID.bogus","title":"Bogus","domains":["encryption"],"requirements":["R999"]}]}
+EOF
+out=$(run_split --plan "$PLAN3" || true)
+if echo "$out" | grep -q "not in parent's R-numbers"; then
+  pass "rejects R-number not in parent"
+else
+  fail "did not reject unknown R-number" "got: $out"
+fi
+
+# 1d: two children claiming the same R-number
+PLAN4="$TMPDIR_TEST/plan4.json"
+cat > "$PLAN4" <<EOF
+{"parent_id":"$PARENT_ID","children":[
+  {"id":"$PARENT_ID.a","title":"A","domains":["encryption"],"requirements":["R10"]},
+  {"id":"$PARENT_ID.b","title":"B","domains":["encryption"],"requirements":["R10"]}]}
+EOF
+out=$(run_split --plan "$PLAN4" || true)
+if echo "$out" | grep -q "claimed by both"; then
+  pass "rejects duplicate R-number claim"
+else
+  fail "did not reject duplicate claim" "got: $out"
+fi
+
+# 1e: every R claimed → no cross-cutting → must reject
+PLAN5="$TMPDIR_TEST/plan5.json"
+cat > "$PLAN5" <<EOF
+{"parent_id":"$PARENT_ID","children":[
+  {"id":"$PARENT_ID.allofit","title":"AllOfIt","domains":["encryption"],
+   "requirements":["R1","R2","R3","R10","R11","R12","R20","R21","R22"]}]}
+EOF
+out=$(run_split --plan "$PLAN5" || true)
+if echo "$out" | grep -q "no cross-cutting requirements"; then
+  pass "rejects plan that drains every R-number from parent"
+else
+  fail "did not enforce non-empty cross-cutting" "got: $out"
+fi
+
+# 1f: --dry-run on a valid plan succeeds without touching files
+PLAN_VALID="$TMPDIR_TEST/plan-valid.json"
+cat > "$PLAN_VALID" <<EOF
+{
+  "parent_id": "$PARENT_ID",
+  "children": [
+    {"id":"$PARENT_ID.key-rotation","title":"Key Rotation",
+     "domains":["encryption"],"requirements":["R10","R11","R12"]},
+    {"id":"$PARENT_ID.dek-management","title":"DEK Management",
+     "domains":["encryption"],"requirements":["R20","R21","R22"]}
+  ]
+}
+EOF
+parent_before="$(cat "$PARENT_FILE")"
+out=$(run_split --plan "$PLAN_VALID" --dry-run || true)
+parent_after="$(cat "$PARENT_FILE")"
+if [[ "$parent_before" == "$parent_after" ]] && echo "$out" | grep -q "DRY RUN"; then
+  pass "--dry-run validates without touching parent"
+else
+  fail "--dry-run modified parent or did not signal" "$(diff <(echo "$parent_before") <(echo "$parent_after") | head -3)"
+fi
+
+# ── Layer 2: golden split ────────────────────────────────────────────────────
+
+echo ""
+echo "── Layer 2: golden 2-child split"
+
+run_split --plan "$PLAN_VALID" >/tmp/spec-split.out 2>&1
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+  pass "spec-split exits 0 on valid plan"
+else
+  fail "spec-split exited $rc on valid plan" "$(tail -10 /tmp/spec-split.out)"
+fi
+
+KR_FILE="$SPEC_DIR/domains/encryption/primitives-lifecycle/key-rotation.md"
+DM_FILE="$SPEC_DIR/domains/encryption/primitives-lifecycle/dek-management.md"
+
+if [[ -f "$KR_FILE" ]]; then
+  pass "child file created: key-rotation.md"
+else
+  fail "child file missing: $KR_FILE"
+fi
+if [[ -f "$DM_FILE" ]]; then
+  pass "child file created: dek-management.md"
+else
+  fail "child file missing: $DM_FILE"
+fi
+
+# ── Layer 3: R-number identity preserved ─────────────────────────────────────
+
+echo ""
+echo "── Layer 3: R-numbers preserved across the split"
+
+if grep -q '^R10\.' "$KR_FILE" && grep -q '^R11\.' "$KR_FILE" && grep -q '^R12\.' "$KR_FILE"; then
+  pass "key-rotation child contains R10, R11, R12"
+else
+  fail "key-rotation child missing original R-numbers" \
+       "$(grep -E '^R[0-9]+\.' "$KR_FILE" | head -5)"
+fi
+if grep -q '^R20\.' "$DM_FILE" && grep -q '^R21\.' "$DM_FILE" && grep -q '^R22\.' "$DM_FILE"; then
+  pass "dek-management child contains R20, R21, R22"
+else
+  fail "dek-management child missing original R-numbers"
+fi
+
+# Parent must contain ONLY cross-cutting (R1, R2, R3) and NOT R10/R11/R12/R20/R21/R22.
+parent_post="$(cat "$PARENT_FILE")"
+if grep -q '^R1\.' "$PARENT_FILE" && \
+   grep -q '^R2\.' "$PARENT_FILE" && \
+   grep -q '^R3\.' "$PARENT_FILE"; then
+  pass "parent retains R1, R2, R3 (cross-cutting)"
+else
+  fail "parent missing cross-cutting R-numbers"
+fi
+if grep -qE '^(R10|R11|R12|R20|R21|R22)\.' "$PARENT_FILE"; then
+  fail "parent still contains moved R-numbers" \
+       "$(grep -E '^R[0-9]+\.' "$PARENT_FILE")"
+else
+  pass "parent does NOT contain moved R-numbers"
+fi
+
+# ── Layer 4: @spec annotation rewrite scope ──────────────────────────────────
+
+echo ""
+echo "── Layer 4: @spec annotations rewritten correctly"
+
+# Rotator.java: R10 and R12 should rewrite; R1 should NOT.
+ROT="$PROJ/modules/jlsm-engine/src/Rotator.java"
+if grep -q "@spec encryption.primitives-lifecycle.key-rotation.R10" "$ROT"; then
+  pass "Rotator.java: @spec parent.R10 → @spec parent.key-rotation.R10"
+else
+  fail "Rotator.java: R10 not rewritten" "$(grep '@spec' "$ROT")"
+fi
+if grep -q "@spec encryption.primitives-lifecycle.key-rotation.R12" "$ROT"; then
+  pass "Rotator.java: @spec parent.R12 → @spec parent.key-rotation.R12"
+else
+  fail "Rotator.java: R12 not rewritten" "$(grep '@spec' "$ROT")"
+fi
+if grep -q "^// @spec encryption.primitives-lifecycle.R1 " "$ROT" || \
+   grep -q "@spec encryption.primitives-lifecycle.R1 —" "$ROT"; then
+  pass "Rotator.java: cross-cutting R1 untouched"
+else
+  fail "Rotator.java: R1 incorrectly rewritten" "$(grep '@spec' "$ROT")"
+fi
+
+# DekStore.java: R20, R21, R22 should rewrite to dek-management child.
+DEK="$PROJ/modules/jlsm-engine/src/DekStore.java"
+# The R20,R21 form is a single annotation listing two reqs from the same spec.
+# Our rewrite handles each separately; both should land at dek-management.
+# After rewrite, the comma form may split or both halves change. Check that
+# both R20 and R21 references now point to dek-management.
+if grep -q "encryption.primitives-lifecycle.dek-management.R20" "$DEK"; then
+  pass "DekStore.java: R20 rewritten to dek-management"
+else
+  fail "DekStore.java: R20 not rewritten" "$(grep '@spec' "$DEK")"
+fi
+if grep -q "@spec encryption.primitives-lifecycle.dek-management.R22" "$DEK"; then
+  pass "DekStore.java: R22 rewritten to dek-management"
+else
+  fail "DekStore.java: R22 not rewritten" "$(grep '@spec' "$DEK")"
+fi
+
+# Test file (not in default scan dirs) should NOT be rewritten.
+TEST_FILE="$PROJ/modules/jlsm-engine/test/RotatorTest.java"
+if grep -q "@spec encryption.primitives-lifecycle.R10" "$TEST_FILE"; then
+  pass "test/ file left alone (not in default scan dirs)"
+else
+  fail "test/ file was incorrectly rewritten" "$(cat "$TEST_FILE")"
+fi
+
+# ── Layer 5: manifest updated ────────────────────────────────────────────────
+
+echo ""
+echo "── Layer 5: manifest has child entries with parent_spec"
+
+count_with_parent=$(jq '[.specs[] | select(.parent_spec != null)] | length' "$MANIFEST")
+if [[ "$count_with_parent" == "2" ]]; then
+  pass "manifest has 2 entries with parent_spec set"
+else
+  fail "manifest parent_spec count wrong" "got: $count_with_parent (expected 2)"
+fi
+
+# ── Layer 6: post-split validation passes ────────────────────────────────────
+
+echo ""
+echo "── Layer 6: spec-validate passes parent + children"
+
+if (cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-validate.sh" "$PARENT_FILE" >/dev/null 2>&1); then
+  pass "spec-validate passes parent post-split"
+else
+  fail "spec-validate failed on parent post-split" \
+       "$(cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-validate.sh" "$PARENT_FILE" 2>&1 | head -10)"
+fi
+if (cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-validate.sh" "$KR_FILE" >/dev/null 2>&1); then
+  pass "spec-validate passes key-rotation child"
+else
+  fail "spec-validate failed on key-rotation child" \
+       "$(cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-validate.sh" "$KR_FILE" 2>&1 | head -10)"
+fi
+if (cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-validate.sh" "$DM_FILE" >/dev/null 2>&1); then
+  pass "spec-validate passes dek-management child"
+else
+  fail "spec-validate failed on dek-management child" \
+       "$(cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-validate.sh" "$DM_FILE" 2>&1 | head -10)"
+fi
+
+# ── Layer 7: rollback drill ──────────────────────────────────────────────────
+
+echo ""
+echo "── Layer 7: rollback restores parent + manifest + annotations"
+
+# Get the rollback log from the previous successful split.
+LOG_FILE=$(ls -1 "$SPEC_DIR/.split-log/"*.json 2>/dev/null | head -1)
+if [[ -z "$LOG_FILE" ]]; then
+  fail "no rollback log found post-split"
+else
+  # Capture current state.
+  current_parent="$(cat "$PARENT_FILE")"
+  current_manifest="$(cat "$MANIFEST")"
+
+  # Replay rollback.
+  bash "$REPO_ROOT/scripts/spec-split.sh" --rollback "$LOG_FILE" >/tmp/rollback.out 2>&1
+  rb_rc=$?
+
+  if [[ $rb_rc -eq 0 ]]; then
+    pass "rollback exits 0"
+  else
+    fail "rollback exited $rb_rc" "$(tail -5 /tmp/rollback.out)"
+  fi
+
+  # Parent should be restored to original (not current post-split).
+  parent_after_rb="$(cat "$PARENT_FILE")"
+  if [[ "$parent_after_rb" == *"R10. Key rotation must run"* ]]; then
+    pass "rollback: parent has R10 (rotation reqs) again"
+  else
+    fail "rollback: parent did NOT restore moved reqs"
+  fi
+
+  # Children should be deleted.
+  if [[ ! -f "$KR_FILE" ]] && [[ ! -f "$DM_FILE" ]]; then
+    pass "rollback: child files deleted"
+  else
+    fail "rollback: child files still exist"
+  fi
+
+  # Manifest should be back to 1 spec.
+  manifest_count=$(jq '.specs | length' "$MANIFEST")
+  if [[ "$manifest_count" == "1" ]]; then
+    pass "rollback: manifest restored to 1 spec"
+  else
+    fail "rollback: manifest count is $manifest_count, expected 1"
+  fi
+
+  # Annotations should be reverted.
+  if grep -q "@spec encryption.primitives-lifecycle.R10" "$ROT" && \
+     ! grep -q "key-rotation.R10" "$ROT"; then
+    pass "rollback: @spec annotations reverted"
+  else
+    fail "rollback: annotations not reverted" \
+         "$(grep '@spec' "$ROT" | head -3)"
+  fi
+fi
+
+# ── Layer 8: missing args / usage ────────────────────────────────────────────
+
+echo ""
+echo "── Layer 8: usage and arg parsing"
+
+out=$(cd "$PROJ" && bash "$REPO_ROOT/scripts/spec-split.sh" 2>&1 || true)
+if echo "$out" | grep -q "Usage:"; then
+  pass "no args → usage message"
+else
+  fail "no args did not surface usage" "got: $out"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+  echo "ALL PASSED  ($passed/$total)"
+  exit 0
+else
+  echo "FAILED  $failed/$total  ($passed passed)"
+  exit 1
+fi

--- a/tests/scenario-wd-status-update-no-edit.sh
+++ b/tests/scenario-wd-status-update-no-edit.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Scenario: WD status updates must use `sed -i`, not `Edit`.
+#
+# The Edit tool requires the target file to be Read in the same session
+# first. /work-plan and /work-start update WD status without otherwise
+# needing the file's content, so an Edit instruction yields predictable
+# "File has not been read yet" errors. The kit already uses
+# `sed -i "s/^status:.*$/status: X/" <wd-file>` in
+# `scripts/work-finalize.sh:80` for the equivalent operation; the skill
+# prompts must mirror that pattern.
+#
+# Surfaced from the 2026-04-23 → 2026-04-27 jlsm session sweep —
+# multiple edit-before-read errors traced to the three Edit-status
+# instructions in /work-start and /work-plan.
+#
+# Run from repo root: bash tests/scenario-wd-status-update-no-edit.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: WD status updates must use sed -i (not Edit)"
+echo "────────────────────────────────────────────────"
+
+# ── Invariant 1: prohibited Edit-instruction pattern is absent ───────────────
+
+echo ""
+echo "── Invariant 1: no 'Edit .work/<group>/WD-<nn>.md — set status:' instructions"
+
+# This is a literal pattern the bug PR removed. If reintroduced (typically
+# via copy-paste from older docs), the prompt will fail at runtime when the
+# assistant follows the instruction without first reading the file.
+check_no_edit_status() {
+    local file="$1"
+    local name="$2"
+    # Match the prose form: `Edit \`.work/...WD...\` — set \`status:`
+    # (curly em-dash and ASCII hyphens both, defensively).
+    if grep -nE 'Edit \`\.work/.*WD-.*\.md\`.*[—-].*set \`status:' "$file" >/dev/null 2>&1; then
+        local hits
+        hits="$(grep -nE 'Edit \`\.work/.*WD-.*\.md\`.*[—-].*set \`status:' "$file" | cut -d: -f1 | tr '\n' ' ')"
+        fail "$name: contains Edit-status instruction" \
+             "lines: $hits — replace with: sed -i \"s/^status:.*\\\$/status: <NEW>/\" <wd-file>"
+    else
+        pass "$name: no Edit-status instructions"
+    fi
+}
+
+check_no_edit_status "$REPO_ROOT/skills/work-start/SKILL.md" "/work-start"
+check_no_edit_status "$REPO_ROOT/skills/work-plan/SKILL.md" "/work-plan"
+
+# ── Invariant 2: required sed-i pattern is present in each file ──────────────
+
+echo ""
+echo "── Invariant 2: sed -i status-update pattern is present"
+
+# The replacement form. Each skill that updates WD status must use the
+# `sed -i "s/^status:.*$/status: X/"` shape so it matches what
+# scripts/work-finalize.sh:80 already does.
+check_has_sed_status() {
+    local file="$1"
+    local name="$2"
+    local expected_state="$3"
+    if grep -qE "sed -i \"s/\^status:.\*\\\$/status: ${expected_state}/\"" "$file"; then
+        pass "$name: uses sed -i for status: $expected_state"
+    else
+        fail "$name: missing sed -i status update for $expected_state" \
+             "expected: sed -i \"s/^status:.*\\\$/status: ${expected_state}/\" .work/<group-slug>/WD-<nn>.md"
+    fi
+}
+
+check_has_sed_status "$REPO_ROOT/skills/work-start/SKILL.md"  "/work-start" "IMPLEMENTING"
+check_has_sed_status "$REPO_ROOT/skills/work-plan/SKILL.md"   "/work-plan"  "SPECIFYING"
+check_has_sed_status "$REPO_ROOT/skills/work-plan/SKILL.md"   "/work-plan"  "SPECIFIED"
+
+# ── Invariant 3: precedent script still uses the same pattern ────────────────
+
+echo ""
+echo "── Invariant 3: scripts/work-finalize.sh precedent unchanged"
+
+# If the precedent moves, the skill prompts should too — flagging here
+# means the skill prompts may have drifted from the script's actual pattern.
+finalize="$REPO_ROOT/scripts/work-finalize.sh"
+if grep -qF 'sed -i "s/^status:.*$/status: COMPLETE/"' "$finalize"; then
+    pass "scripts/work-finalize.sh still sets status via sed -i (precedent)"
+else
+    fail "scripts/work-finalize.sh precedent missing or changed" \
+         "if the script's pattern moved, update both the script and the skill prompts together"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+    exit 0
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Bundles the 4-day jlsm session-sweep fixes with the full spec-layering
initiative. Six commits, one branch, one PR — the work is one coherent
stream the user guided throughout.

**Investigation → fixes → design → implementation:**

1. Sweep of jlsm Claude Code sessions (2026-04-23 → 2026-04-27)
   surfaced two kit-side bugs and one structural issue (a spec that
   has matured past one file's worth of behavior).
2. Bug fixes shipped first: `Edit`-on-WD-status without prior Read,
   and SIGPIPE under `pipefail` on `echo "$var" | grep -q` for large
   stdin.
3. Structural issue treated as a design problem: specs should subdivide
   as a **natural progression** of growing domains, not via reactive
   remediation. Designed via `/ideate` plan mode, executed in four
   shippable parts.

## Spec layering — natural progression model

A mature spec subdivides into a parent + concern-specific children.
Every node is a full falsifiable spec; the parent retains R-numbered
cross-cutting requirements while children own concern-specific ones.
Subdivision is recursive (a child can itself subdivide) and triggered
by either:

- `/curate` housekeeping — passive detection during periodic scans
- `/spec-author` Pass 2 — just-in-time signal when an amendment tips
  the spec into subdivision territory

Both triggers use the same heuristic; both produce a non-blocking
`/spec-split <id>` suggestion that the user accepts, declines (with
documented reason), or defers. Decline is a first-class outcome —
subdivision should never be forced on indivisible concerns.

The mechanical executor (`scripts/spec-split.sh`) is transactional:
snapshots prior state into a rollback log, carves children preserving
R-number identity, rewrites parent to retain only cross-cutting reqs,
updates manifest with `parent_spec` references, sweeps `@spec`
annotations in production source dirs (skipping test/build paths),
runs `spec-validate` on parent + every child, and on any post-write
failure replays the rollback log automatically.

## Commits

```
3eab122 feat(spec-author): sibling-aware Pass 2/3 + JIT subdivision signal (PR 4/4)
9300f0f feat(curate): subdivision-candidate detector (PR 3/4)
824f71e feat(spec): /spec-split skill — execute spec subdivision (PR 2/4)
03ab811 feat(spec): support layered specs via parent_spec field (PR 1/4)
e4b3443 fix(scripts): SIGPIPE on `echo "$var" | grep -q` for large stdin under pipefail
1618427 fix(work): use sed -i for WD status updates so files don't need a prior Read
```

## What lands

- **`parent_spec` frontmatter field** — single-string optional, points at
  immediate parent. Children declare; parents do not declare children
  (computed at scan time, mirrors `.decisions/` precedent).
- **Multi-dot ID grammar** — `encryption.primitives-lifecycle.key-rotation`
  accepted across `spec-validate.sh` and `spec-trace.sh`. ID-to-path
  mapping is computable: `a.b.c.d` → `domains/a/b/c/d.md`.
- **Hierarchy-aware `spec-resolve.sh`** — auto-includes parent chain when
  a child is selected; `INCLUDE_SIBLINGS=true` opt-in for adversarial
  paths. Existing `requires` transitive closure runs unchanged.
- **`/spec-split <spec-id>` skill + executor** — orchestrating prompt +
  transactional bash script with rollback log, JSON-plan validation,
  `@spec` annotation rewrite, and post-split `spec-validate` gate.
- **`/curate` Analysis 20** — flags subdivision candidates by counting
  reqs per section + checking distribution, with safeguards against
  false-positives (single-section large specs, dominant-section specs,
  already-children, small specs).
- **`/spec-author` PR 4 changes** — pre-flight loads parent + siblings
  when amending a child; just-in-time signal between Pass 2 arbitration
  and Pass 3 surfaces a `/spec-split` suggestion when thresholds match.
  Both triggers (curate + spec-author) use the same heuristic — what
  one flags, the other flags.
- **`.spec/CLAUDE.md` Layered Specs section** — documents the model,
  file layout, ID grammar, validation rules, when to subdivide, when
  not to.

## Pre-PR validation

- 42/42 scenario tests passing (5 new: WD status, pipefail SIGPIPE,
  spec layering, spec split, curate subdivision candidates, spec-author
  layered).
- 91 new test invariants total.
- 59/59 install tests passing.
- Fresh install verified: `/spec-split` lands, settings.json permission
  entry present, manifest reflects skill + script.
- Both branches the work originally lived on (`fix/jlsm-soak-followups`,
  `feat/spec-layering-pr1`, `feat/spec-layering-pr2`) deleted; this is
  the only branch.

## Test plan

- [ ] CI green
- [ ] `bash tests/test-install.sh` — 59/59
- [ ] `for t in tests/scenario-*.sh; do bash "$t"; done` — 42/42
- [ ] After merge + release + jlsm upgrade: run `/curate` in jlsm and
      confirm `encryption.primitives-lifecycle` appears in
      "Subdivision Candidates" with a sane rationale.
- [ ] After flag (above): run `/spec-split encryption.primitives-lifecycle`
      and verify proposed concern boundaries match user intuition
      (likely: key-derivation, key-hierarchy, DEK-lifecycle, KEK-rotation,
      revocation, error-handling, tenant-flavors).
- [ ] Run `/spec-author` Pass 2 on a child post-split; verify subagent
      receives parent + siblings (cross-family falsification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)