### PR TITLE
fix(spec/curate): jlsm spec-split + curate-scan triage (8 fixes)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -548,6 +548,14 @@ echo "── Gitignore (runtime files) ─────────────�
 GITIGNORE="$TARGET/.gitignore"
 IGNORE_MARKER="# vallorcine runtime files"
 
+# Entries added in newer releases that an existing install (with the runtime
+# block already in place) would otherwise miss. Listed here so the upgrade
+# path can append any that are not already present.
+NEW_GITIGNORE_ENTRIES=(
+    ".spec/.split-log/"
+    ".spec/.split-plan.json"
+)
+
 if [[ "$DIFF_MODE" != "1" ]]; then
     if ! grep -qF "$IGNORE_MARKER" "$GITIGNORE" 2>/dev/null; then
         cat >> "$GITIGNORE" << 'GITIGNOREBLOCK'
@@ -559,18 +567,45 @@ if [[ "$DIFF_MODE" != "1" ]]; then
 .claude/.subagent-state
 .feature/
 .curate/
+.spec/.split-log/
+.spec/.split-plan.json
 __pycache__/
 GITIGNOREBLOCK
         echo -e "  ${GREEN}write${NC} .gitignore  (runtime file entries)"
     else
-        echo -e "  ${YELLOW}skip${NC}  .gitignore already has runtime file entries"
+        # Existing install: append any newly-introduced entries that aren't
+        # already listed. Without this, users who installed before v0.16.x
+        # would never pick up the spec-split runtime artifacts and would
+        # commit per-machine logs/plans.
+        added=()
+        for entry in "${NEW_GITIGNORE_ENTRIES[@]}"; do
+            if ! grep -qxF "$entry" "$GITIGNORE" 2>/dev/null; then
+                echo "$entry" >> "$GITIGNORE"
+                added+=("$entry")
+            fi
+        done
+        if (( ${#added[@]} > 0 )); then
+            echo -e "  ${GREEN}update${NC} .gitignore  (added ${#added[@]} new entries: ${added[*]})"
+        else
+            echo -e "  ${YELLOW}skip${NC}  .gitignore already has runtime file entries"
+        fi
     fi
 else
     if ! grep -qF "$IGNORE_MARKER" "$GITIGNORE" 2>/dev/null; then
         echo -e "  ${GREEN}new${NC}    .gitignore runtime file entries"
         ((changed++)) || true
     else
-        ((unchanged++)) || true
+        # Diff mode: count missing entries as a "would-add" signal.
+        missing_count=0
+        for entry in "${NEW_GITIGNORE_ENTRIES[@]}"; do
+            grep -qxF "$entry" "$GITIGNORE" 2>/dev/null || ((missing_count++)) || true
+        done
+        if (( missing_count > 0 )); then
+            echo -e "  ${GREEN}update${NC} .gitignore  ($missing_count new entries to add)"
+            ((changed++)) || true
+        else
+            ((unchanged++)) || true
+        fi
     fi
 fi
 

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -568,6 +568,41 @@ if [[ -d ".spec" && -d ".spec/domains" ]]; then
     # Find CamelCase type names referenced in 3+ spec files that have no
     # spec of their own.
 
+    # JDK / standard library types — referencing them in 3+ specs is normal,
+    # specifying them is meaningless, and they otherwise drown out genuine
+    # shared-type signals (project value types, services, repositories).
+    # This list covers java.lang, java.io, java.util, java.nio, java.time —
+    # the surfaces that account for ~all noise in real-project scans.
+    JDK_BLOCKLIST=(
+        # java.lang exceptions
+        IllegalArgumentException IllegalStateException NullPointerException
+        UnsupportedOperationException IndexOutOfBoundsException
+        ArrayIndexOutOfBoundsException ClassCastException ClassNotFoundException
+        NoSuchMethodException NoSuchFieldException SecurityException
+        NumberFormatException ArithmeticException ConcurrentModificationException
+        OutOfMemoryError StackOverflowError AssertionError InterruptedException
+        RuntimeException
+        # java.lang core
+        StringBuilder StringBuffer CharSequence Throwable Iterable
+        Comparable Cloneable AutoCloseable Runnable
+        # java.io
+        IOException FileNotFoundException InputStream OutputStream
+        BufferedReader BufferedWriter PrintWriter PrintStream
+        # java.util collections / utilities
+        ArrayList HashMap HashSet LinkedList LinkedHashMap LinkedHashSet
+        TreeMap TreeSet ConcurrentHashMap CopyOnWriteArrayList Collections
+        Optional Iterator NoSuchElementException Comparator
+        # java.nio
+        ByteBuffer CharBuffer ByteBuffer
+        # java.time
+        LocalDate LocalTime LocalDateTime ZonedDateTime Instant
+        # concurrency
+        AtomicInteger AtomicLong AtomicReference CompletableFuture
+        ExecutorService ThreadPoolExecutor ScheduledExecutorService
+    )
+    declare -A JDK_BLOCKLIST_SET=()
+    for jt in "${JDK_BLOCKLIST[@]}"; do JDK_BLOCKLIST_SET["$jt"]=1; done
+
     > "$TMPDIR_SCAN/spec-type-refs.txt"
 
     # Extract CamelCase words from all spec files, record which spec references them
@@ -596,6 +631,9 @@ if [[ -d ".spec" && -d ".spec/domains" ]]; then
         while IFS= read -r line; do
             ref_count="$(echo "$line" | awk '{print $1}')"
             type_name="$(echo "$line" | awk '{$1=""; print $0}' | sed 's/^ //')"
+            # Drop JDK / standard library types — referencing them is universal,
+            # specifying them is meaningless, and they swamp the report.
+            [[ -n "${JDK_BLOCKLIST_SET[$type_name]+x}" ]] && continue
             # Check if any spec file name contains this type name (case-insensitive)
             type_lower="$(echo "$type_name" | tr '[:upper:]' '[:lower:]')"
             has_spec=0
@@ -619,39 +657,49 @@ if [[ -d ".spec" && -d ".spec/domains" ]]; then
     fi
 
     # ── 10b: Specs with open obligations ──────────────────────────────────
-    # Scan specs for open_obligations in frontmatter or [UNRESOLVED]/[CONFLICT] markers
+    # Surface specs with [UNRESOLVED]/[CONFLICT] markers in the body OR a
+    # non-empty `open_obligations` array in the JSON frontmatter. The
+    # frontmatter check uses jq so an empty array (`open_obligations: []`)
+    # or stripped punctuation never registers as an open obligation —
+    # the prior shell-based stripper false-positived on every spec that
+    # carried the empty-array convention in its frontmatter.
 
     find .spec/domains -name '*.md' 2>/dev/null | while IFS= read -r spec_file; do
         spec_base="$(basename "$spec_file" .md)"
-        obligation_count=0
-        obligations=""
 
-        # Check frontmatter for open_obligations
-        fm_obligations="$(sed -n '/^---$/,/^---$/p' "$spec_file" 2>/dev/null \
-            | grep 'open_obligations' | head -1 || true)"
-
-        # Count [UNRESOLVED] and [CONFLICT] markers in body
+        # Body markers
         unresolved_count="$( (grep -c '\[UNRESOLVED\]' "$spec_file" || true) 2>/dev/null)"
         conflict_count="$( (grep -c '\[CONFLICT\]' "$spec_file" || true) 2>/dev/null)"
         [[ -z "$unresolved_count" ]] && unresolved_count=0
         [[ -z "$conflict_count" ]] && conflict_count=0
-        obligation_count=$((unresolved_count + conflict_count))
+        body_count=$((unresolved_count + conflict_count))
 
-        # Extract obligation text for display
-        if [[ "$obligation_count" -gt 0 ]]; then
-            obligations="$(grep -oE '\[UNRESOLVED\][^.]*\.|\[CONFLICT\][^.]*\.' "$spec_file" 2>/dev/null \
-                | head -5 | tr '\n' ';' | sed 's/;$//' || true)"
-            echo "OBLIGATION|$spec_base|$obligation_count|$obligations" >> "$TMPDIR_SCAN/spec-obligations.txt"
-        fi
-
-        # Also check for DRAFT status with open_obligations in frontmatter
-        if [[ -n "$fm_obligations" && "$obligation_count" -eq 0 ]]; then
-            ob_text="$(echo "$fm_obligations" | sed 's/.*open_obligations:[[:space:]]*//' | tr -d '[]"' || true)"
-            if [[ -n "$ob_text" ]]; then
-                ob_count="$(echo "$ob_text" | tr ',' '\n' | grep -c '[a-z]' 2>/dev/null)" || ob_count=1
-                echo "OBLIGATION|$spec_base|$ob_count|$ob_text" >> "$TMPDIR_SCAN/spec-obligations.txt"
+        # Frontmatter open_obligations (parsed as JSON array; empty → 0)
+        fm_count=0
+        fm_json=""
+        if command -v jq >/dev/null 2>&1; then
+            fm_json="$(awk '/^---$/{n++; next} n==1 && /^[[:space:]]*\{/{inj=1} n==1 && inj{print} n>=2{exit}' "$spec_file" 2>/dev/null || true)"
+            if [[ -n "$fm_json" ]]; then
+                fm_count="$(echo "$fm_json" | jq 'if (.open_obligations | type) == "array" then (.open_obligations | length) else 0 end' 2>/dev/null || echo 0)"
             fi
         fi
+
+        total_count=$((body_count + fm_count))
+        [[ "$total_count" -eq 0 ]] && continue
+
+        if [[ "$body_count" -gt 0 ]]; then
+            obligations="$(grep -oE '\[UNRESOLVED\][^.]*\.|\[CONFLICT\][^.]*\.' "$spec_file" 2>/dev/null \
+                | head -5 | tr '\n' ';' | sed 's/;$//' || true)"
+        else
+            obligations="$(echo "$fm_json" | jq -r '
+                (.open_obligations // [])
+                | .[]
+                | (if type == "string" then .
+                   elif type == "object" then (.text // .description // .summary // tostring)
+                   else tostring end)
+            ' 2>/dev/null | head -5 | tr '\n' ';' | sed 's/;$//' || true)"
+        fi
+        echo "OBLIGATION|$spec_base|$total_count|$obligations" >> "$TMPDIR_SCAN/spec-obligations.txt"
     done
 
     sort -t'|' -k3 -rn "$TMPDIR_SCAN/spec-obligations.txt" -o "$TMPDIR_SCAN/spec-obligations.txt" 2>/dev/null || true
@@ -1186,6 +1234,28 @@ fi
 
 > "$TMPDIR_SCAN/spec-annotation-gaps.txt"
 > "$TMPDIR_SCAN/spec-unannotated.txt"
+> "$TMPDIR_SCAN/spec-bare-only.txt"
+
+# has_bare_annotations <spec-id> — returns 0 if the source tree contains a
+# bare `@spec <sid>` reference (no `.R<n>` suffix). Used to differentiate
+# "spec is associated with code but lacks R-level granularity" from "spec
+# is not referenced anywhere". The classification matters because the user
+# remediation differs: the former needs a refactor of existing annotations,
+# the latter needs new annotations from scratch.
+has_bare_annotations() {
+    local sid="$1"
+    local sid_re="${sid//./\\.}"
+    grep -rqE "@spec ${sid_re}([^.A-Za-z0-9_-]|\$)" \
+        --include='*.java' --include='*.py' --include='*.js' \
+        --include='*.ts' --include='*.go' --include='*.rs' \
+        --include='*.kt' --include='*.scala' --include='*.c' \
+        --include='*.cpp' --include='*.h' --include='*.hpp' \
+        --include='*.cs' --include='*.rb' --include='*.swift' \
+        --include='*.m' --include='*.sh' \
+        --exclude-dir='node_modules' --exclude-dir='vendor' \
+        --exclude-dir='target' --exclude-dir='build' --exclude-dir='dist' \
+        . 2>/dev/null
+}
 
 if [[ -f ".spec/registry/manifest.json" ]] && command -v jq >/dev/null 2>&1; then
     # Locate the spec-trace script — support installed layout and dev-repo layout.
@@ -1224,7 +1294,14 @@ if [[ -f ".spec/registry/manifest.json" ]] && command -v jq >/dev/null 2>&1; the
             # Use here-strings so SIGPIPE under pipefail cannot flip results
             # on long /spec-trace output (grep -q / -m1 close stdin early).
             if grep -q '\*\*No annotations found\.\*\*' <<< "$trace_out"; then
-                echo "UNANNOTATED|$sid" >> "$TMPDIR_SCAN/spec-unannotated.txt"
+                # Bare `@spec <sid>` references count as a separate gap class:
+                # impl is associated, but R-level granularity is missing.
+                # Pure UNANNOTATED means zero `@spec` references of any kind.
+                if has_bare_annotations "$sid"; then
+                    echo "BARE_ONLY|$sid" >> "$TMPDIR_SCAN/spec-bare-only.txt"
+                else
+                    echo "UNANNOTATED|$sid" >> "$TMPDIR_SCAN/spec-unannotated.txt"
+                fi
                 continue
             fi
 
@@ -1239,14 +1316,14 @@ if [[ -f ".spec/registry/manifest.json" ]] && command -v jq >/dev/null 2>&1; the
                 # req list as "<spec-id>.Rn[a] <spec-id>.Rm ..." — count by
                 # matching the .Rn[a] suffixes.
                 no_impl_clean="$(echo "$no_impl" | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//')"
-                req_count="$(echo "$no_impl_clean" | grep -oE '\.R[0-9]+[a-z]?' | wc -l || true)"
+                req_count="$(echo "$no_impl_clean" | grep -oE '\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?' | wc -l || true)"
                 [[ -z "$req_count" ]] && req_count=0
                 echo "IMPL_GAP|$sid|$req_count|$no_impl_clean" >> "$TMPDIR_SCAN/spec-annotation-gaps.txt"
             fi
 
             if [[ -n "$no_test" ]]; then
                 no_test_clean="$(echo "$no_test" | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//')"
-                req_count="$(echo "$no_test_clean" | grep -oE '\.R[0-9]+[a-z]?' | wc -l || true)"
+                req_count="$(echo "$no_test_clean" | grep -oE '\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?' | wc -l || true)"
                 [[ -z "$req_count" ]] && req_count=0
                 echo "TEST_GAP|$sid|$req_count|$no_test_clean" >> "$TMPDIR_SCAN/spec-annotation-gaps.txt"
             fi
@@ -1256,11 +1333,13 @@ if [[ -f ".spec/registry/manifest.json" ]] && command -v jq >/dev/null 2>&1; the
         sort -t'|' -k1,1 -k3 -rn "$TMPDIR_SCAN/spec-annotation-gaps.txt" \
             -o "$TMPDIR_SCAN/spec-annotation-gaps.txt" 2>/dev/null || true
 
-        # Cap both files at 20 rows each for summary sanity
+        # Cap files at 20 rows each for summary sanity
         head -20 "$TMPDIR_SCAN/spec-annotation-gaps.txt" > "$TMPDIR_SCAN/spec-annotation-gaps.capped.txt" 2>/dev/null || true
         mv "$TMPDIR_SCAN/spec-annotation-gaps.capped.txt" "$TMPDIR_SCAN/spec-annotation-gaps.txt"
         head -20 "$TMPDIR_SCAN/spec-unannotated.txt" > "$TMPDIR_SCAN/spec-unannotated.capped.txt" 2>/dev/null || true
         mv "$TMPDIR_SCAN/spec-unannotated.capped.txt" "$TMPDIR_SCAN/spec-unannotated.txt"
+        head -20 "$TMPDIR_SCAN/spec-bare-only.txt" > "$TMPDIR_SCAN/spec-bare-only.capped.txt" 2>/dev/null || true
+        mv "$TMPDIR_SCAN/spec-bare-only.capped.txt" "$TMPDIR_SCAN/spec-bare-only.txt"
     fi
 fi
 
@@ -1391,8 +1470,8 @@ if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
         body_chars=${#body}
         body_tokens_k=$(( body_chars / 4 / 1000 ))
 
-        # Count R-numbered requirements (RN, RNa form supported).
-        reqs_count=$(grep -cE '^R[0-9]+[a-z]?\.' <<< "$body" || true)
+        # Count R-numbered requirements (RN, RNa, RNa-1 / RN-1 forms).
+        reqs_count=$(grep -cE '^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\.' <<< "$body" || true)
 
         # Below either size threshold → not a candidate.
         if (( reqs_count < SUBDIV_MIN_REQS )) && (( body_tokens_k < SUBDIV_MIN_TOKENS_K )); then
@@ -1429,7 +1508,7 @@ if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
                     current_section="$hdr"
                     section_req_count["$current_section"]=${section_req_count["$current_section"]:-0}
                 fi
-            elif [[ -n "$current_section" ]] && [[ "$line" =~ ^R[0-9]+[a-z]?\. ]]; then
+            elif [[ -n "$current_section" ]] && [[ "$line" =~ ^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\. ]]; then
                 section_req_count["$current_section"]=$(( ${section_req_count["$current_section"]:-0} + 1 ))
             fi
         done <<< "$body"
@@ -1849,7 +1928,7 @@ fi
 
 # Spec annotation gaps (Analysis 18)
 has_ann_signals=0
-if [[ -s "$TMPDIR_SCAN/spec-annotation-gaps.txt" ]] || [[ -s "$TMPDIR_SCAN/spec-unannotated.txt" ]]; then
+if [[ -s "$TMPDIR_SCAN/spec-annotation-gaps.txt" ]] || [[ -s "$TMPDIR_SCAN/spec-unannotated.txt" ]] || [[ -s "$TMPDIR_SCAN/spec-bare-only.txt" ]]; then
     echo "## Spec Annotation Coverage Gaps" >> "$SUMMARY_FILE"
     echo "APPROVED specs where @spec annotations are missing on implementation or test side." >> "$SUMMARY_FILE"
     echo "Route to \`/spec-verify\` to add missing annotations, write missing tests, or accept gaps with justification." >> "$SUMMARY_FILE"
@@ -1871,12 +1950,22 @@ if [[ -s "$TMPDIR_SCAN/spec-annotation-gaps.txt" ]]; then
 fi
 
 if [[ -s "$TMPDIR_SCAN/spec-unannotated.txt" ]]; then
-    echo "### APPROVED specs with no annotations at all" >> "$SUMMARY_FILE"
-    echo "Specs where \`spec-trace\` found zero \`@spec\` references in source or test files." >> "$SUMMARY_FILE"
+    echo "### APPROVED specs with no @spec annotations of any kind" >> "$SUMMARY_FILE"
+    echo "Specs where source contains zero \`@spec\` references — neither bare nor R-suffixed." >> "$SUMMARY_FILE"
     echo "" >> "$SUMMARY_FILE"
     while IFS='|' read -r _ sid; do
         echo "- $sid — no \`@spec\` annotations found anywhere" >> "$SUMMARY_FILE"
     done < "$TMPDIR_SCAN/spec-unannotated.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+if [[ -s "$TMPDIR_SCAN/spec-bare-only.txt" ]]; then
+    echo "### APPROVED specs with bare-only @spec annotations" >> "$SUMMARY_FILE"
+    echo "Specs annotated only by spec-id (e.g. \`@spec engine.handle-lifecycle\`) without per-requirement (\`.R<n>\`) granularity. Implementation is associated with the spec, but R-level coverage cannot be traced. Remediation: refine existing annotations rather than add from scratch." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ sid; do
+        echo "- $sid — bare annotations exist; add \`.R<n>\` for per-requirement traceability" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/spec-bare-only.txt"
     echo "" >> "$SUMMARY_FILE"
 fi
 
@@ -1942,6 +2031,7 @@ echo "  Stalled work groups: $(wc -l < "$TMPDIR_SCAN/work-stalled.txt" 2>/dev/nu
 echo "  Work artifact drift: $(wc -l < "$TMPDIR_SCAN/work-drift.txt" 2>/dev/null || echo 0)"
 echo "  Spec annotation gaps: $(wc -l < "$TMPDIR_SCAN/spec-annotation-gaps.txt" 2>/dev/null || echo 0)"
 echo "  Unannotated APPROVED specs: $(wc -l < "$TMPDIR_SCAN/spec-unannotated.txt" 2>/dev/null || echo 0)"
+echo "  Bare-only annotated specs: $(wc -l < "$TMPDIR_SCAN/spec-bare-only.txt" 2>/dev/null || echo 0)"
 echo "  Aging obligations: $(wc -l < "$TMPDIR_SCAN/aging-obligations.txt" 2>/dev/null || echo 0)"
 echo "  Subdivision candidates: $(wc -l < "$TMPDIR_SCAN/spec-subdivision-candidates.txt" 2>/dev/null || echo 0)"
 

--- a/scripts/index-verify.sh
+++ b/scripts/index-verify.sh
@@ -191,10 +191,79 @@ if [[ "$CHECK_DECISIONS" == "1" && -d ".decisions" && -f ".decisions/CLAUDE.md" 
         fi
     done < <(find .decisions -name 'adr.md' 2>/dev/null)
 
-    # Enforce 80-line cap and overflow to history.md
+    # Enforce 80-line cap by overflowing oldest "Recently Accepted" rows to
+    # history.md. Until v0.16.x this was a warn-and-proceed: the index grew
+    # unbounded after auto-repair (e.g. 46 reconstructed ADRs → 151 lines).
+    # The cap exists because this file is loaded into context on demand —
+    # silent growth burns tokens. The seed CLAUDE.md documents "Once this
+    # section exceeds 5 rows, oldest row moves to history.md"; this code
+    # enforces it.
+    #
+    # Tunable: VALLORCINE_DECISIONS_KEEP (default 5) controls how many
+    # most-recent rows stay in the index before overflow kicks in.
     line_count="$(wc -l < ".decisions/CLAUDE.md")"
     if [[ "$line_count" -gt 80 ]]; then
-        [[ "$QUIET" != "1" ]] && echo "  ⚠ Decisions index: over 80-line cap ($line_count lines) — overflow to history.md needed"
+        keep="${VALLORCINE_DECISIONS_KEEP:-5}"
+        ra_start="$(grep -n '^## Recently Accepted' '.decisions/CLAUDE.md' 2>/dev/null | head -1 | cut -d: -f1)"
+        if [[ -n "$ra_start" ]]; then
+            # Section bounds: ra_start through the line before the next "^## "
+            # heading, or EOF. The found flag ensures END only fires when
+            # the loop exits without hitting another heading (EOF case);
+            # otherwise the inline-print + END would double-emit.
+            ra_end="$(awk -v s="$ra_start" '
+                NR>s && /^## /{print NR-1; found=1; exit}
+                END{if (!found) print NR}
+            ' '.decisions/CLAUDE.md')"
+            # Find table separator within section
+            sep_line="$(awk -v s="$ra_start" -v e="$ra_end" 'NR>=s && NR<=e && /^\|----/{print NR; exit}' '.decisions/CLAUDE.md')"
+
+            if [[ -n "$sep_line" && -n "$ra_end" ]]; then
+                # Row line numbers: between sep and end, starting with "| "
+                mapfile -t row_nums < <(awk -v s="$sep_line" -v e="$ra_end" 'NR>s && NR<=e && /^\| / {print NR}' '.decisions/CLAUDE.md')
+                total="${#row_nums[@]}"
+                if (( total > keep )); then
+                    overflow_count=$(( total - keep ))
+                    # Rows are stored newest-first (auto-repair inserts right
+                    # after the separator). Overflow the LAST `overflow_count`
+                    # rows = oldest by insertion order.
+                    first_overflow_idx=$(( total - overflow_count ))
+                    first_line="${row_nums[$first_overflow_idx]}"
+                    last_line="${row_nums[$((total - 1))]}"
+
+                    overflow_rows="$(sed -n "${first_line},${last_line}p" '.decisions/CLAUDE.md')"
+
+                    # Append to history.md (create with header on first overflow).
+                    if [[ ! -f '.decisions/history.md' ]]; then
+                        cat > '.decisions/history.md' << 'HISTEOF'
+# Decision History
+
+Archived ADRs that overflowed from `CLAUDE.md` once the index exceeded its
+80-line cap. Newest archived first within each batch; batches accumulate
+oldest-first overall.
+
+## Archived from Recently Accepted
+
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+HISTEOF
+                    fi
+                    printf '%s\n' "$overflow_rows" >> '.decisions/history.md'
+
+                    # Delete the overflowed range from CLAUDE.md.
+                    sed -i "${first_line},${last_line}d" '.decisions/CLAUDE.md'
+
+                    ((REPAIRED++)) || true
+                    [[ "$QUIET" != "1" ]] && \
+                        echo "  ⚠ Decisions index: archived $overflow_count Recently Accepted rows to history.md (kept $keep newest)"
+                fi
+            fi
+        fi
+
+        # Recheck after overflow attempt.
+        line_count="$(wc -l < ".decisions/CLAUDE.md")"
+        if [[ "$line_count" -gt 80 && "$QUIET" != "1" ]]; then
+            echo "  ⚠ Decisions index: still $line_count lines after Recently Accepted overflow — review Active/Deferred/Closed sections manually"
+        fi
     fi
 fi
 

--- a/scripts/spec-ambiguity-score.sh
+++ b/scripts/spec-ambiguity-score.sh
@@ -100,9 +100,9 @@ fi
 
 # ── Counters ─────────────────────────────────────────────────────────────────
 
-# Requirement count: lines starting with R<digits>. (allowing optional letter
-# suffix like R3a)
-TOTAL_REQS=$(echo "$SECTION_CONTENT" | grep -cE '^R[0-9]+[a-z]?\.' || true)
+# Requirement count: lines starting with R<digits>. (allowing letter suffix
+# like R3a, plus hyphenated sub-numbers like R3a-1 / R83-1)
+TOTAL_REQS=$(echo "$SECTION_CONTENT" | grep -cE '^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\.' || true)
 
 # Red-flag markers (case-sensitive by convention).
 UNVERIFIED=$(echo "$SECTION_CONTENT" | grep -cE '\[UNVERIFIED' || true)

--- a/scripts/spec-lib.sh
+++ b/scripts/spec-lib.sh
@@ -295,9 +295,9 @@ spec_invalidates_check() {
   local manifest="$1" ref="$2"
   local sid req_num
   # Strip the trailing .RN[a] to get the spec ID (works for both forms).
-  sid=$(echo "$ref" | sed -E 's/\.R[0-9]+[a-z]?$//')
-  # Capture the trailing R-number (with optional letter suffix).
-  req_num=$(echo "$ref" | grep -oE 'R[0-9]+[a-z]?$' || true)
+  sid=$(echo "$ref" | sed -E 's/\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?$//')
+  # Capture the trailing R-number (optional letter suffix, optional -<digits>[letters]).
+  req_num=$(echo "$ref" | grep -oE 'R[0-9]+[a-z]*(-[0-9]+[a-z]*)?$' || true)
   if [[ -z "$sid" || -z "$req_num" || "$sid" == "$ref" ]]; then
     echo "  FAIL invalidates '$ref': cannot parse as <spec-id>.RN (e.g. F01.R3 or schema.field-access.R3)" >&2
     return 1

--- a/scripts/spec-resolve.sh
+++ b/scripts/spec-resolve.sh
@@ -341,7 +341,7 @@ for f in "${ALL_FILES[@]+"${ALL_FILES[@]}"}"; do
     [[ -z "$inv_ref" ]] && continue
     # Strip trailing .RN to get the target spec ID. Works for both
     # FXX.RN (→ FXX) and domain.slug.RN (→ domain.slug).
-    target_id=$(echo "$inv_ref" | sed -E 's/\.R[0-9]+[a-z]?$//')
+    target_id=$(echo "$inv_ref" | sed -E 's/\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?$//')
     [[ -z "$target_id" ]] && continue
     if [[ -n "${INCLUDED_IDS[$target_id]+x}" ]]; then
       CONFLICTS+="INVALIDATES: $src_id invalidates $inv_ref, but $target_id is also in this bundle"$'\n'

--- a/scripts/spec-split.sh
+++ b/scripts/spec-split.sh
@@ -136,19 +136,34 @@ replay_rollback() {
     fi
   done < <(jq -r '.children_created[]' "$log")
 
-  # Reverse @spec annotation rewrites.
-  while IFS= read -r rewrite; do
-    [[ -z "$rewrite" ]] && continue
-    local file from_text to_text
-    file="$(jq -r '.file' <<< "$rewrite")"
-    from_text="$(jq -r '.to' <<< "$rewrite")"   # "to" was applied; reverse to "from"
-    to_text="$(jq -r '.from' <<< "$rewrite")"
-    if [[ -f "$file" ]]; then
-      # Use a delimiter unlikely to appear in identifiers: |
-      sed -i "s|${from_text}|${to_text}|g" "$file"
-      echo "  unrewrote: $file (${from_text} → ${to_text})" >&2
-    fi
-  done < <(jq -c '.annotation_rewrites[]?' "$log")
+  # Restore source files. Prefer file snapshots (added in v0.16.x) since they
+  # round-trip the compound-annotation explosion pass; fall back to per-rewrite
+  # sed reversal for legacy logs that predate snapshots.
+  local snap_count
+  snap_count="$(jq '.annotation_file_snapshots // [] | length' "$log")"
+  if [[ "$snap_count" -gt 0 ]]; then
+    local i
+    for ((i=0; i<snap_count; i++)); do
+      local sf
+      sf="$(jq -r ".annotation_file_snapshots[$i].file" "$log")"
+      [[ -z "$sf" || "$sf" == "null" ]] && continue
+      jq -r ".annotation_file_snapshots[$i].content" "$log" > "$sf"
+      echo "  restored: $sf (snapshot)" >&2
+    done
+  else
+    while IFS= read -r rewrite; do
+      [[ -z "$rewrite" ]] && continue
+      local file from_text to_text
+      file="$(jq -r '.file' <<< "$rewrite")"
+      from_text="$(jq -r '.to' <<< "$rewrite")"   # "to" was applied; reverse to "from"
+      to_text="$(jq -r '.from' <<< "$rewrite")"
+      if [[ -f "$file" ]]; then
+        # Use a delimiter unlikely to appear in identifiers: |
+        sed -i "s|${from_text}|${to_text}|g" "$file"
+        echo "  unrewrote: $file (${from_text} → ${to_text})" >&2
+      fi
+    done < <(jq -c '.annotation_rewrites[]?' "$log")
+  fi
 
   echo "[split] Rollback complete." >&2
   return 0
@@ -176,8 +191,12 @@ PARENT_FILE="$(spec_file_for_id "$MANIFEST" "$PARENT_ID")"
 
 # ── Parse parent's R-numbers from machine section ────────────────────────────
 
+# R-number forms recognized:
+#   R10, R37b, R37b-1, R83-1, R71b-2 — base + optional letter(s) + optional -digit[letters]
+# Hyphenated/sub-numbered Rs are first-class claims, not continuation prose;
+# they get their own block during the carve.
 mapfile -t PARENT_R_NUMBERS < <(machine_section "$PARENT_FILE" \
-  | grep -oE '^R[0-9]+[a-z]?\.' \
+  | grep -oE '^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\.' \
   | sed 's/\.$//' \
   | sort -u)
 
@@ -295,6 +314,20 @@ declare -A ANNOTATION_REWRITES_TO=()
 declare -A ANNOTATION_REWRITES_FILE=()
 REWRITE_INDEX=0
 
+# Per-file content snapshots taken just before any source-file modification.
+# This is the primary rollback mechanism for the @spec sweep: it survives the
+# compound-annotation explosion pass (which can rewrite multiple lines on a
+# single source line) where line-level rewrite reversal would not. The
+# annotation_rewrites array is preserved alongside it for inspection only.
+declare -A FILE_SNAPSHOTS=()  # key=path, val=original content (before any sweep edit)
+
+snapshot_source_file() {
+  local file="$1"
+  if [[ -z "${FILE_SNAPSHOTS[$file]+x}" ]]; then
+    FILE_SNAPSHOTS["$file"]="$(cat "$file")"
+  fi
+}
+
 # Write initial rollback log (we'll rewrite at the end with full state).
 emit_rollback_log() {
   jq -n \
@@ -318,6 +351,16 @@ emit_rollback_log() {
         echo '[]'
       fi
     )" \
+    --argjson file_snapshots "$(
+      if (( ${#FILE_SNAPSHOTS[@]} > 0 )); then
+        for k in "${!FILE_SNAPSHOTS[@]}"; do
+          jq -n --arg file "$k" --arg content "${FILE_SNAPSHOTS[$k]}" \
+            '{file: $file, content: $content}'
+        done | jq -s .
+      else
+        echo '[]'
+      fi
+    )" \
     '{
       parent_id: $parent_id,
       parent_path: $parent_path,
@@ -326,7 +369,8 @@ emit_rollback_log() {
       manifest_snapshot: $manifest_snapshot,
       timestamp: $timestamp,
       children_created: $children_created,
-      annotation_rewrites: $rewrites
+      annotation_rewrites: $rewrites,
+      annotation_file_snapshots: $file_snapshots
     }' > "$ROLLBACK_LOG"
 }
 
@@ -341,7 +385,7 @@ extract_requirement_block() {
   local body="$1" rn="$2"
   awk -v target="$rn" '
     BEGIN { in_target = 0 }
-    /^R[0-9]+[a-z]?\./ {
+    /^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\./ {
       if (in_target) exit
       # Match "Rxx." prefix exactly (Rxx followed by .)
       if (substr($0, 1, length(target) + 1) == target".") {
@@ -387,7 +431,7 @@ PARENT_PRENARRATIVE="$(awk '
 
 # Recompute pre/R/post split from machine_section content.
 PARENT_PRENARRATIVE="$(awk '
-  /^R[0-9]+[a-z]?\./ { exit }
+  /^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\./ { exit }
   { print }
 ' <<< "$PARENT_BODY")"
 
@@ -570,8 +614,20 @@ $post_narrative"
         | .generated_at = (now | todate)
        ' "$manifest_tmp" > "$next_tmp" && mv "$next_tmp" "$manifest_tmp"
   done
+
+  # Sync parent's manifest entry version to match its on-disk version (which
+  # we just bumped). The manifest entry is the canonical source of truth for
+  # downstream tooling (curate, spec-trace) and silently lagging from the
+  # file's own frontmatter is a correctness bug, not a stylistic one.
+  local sync_tmp
+  sync_tmp="$(mktemp)"
+  jq --arg pid "$PARENT_ID" \
+     --argjson pv "$((PARENT_VERSION + 1))" \
+     '.specs = (.specs | map(if .id == $pid then .version = $pv else . end))' \
+     "$manifest_tmp" > "$sync_tmp" && mv "$sync_tmp" "$manifest_tmp"
+
   mv "$manifest_tmp" "$MANIFEST"
-  echo "  manifest: added $CHILD_COUNT child entries" >&2
+  echo "  manifest: added $CHILD_COUNT child entries; parent bumped to v$((PARENT_VERSION + 1))" >&2
 
   # Step 6: sweep @spec annotations for moved requirements.
   rewrite_annotations
@@ -597,6 +653,17 @@ rewrite_annotations() {
     return 0
   fi
   echo "[split] @spec rewrite scan: ${scan_dirs[*]}" >&2
+
+  # Pre-pass: explode compound `@spec PARENT.R1,R2[,R3]` annotations into one
+  # annotation per R on consecutive lines. Without this, the per-R sed below
+  # rewrites only the first R's prefix and leaves the rest dangling under
+  # the wrong child. Example:
+  #   Before: // @spec query.foo.R10,R42
+  #   Pass for R10 (lexer child) finds the literal "query.foo.R10" via [^A-Z0-9]
+  #   match (the ',' qualifies), rewrites to "// @spec query.foo.lexer.R10,R42"
+  #   leaving R42 incorrectly prefixed with "lexer".
+  # The explosion guarantees each per-R sed sees a single isolated R.
+  explode_compound_annotations "${scan_dirs[@]}"
 
   # For each child, for each moved requirement, rewrite annotations.
   for ((i=0; i<CHILD_COUNT; i++)); do
@@ -630,10 +697,13 @@ rewrite_annotations() {
 
       for hit in "${hits[@]}"; do
         [[ -z "$hit" ]] && continue
+        snapshot_source_file "$hit"
         # Use sed with | delimiter (file paths may contain /).
         # Anchor: from_anno followed by a non-identifier character or EOL,
         # so we don't accidentally match `parent.R1` when intending `parent.R12`.
-        sed -i -E "s|${from_anno}([^A-Za-z0-9])|${to_anno}\1|g; s|${from_anno}\$|${to_anno}|g" "$hit"
+        # The character class includes `-` as a literal (last position) so
+        # sub-numbered Rs like R37b-1 aren't accidentally split mid-token.
+        sed -i -E "s|${from_anno}([^A-Za-z0-9-])|${to_anno}\1|g; s|${from_anno}\$|${to_anno}|g" "$hit"
         ANNOTATION_REWRITES_FILE[$REWRITE_INDEX]="$hit"
         ANNOTATION_REWRITES_FROM[$REWRITE_INDEX]="$from_anno"
         ANNOTATION_REWRITES_TO[$REWRITE_INDEX]="$to_anno"
@@ -645,6 +715,74 @@ rewrite_annotations() {
 
   # Update rollback log with the rewrite list.
   emit_rollback_log
+}
+
+# ── Compound annotation explosion ────────────────────────────────────────────
+# Walks each candidate file, finds `@spec PARENT_ID.<R-list>` lines where
+# <R-list> contains a comma, and rewrites them to one annotation per R on
+# consecutive lines. Indentation, comment prefix, and trailing text are
+# preserved on every emitted line. Files are snapshotted before modification
+# so the rollback log can restore them to their pre-sweep state.
+explode_compound_annotations() {
+  local scan_dirs=("$@")
+
+  # Find candidate files: anything with `@spec PARENT.R...,R...` (a comma in
+  # the R-list immediately after the parent prefix).
+  mapfile -t candidates < <(
+    grep -rlE --binary-files=without-match \
+      "@spec ${PARENT_ID//./\\.}\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?,R" "${scan_dirs[@]}" \
+      --include='*.java' --include='*.py' --include='*.js' \
+      --include='*.ts' --include='*.go' --include='*.rs' \
+      --include='*.kt' --include='*.scala' --include='*.c' \
+      --include='*.cpp' --include='*.h' --include='*.hpp' \
+      --include='*.cs' --include='*.rb' --include='*.swift' \
+      --include='*.m' --include='*.sh' \
+      --exclude-dir='test' --exclude-dir='tests' \
+      --exclude-dir='__tests__' --exclude-dir='spec' \
+      --exclude-dir='node_modules' --exclude-dir='vendor' \
+      --exclude-dir='target' --exclude-dir='build' --exclude-dir='dist' \
+      2>/dev/null || true
+  )
+
+  if (( ${#candidates[@]} == 0 )); then
+    return 0
+  fi
+
+  for file in "${candidates[@]}"; do
+    [[ -z "$file" ]] && continue
+    snapshot_source_file "$file"
+    local tmp="${file}.split-explode.tmp"
+    awk -v parent="$PARENT_ID" '
+      BEGIN { tag = "@spec " parent "." }
+      {
+        i = index($0, tag)
+        if (i == 0) { print; next }
+        before = substr($0, 1, i - 1)
+        rest = substr($0, i + length(tag))
+        # Walk the R-list; legal chars in an R-name + comma separator.
+        rlist_end = 0
+        for (j = 1; j <= length(rest); j++) {
+          c = substr(rest, j, 1)
+          if (c ~ /[A-Za-z0-9,-]/) {
+            rlist_end = j
+          } else {
+            break
+          }
+        }
+        if (rlist_end == 0) { print; next }
+        rlist = substr(rest, 1, rlist_end)
+        trailing = substr(rest, rlist_end + 1)
+        if (index(rlist, ",") == 0) { print; next }
+        n = split(rlist, rs, ",")
+        for (k = 1; k <= n; k++) {
+          if (rs[k] == "") continue
+          print before tag rs[k] trailing
+        }
+      }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+    echo "  @spec exploded: $file (compound → per-R lines)" >&2
+  done
 }
 
 # ── Validation gate ──────────────────────────────────────────────────────────

--- a/scripts/spec-trace.sh
+++ b/scripts/spec-trace.sh
@@ -152,7 +152,7 @@ while IFS= read -r line; do
 
   # Extract refs for our spec: <SPEC_ID>.RN[,RN,RN]
   # SPEC_ID_RE has dots regex-escaped so domain.slug ids match literally.
-  our_refs=$(echo "$spec_portion" | grep -oE "${SPEC_ID_RE}\\.R[0-9]+[a-z]?(,R[0-9]+[a-z]?)*" || true)
+  our_refs=$(echo "$spec_portion" | grep -oE "${SPEC_ID_RE}\\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?(,R[0-9]+[a-z]*(-[0-9]+[a-z]*)?)*" || true)
 
   for ref_group in $our_refs; do
     # ref_group is like "<spec>.R1,R3,R7" or "<spec>.R1"
@@ -161,7 +161,7 @@ while IFS= read -r line; do
     IFS=',' read -ra req_ids <<< "$req_part"
     for rid in "${req_ids[@]}"; do
       # Normalize: ensure it looks like Rn or Rn<letter>
-      if echo "$rid" | grep -qE '^R[0-9]+[a-z]?$'; then
+      if echo "$rid" | grep -qE '^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?$'; then
         full_ref="${SPEC_ID}.${rid}"
 
         # Track unique requirements

--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -85,7 +85,7 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
   #                          (letter-suffix RNs like R51a are supported;
   #                           multi-dot IDs are nested specs.)
   spec_id_re='^(F[0-9]+|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)$'
-  spec_ref_re='^(F[0-9]+|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)\.R[0-9]+[a-z]?$'
+  spec_ref_re='^(F[0-9]+|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?$'
 
   # ── Check 7: invalidates[] format AND target existence
   while IFS= read -r inv; do
@@ -240,7 +240,7 @@ fi
 # ── Check 11: numbered requirements exist in machine section
 # Here-string instead of pipe — see 9b above for SIGPIPE rationale.
 machine=$(machine_section "$FILE")
-if ! grep -qE '^R[0-9]+\.' <<< "$machine"; then
+if ! grep -qE '^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\.' <<< "$machine"; then
   ERRORS+=("No numbered requirements found in machine section (expected R1. R2. format)")
 fi
 

--- a/tests/scenario-curate-drift.sh
+++ b/tests/scenario-curate-drift.sh
@@ -224,7 +224,9 @@ else
 fi
 
 # ── Test: Unannotated-spec section appears ──────────────────────────────────
-if echo "$gap_section" | grep -q "APPROVED specs with no annotations at all"; then
+# Heading was renamed in v0.16.x to distinguish from the new "bare-only"
+# class introduced alongside it.
+if echo "$gap_section" | grep -q "APPROVED specs with no @spec annotations of any kind"; then
     pass "unannotated-spec subsection present"
 else
     fail "should list schema.unannotated as fully unannotated" "section: $gap_section"

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -1067,6 +1067,282 @@ fi
 rm -rf "$OB_TEST_DIR" 2>/dev/null || true
 cd "$REPO_ROOT"
 
+# ── Test 29: Empty open_obligations frontmatter is NOT flagged ───────────────
+# Regression: prior shell-based stripper false-positived on every spec whose
+# frontmatter contained `open_obligations: []` (the array's punctuation
+# survived `tr -d '[]"'` and registered as content). Real-world impact:
+# "specs with open obligations" reported ~all specs, drowning the real signal.
+
+echo ""
+echo "── Test 29: Empty open_obligations frontmatter must not be flagged"
+
+EMPTY_OB_DIR="/tmp/vallorcine/scenario-empty-ob"
+rm -rf "$EMPTY_OB_DIR" 2>/dev/null || true
+mkdir -p "$EMPTY_OB_DIR/.spec/domains/engine" "$EMPTY_OB_DIR/.spec/registry" \
+         "$EMPTY_OB_DIR/.curate" "$EMPTY_OB_DIR/.claude/scripts"
+cp "$REPO_ROOT/scripts/curate-scan.sh" "$EMPTY_OB_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$EMPTY_OB_DIR/.claude/scripts/"
+
+cd "$EMPTY_OB_DIR"
+git init -q .
+git config user.email t@t.com && git config user.name t
+
+# Spec with explicit `open_obligations: []` in frontmatter — must NOT be
+# flagged. This is the exact convention that caused the false-positive.
+cat > .spec/domains/engine/empty-ob.md << 'SPECEOF'
+---
+{
+  "id": "engine.empty-ob",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["engine"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": [],
+  "open_obligations": []
+}
+---
+
+# engine.empty-ob
+
+R1. A normal requirement.
+SPECEOF
+
+# Spec with a populated open_obligations array — MUST be flagged.
+cat > .spec/domains/engine/real-ob.md << 'SPECEOF'
+---
+{
+  "id": "engine.real-ob",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["engine"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": [],
+  "open_obligations": ["needs ADR on retry budget"]
+}
+---
+
+# engine.real-ob
+
+R1. Requires retry budget decision.
+SPECEOF
+
+cat > .spec/registry/manifest.json << 'MFEOF'
+{"schema_version": 2, "spec_count": 2,
+ "specs": [
+   {"id":"engine.empty-ob","path":".spec/domains/engine/empty-ob.md","state":"APPROVED","version":1,"domains":["engine"],"requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+   {"id":"engine.real-ob","path":".spec/domains/engine/real-ob.md","state":"APPROVED","version":1,"domains":["engine"],"requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]}
+ ]}
+MFEOF
+
+git add -A && git commit -q -m "init"
+
+if command -v jq >/dev/null 2>&1; then
+    bash .claude/scripts/curate-scan.sh --init >/tmp/curate-empty-ob.out 2>&1 || true
+
+    # Note: the obligations report uses the spec file basename (not the
+    # full id), so empty-ob / real-ob are the table keys.
+    if grep -qE '^\| empty-ob \|' .curate/scan-summary.md 2>/dev/null; then
+        fail "empty open_obligations:[] flagged as having obligations" \
+             "$(grep 'open obligation' -A 5 .curate/scan-summary.md | head -10)"
+    else
+        pass "empty open_obligations:[] not flagged"
+    fi
+
+    if grep -qE '^\| real-ob \|' .curate/scan-summary.md 2>/dev/null; then
+        pass "populated open_obligations correctly flagged"
+    else
+        fail "real obligation should be flagged" \
+             "$(grep 'open obligation' -A 5 .curate/scan-summary.md | head -10)"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+rm -rf "$EMPTY_OB_DIR" 2>/dev/null || true
+cd "$REPO_ROOT"
+
+# ── Test 30: JDK types blocklisted from unspecified-shared-types ─────────────
+# Regression: IllegalArgumentException, NullPointerException, etc. dominated
+# the "unspecified shared types" report on real codebases (JDK exceptions are
+# referenced in nearly every spec). The blocklist drops them so genuine
+# project value-types surface above the noise.
+
+echo ""
+echo "── Test 30: JDK types blocklisted from unspecified shared types"
+
+JDK_DIR="/tmp/vallorcine/scenario-jdk-blocklist"
+rm -rf "$JDK_DIR" 2>/dev/null || true
+mkdir -p "$JDK_DIR/.spec/domains/engine" "$JDK_DIR/.curate" "$JDK_DIR/.claude/scripts"
+cp "$REPO_ROOT/scripts/curate-scan.sh" "$JDK_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$JDK_DIR/.claude/scripts/"
+
+cd "$JDK_DIR"
+git init -q .
+git config user.email t@t.com && git config user.name t
+
+# Three specs each referencing the same JDK exception types AND a real
+# project value type. The JDK types should be filtered out; VectorType
+# should surface as an unspecified shared type.
+for n in 1 2 3 4; do
+  cat > ".spec/domains/engine/spec$n.md" <<SPECEOF
+---
+{
+  "id": "engine.spec$n",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["engine"],
+  "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []
+}
+---
+
+# engine.spec$n
+
+R1. Throws IllegalArgumentException on bad input.
+R2. Returns NullPointerException for missing data.
+R3. Validates IllegalStateException on guard.
+R4. Operates on VectorType payload.
+R5. Manages BoundedString reference.
+SPECEOF
+done
+
+git add -A && git commit -q -m "init"
+
+bash .claude/scripts/curate-scan.sh --init >/tmp/curate-jdk.out 2>&1 || true
+
+# JDK types should NOT appear under "Unspecified shared types"
+if grep -A 50 "### Unspecified shared types" .curate/scan-summary.md 2>/dev/null \
+   | grep -E '^\| (IllegalArgumentException|NullPointerException|IllegalStateException) '; then
+    fail "JDK exceptions leaked into unspecified shared types" \
+         "$(grep -A 30 'Unspecified shared types' .curate/scan-summary.md | head -20)"
+else
+    pass "JDK exception types blocklisted from unspecified shared types"
+fi
+
+# Real project type SHOULD appear (referenced by all 4 specs ≥ 3 threshold)
+if grep -A 50 "### Unspecified shared types" .curate/scan-summary.md 2>/dev/null \
+   | grep -qE '^\| VectorType '; then
+    pass "real shared type (VectorType) still surfaces above blocklist filter"
+else
+    fail "VectorType should appear in unspecified shared types" \
+         "$(grep -A 30 'Unspecified shared types' .curate/scan-summary.md | head -20)"
+fi
+
+rm -rf "$JDK_DIR" 2>/dev/null || true
+cd "$REPO_ROOT"
+
+# ── Test 31: Bare-only @spec annotations classified separately ───────────────
+# Regression: previously, specs with only bare `@spec engine.foo` annotations
+# (no R-suffix) were lumped into "no @spec annotations at all". The
+# remediation differs (refine vs. add) so they need their own gap class.
+
+echo ""
+echo "── Test 31: Bare-only annotations distinct from no-annotations"
+
+BARE_DIR="/tmp/vallorcine/scenario-bare-only"
+rm -rf "$BARE_DIR" 2>/dev/null || true
+mkdir -p "$BARE_DIR/.spec/domains/engine" "$BARE_DIR/.spec/registry" \
+         "$BARE_DIR/.curate" "$BARE_DIR/.claude/scripts" "$BARE_DIR/src"
+cp "$REPO_ROOT/scripts/curate-scan.sh" "$BARE_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$BARE_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-trace.sh" "$BARE_DIR/.claude/scripts/"
+
+cd "$BARE_DIR"
+git init -q .
+git config user.email t@t.com && git config user.name t
+
+# Spec A: source has bare @spec engine.bare-anno (no R-suffix)
+cat > .spec/domains/engine/bare-anno.md << 'SPECEOF'
+---
+{
+  "id": "engine.bare-anno",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["engine"],
+  "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []
+}
+---
+
+# engine.bare-anno
+
+R1. Some requirement.
+SPECEOF
+
+# Spec B: source has nothing referencing it at all.
+cat > .spec/domains/engine/nothing.md << 'SPECEOF'
+---
+{
+  "id": "engine.nothing",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["engine"],
+  "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []
+}
+---
+
+# engine.nothing
+
+R1. Some requirement.
+SPECEOF
+
+cat > src/Bare.java << 'JEOF'
+// @spec engine.bare-anno — bare reference, no R suffix
+public class Bare {}
+JEOF
+
+cat > .spec/registry/manifest.json << 'MFEOF'
+{"schema_version": 2, "spec_count": 2,
+ "specs": [
+   {"id":"engine.bare-anno","path":".spec/domains/engine/bare-anno.md","state":"APPROVED","version":1,"domains":["engine"],"requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+   {"id":"engine.nothing","path":".spec/domains/engine/nothing.md","state":"APPROVED","version":1,"domains":["engine"],"requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]}
+ ]}
+MFEOF
+
+git add -A && git commit -q -m "init"
+
+if command -v jq >/dev/null 2>&1; then
+    bash .claude/scripts/curate-scan.sh --init >/tmp/curate-bare.out 2>&1 || true
+
+    # bare-anno should appear in BARE_ONLY section
+    if grep -A 10 "specs with bare-only @spec annotations" .curate/scan-summary.md 2>/dev/null \
+       | grep -q "engine.bare-anno"; then
+        pass "spec with bare @spec anno classified as BARE_ONLY"
+    else
+        fail "bare-anno should appear in bare-only section" \
+             "$(grep -A 5 -E 'bare|annotations' .curate/scan-summary.md | head -30)"
+    fi
+
+    # nothing should appear in UNANNOTATED section
+    if grep -A 10 "no @spec annotations of any kind" .curate/scan-summary.md 2>/dev/null \
+       | grep -q "engine.nothing"; then
+        pass "spec with no annotations classified as UNANNOTATED"
+    else
+        fail "engine.nothing should appear in no-annotations section" \
+             "$(grep -A 5 -E 'no.*annotations|of any kind' .curate/scan-summary.md | head -30)"
+    fi
+
+    # nothing should NOT appear in BARE_ONLY
+    if grep -A 10 "specs with bare-only @spec annotations" .curate/scan-summary.md 2>/dev/null \
+       | grep -q "engine.nothing"; then
+        fail "engine.nothing leaked into BARE_ONLY (false positive)"
+    else
+        pass "no-annotations spec stays out of BARE_ONLY"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+rm -rf "$BARE_DIR" 2>/dev/null || true
+cd "$REPO_ROOT"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/scenario-index-verify.sh
+++ b/tests/scenario-index-verify.sh
@@ -314,6 +314,173 @@ else
     fail "cache-strategy should be in Deferred section, not elsewhere"
 fi
 
+# ── Test 9: Recently Accepted overflows to history.md when over cap ─────────
+# Regression: prior to v0.16.x, when auto-repair stacked many "confirmed"
+# ADRs into Recently Accepted, the file blew the 80-line cap and the script
+# only warned. The cap exists because CLAUDE.md is loaded into context;
+# silent growth burns tokens. Overflow keeps the newest rows in the index
+# and archives the rest to history.md.
+
+echo ""
+echo "── Test 9: Recently Accepted overflows to history.md when over 80-line cap"
+
+OVERFLOW_DIR="/tmp/vallorcine/scenario-overflow"
+rm -rf "$OVERFLOW_DIR" 2>/dev/null || true
+mkdir -p "$OVERFLOW_DIR/.claude/scripts" "$OVERFLOW_DIR/.decisions"
+cp "$REPO_ROOT/scripts/index-verify.sh" "$OVERFLOW_DIR/.claude/scripts/"
+
+# Build a CLAUDE.md with many Recently Accepted rows — enough to blow 80
+# lines. 30 rows + headers + other sections ≈ 95 lines.
+{
+    cat << 'HEAD'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+
+## Recently Accepted (last 5)
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+HEAD
+    for n in $(seq 1 90); do
+        d=$(printf "2026-01-%02d" $((n % 28 + 1)))
+        echo "| Problem $n | adr-$n | $d | Choose option $n |"
+    done
+    cat << 'TAIL'
+
+## Deferred
+| Problem | Slug | Deferred | Resume When |
+|---------|------|----------|-------------|
+
+## Closed
+| Problem | Slug | Closed | Reason |
+|---------|------|--------|--------|
+TAIL
+} > "$OVERFLOW_DIR/.decisions/CLAUDE.md"
+
+before_lines="$(wc -l < "$OVERFLOW_DIR/.decisions/CLAUDE.md")"
+if (( before_lines <= 80 )); then
+    fail "test setup wrong: file is only $before_lines lines, won't trigger cap"
+fi
+
+(cd "$OVERFLOW_DIR" && bash .claude/scripts/index-verify.sh --decisions 2>&1) >/tmp/index-verify-overflow.out
+
+after_lines="$(wc -l < "$OVERFLOW_DIR/.decisions/CLAUDE.md")"
+if (( after_lines <= 80 )); then
+    pass "CLAUDE.md trimmed to $after_lines lines (under 80-line cap)"
+else
+    fail "CLAUDE.md still over cap after overflow ($after_lines lines)"
+fi
+
+if [[ -f "$OVERFLOW_DIR/.decisions/history.md" ]]; then
+    pass "history.md created on first overflow"
+else
+    fail "history.md should have been created"
+fi
+
+# 90 rows started, default keep=5 → 85 rows should land in history.md.
+# Match `Problem <digit>` to avoid catching the Active Decisions table
+# header `| Problem | Slug | …`.
+hist_rows="$(grep -cE '^\| Problem [0-9]' "$OVERFLOW_DIR/.decisions/history.md" 2>/dev/null || echo 0)"
+if (( hist_rows == 85 )); then
+    pass "history.md received 85 archived rows (kept 5, archived 85)"
+else
+    fail "expected 85 archived rows in history.md, got $hist_rows"
+fi
+
+# Newest 5 rows should remain in the index.
+remaining_rows="$(grep -cE '^\| Problem [0-9]' "$OVERFLOW_DIR/.decisions/CLAUDE.md" 2>/dev/null || echo 0)"
+if (( remaining_rows == 5 )); then
+    pass "5 most recent rows remain in CLAUDE.md"
+else
+    fail "expected 5 remaining rows in CLAUDE.md, got $remaining_rows"
+fi
+
+# VALLORCINE_DECISIONS_KEEP env var should change the cap.
+rm -rf "$OVERFLOW_DIR/.decisions/history.md"
+{
+    cat << 'HEAD'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+
+## Recently Accepted (last 5)
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+HEAD
+    for n in $(seq 1 90); do
+        echo "| P$n | adr-$n | 2026-01-01 | reco$n |"
+    done
+    echo ""
+    echo "## Deferred"
+    echo "| Problem | Slug | Deferred | Resume When |"
+    echo "|---------|------|----------|-------------|"
+} > "$OVERFLOW_DIR/.decisions/CLAUDE.md"
+
+(cd "$OVERFLOW_DIR" && VALLORCINE_DECISIONS_KEEP=10 bash .claude/scripts/index-verify.sh --decisions 2>&1) >/dev/null
+
+remaining="$(grep -cE '^\| P[0-9]+ ' "$OVERFLOW_DIR/.decisions/CLAUDE.md" 2>/dev/null || echo 0)"
+if (( remaining == 10 )); then
+    pass "VALLORCINE_DECISIONS_KEEP=10 retains 10 rows"
+else
+    fail "VALLORCINE_DECISIONS_KEEP override failed (kept $remaining instead of 10)"
+fi
+
+rm -rf "$OVERFLOW_DIR" 2>/dev/null || true
+
+# ── Test 10: under-cap files unchanged ──────────────────────────────────────
+
+echo ""
+echo "── Test 10: under-cap CLAUDE.md left untouched"
+
+UNDERCAP_DIR="/tmp/vallorcine/scenario-undercap"
+rm -rf "$UNDERCAP_DIR" 2>/dev/null || true
+mkdir -p "$UNDERCAP_DIR/.claude/scripts" "$UNDERCAP_DIR/.decisions"
+cp "$REPO_ROOT/scripts/index-verify.sh" "$UNDERCAP_DIR/.claude/scripts/"
+
+cat > "$UNDERCAP_DIR/.decisions/CLAUDE.md" << 'EOF'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+
+## Recently Accepted (last 5)
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+| One thing | adr-1 | 2026-01-01 | reco-1 |
+| Two thing | adr-2 | 2026-01-02 | reco-2 |
+
+## Deferred
+| Problem | Slug | Deferred | Resume When |
+|---------|------|----------|-------------|
+
+## Closed
+| Problem | Slug | Closed | Reason |
+|---------|------|--------|--------|
+EOF
+
+before_md5="$(md5sum "$UNDERCAP_DIR/.decisions/CLAUDE.md" | cut -d' ' -f1)"
+(cd "$UNDERCAP_DIR" && bash .claude/scripts/index-verify.sh --decisions 2>&1) >/dev/null
+after_md5="$(md5sum "$UNDERCAP_DIR/.decisions/CLAUDE.md" | cut -d' ' -f1)"
+
+if [[ "$before_md5" == "$after_md5" ]]; then
+    pass "under-cap CLAUDE.md left untouched"
+else
+    fail "under-cap file was modified unnecessarily"
+fi
+
+if [[ ! -f "$UNDERCAP_DIR/.decisions/history.md" ]]; then
+    pass "history.md not created when under cap"
+else
+    fail "history.md should not be created when under cap"
+fi
+
+rm -rf "$UNDERCAP_DIR" 2>/dev/null || true
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/scenario-spec-split.sh
+++ b/tests/scenario-spec-split.sh
@@ -462,6 +462,197 @@ else
   fail "no args did not surface usage" "got: $out"
 fi
 
+# ── Layer 9: parent manifest version synced to bumped file version ───────────
+
+echo ""
+echo "── Layer 9: manifest sync (parent version bumped)"
+
+# After the previous successful split (then rollback), do a fresh split and
+# verify the parent's manifest entry version matches the parent file's
+# frontmatter version. The bug this guards: file frontmatter bumped to vN+1
+# while manifest entry stayed at vN, leaving downstream tooling stale.
+
+run_split --plan "$PLAN_VALID" >/tmp/spec-split-l9.out 2>&1 || true
+
+parent_file_version="$(jq -r '.version' < <(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$PARENT_FILE"))"
+parent_manifest_version="$(jq -r --arg pid "$PARENT_ID" '.specs[] | select(.id==$pid) | .version' "$MANIFEST")"
+if [[ -n "$parent_file_version" && "$parent_file_version" == "$parent_manifest_version" ]]; then
+  pass "parent manifest version ($parent_manifest_version) matches file version ($parent_file_version)"
+else
+  fail "manifest/file version mismatch after split" \
+       "file=$parent_file_version manifest=$parent_manifest_version"
+fi
+
+# Rollback to clean slate for layer 10.
+LAYER9_LOG=$(ls -1t "$SPEC_DIR/.split-log/"*.json 2>/dev/null | head -1)
+[[ -n "$LAYER9_LOG" ]] && bash "$REPO_ROOT/scripts/spec-split.sh" --rollback "$LAYER9_LOG" >/dev/null 2>&1 || true
+
+# ── Layer 10: compound annotations spanning multiple children ───────────────
+
+echo ""
+echo "── Layer 10: compound @spec parent.R1,R2 annotations route Rs to right children"
+
+# Add a synthetic source file with a TRULY cross-child compound annotation:
+# R10 must end up at key-rotation, R20 must end up at dek-management.
+# This is the exact bug that blocked query.sql-query-support split: literal-
+# substring rewrite corrupted the second R in the compound list.
+
+CROSS="$PROJ/modules/jlsm-engine/src/CrossChild.java"
+cat > "$CROSS" <<'EOF'
+// @spec encryption.primitives-lifecycle.R10,R20 — straddles two children
+// @spec encryption.primitives-lifecycle.R11,R12,R21 — three across two children
+public class CrossChild {}
+EOF
+
+# Run the split.
+run_split --plan "$PLAN_VALID" >/tmp/spec-split-l10.out 2>&1
+rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail "split failed with cross-child compound annotations present" \
+       "$(tail -10 /tmp/spec-split-l10.out)"
+else
+  pass "split exits 0 with cross-child compound annotations"
+fi
+
+# After explosion + per-R rewrite, the file should have:
+#   - R10 under key-rotation
+#   - R20 under dek-management
+#   - R11, R12 under key-rotation
+#   - R21 under dek-management
+# The exact bug: prior behavior would emit "lexer.R10,R20" (single line),
+# leaving R20 dangling under the wrong child.
+if grep -q '@spec encryption\.primitives-lifecycle\.key-rotation\.R10\b' "$CROSS" && \
+   grep -q '@spec encryption\.primitives-lifecycle\.dek-management\.R20\b' "$CROSS"; then
+  pass "compound R10,R20 → R10@key-rotation + R20@dek-management on separate lines"
+else
+  fail "compound R10,R20 not split correctly" \
+       "$(grep '@spec' "$CROSS")"
+fi
+
+# Verify three-element compound also exploded correctly.
+if grep -q '@spec encryption\.primitives-lifecycle\.key-rotation\.R11\b' "$CROSS" && \
+   grep -q '@spec encryption\.primitives-lifecycle\.key-rotation\.R12\b' "$CROSS" && \
+   grep -q '@spec encryption\.primitives-lifecycle\.dek-management\.R21\b' "$CROSS"; then
+  pass "compound R11,R12,R21 split into three correctly-prefixed lines"
+else
+  fail "three-element compound not split correctly" \
+       "$(grep '@spec' "$CROSS")"
+fi
+
+# Negative: ensure no line has a dangling R that's still under the parent
+# prefix without a child segment (the original bug shape).
+if grep -E '@spec encryption\.primitives-lifecycle\.R[0-9]+(,R[0-9]+)+' "$CROSS" >/dev/null; then
+  fail "compound annotation left intact (bug regressed)" \
+       "$(grep '@spec' "$CROSS")"
+else
+  pass "no compound annotation lines remain (all exploded)"
+fi
+
+# Rollback should restore the original compound (snapshot-based).
+LAYER10_LOG=$(ls -1t "$SPEC_DIR/.split-log/"*.json 2>/dev/null | head -1)
+if [[ -n "$LAYER10_LOG" ]]; then
+  bash "$REPO_ROOT/scripts/spec-split.sh" --rollback "$LAYER10_LOG" >/dev/null 2>&1 || true
+  if grep -q '@spec encryption\.primitives-lifecycle\.R10,R20' "$CROSS" && \
+     grep -q '@spec encryption\.primitives-lifecycle\.R11,R12,R21' "$CROSS"; then
+    pass "rollback restores exploded compound annotations to original form"
+  else
+    fail "rollback did not restore compound form" \
+         "$(grep '@spec' "$CROSS")"
+  fi
+fi
+
+# ── Layer 11: hyphenated/sub-numbered R-names recognized ────────────────────
+
+echo ""
+echo "── Layer 11: R37b-1 / R83-1 style sub-numbered claims"
+
+# Construct a synthetic parent with sub-numbered Rs, plan a split that moves
+# them, and verify they're carved correctly (not silently swallowed as prose
+# under a parent R).
+
+SUB_PROJ="$TMPDIR_TEST/proj-subr"
+mkdir -p "$SUB_PROJ/.spec/registry" "$SUB_PROJ/.spec/domains/primitives" "$SUB_PROJ/modules/x/src"
+SUB_PARENT="$SUB_PROJ/.spec/domains/primitives/lifecycle.md"
+SUB_MANIFEST="$SUB_PROJ/.spec/registry/manifest.json"
+SUB_PARENT_ID="primitives.lifecycle"
+
+cat > "$SUB_PARENT" <<'EOF'
+---
+{
+  "id": "primitives.lifecycle",
+  "version": 3,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["primitives"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+
+# primitives.lifecycle
+
+R1. Cross-cutting invariant.
+
+R37b-1. Sub-numbered key derivation requirement.
+R37b-2. Companion sub-numbered requirement.
+R83-1. Independent hyphenated requirement.
+EOF
+
+cat > "$SUB_MANIFEST" <<EOF
+{
+  "schema_version": 2,
+  "spec_count": 1,
+  "specs": [{
+    "id": "primitives.lifecycle",
+    "path": ".spec/domains/primitives/lifecycle.md",
+    "state": "APPROVED",
+    "version": 3,
+    "domains": ["primitives"],
+    "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []
+  }]
+}
+EOF
+
+SUB_PLAN="$TMPDIR_TEST/sub-plan.json"
+cat > "$SUB_PLAN" <<EOF
+{
+  "parent_id": "$SUB_PARENT_ID",
+  "children": [
+    {"id":"$SUB_PARENT_ID.derivation","title":"Derivation",
+     "domains":["primitives"],"requirements":["R37b-1","R37b-2","R83-1"]}
+  ]
+}
+EOF
+
+(cd "$SUB_PROJ" && bash "$REPO_ROOT/scripts/spec-split.sh" --plan "$SUB_PLAN" >/tmp/spec-split-l11.out 2>&1)
+rc=$?
+
+SUB_CHILD="$SUB_PROJ/.spec/domains/primitives/lifecycle/derivation.md"
+if [[ $rc -eq 0 && -f "$SUB_CHILD" ]]; then
+  pass "split with hyphenated R-numbers exits 0 and creates child"
+else
+  fail "split failed for hyphenated R-numbers" "$(tail -10 /tmp/spec-split-l11.out)"
+fi
+
+if grep -q '^R37b-1\.' "$SUB_CHILD" && \
+   grep -q '^R37b-2\.' "$SUB_CHILD" && \
+   grep -q '^R83-1\.' "$SUB_CHILD"; then
+  pass "child contains R37b-1, R37b-2, R83-1 (sub-numbered Rs preserved)"
+else
+  fail "child missing hyphenated R-numbers" \
+       "$(grep -E '^R[0-9]' "$SUB_CHILD" || echo "(none)")"
+fi
+
+# Parent should retain only cross-cutting R1.
+if grep -q '^R1\.' "$SUB_PARENT" && ! grep -qE '^R37b-1|^R83-1' "$SUB_PARENT"; then
+  pass "parent retains R1, no longer contains moved hyphenated Rs"
+else
+  fail "parent state wrong after hyphenated-R split" \
+       "$(grep -E '^R[0-9]' "$SUB_PARENT")"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -925,6 +925,55 @@ else
     fail "__pycache__/ should be in .gitignore"
 fi
 
+# spec-split runtime artifacts must be in the installer's gitignore template.
+# Otherwise users commit per-machine rollback logs and transient plan JSON.
+if assert_file_contains "$ENHANCED_TARGET/.gitignore" ".spec/.split-log/"; then
+    pass ".spec/.split-log/ in .gitignore"
+else
+    fail ".spec/.split-log/ should be in .gitignore"
+fi
+if assert_file_contains "$ENHANCED_TARGET/.gitignore" ".spec/.split-plan.json"; then
+    pass ".spec/.split-plan.json in .gitignore"
+else
+    fail ".spec/.split-plan.json should be in .gitignore"
+fi
+
+# Upgrade path: an existing install that already has the runtime block but
+# was made before v0.16.x should pick up the new entries on re-install.
+UPGRADE_GI_TARGET="$(make_temp)"
+mkdir -p "$UPGRADE_GI_TARGET"
+cat > "$UPGRADE_GI_TARGET/.gitignore" << 'PRELEGACY'
+# vallorcine runtime files — generated at runtime, not committed
+.claude/.statusline-baseline
+.claude/.token-state
+.claude/.token-checkpoint
+.claude/.subagent-state
+.feature/
+.curate/
+__pycache__/
+PRELEGACY
+
+bash "$REPO_ROOT/install.sh" "$UPGRADE_GI_TARGET" >/dev/null 2>&1 || true
+
+if grep -qxF ".spec/.split-log/" "$UPGRADE_GI_TARGET/.gitignore"; then
+    pass "upgrade path adds .spec/.split-log/ to existing .gitignore"
+else
+    fail "upgrade should add .spec/.split-log/ to existing .gitignore"
+fi
+if grep -qxF ".spec/.split-plan.json" "$UPGRADE_GI_TARGET/.gitignore"; then
+    pass "upgrade path adds .spec/.split-plan.json to existing .gitignore"
+else
+    fail "upgrade should add .spec/.split-plan.json to existing .gitignore"
+fi
+# Idempotent: running install twice must not duplicate entries.
+bash "$REPO_ROOT/install.sh" "$UPGRADE_GI_TARGET" >/dev/null 2>&1 || true
+splitlog_count="$(grep -cxF '.spec/.split-log/' "$UPGRADE_GI_TARGET/.gitignore")"
+if (( splitlog_count == 1 )); then
+    pass "re-running install does not duplicate .spec/.split-log/ entry"
+else
+    fail "expected 1 .spec/.split-log/ entry after second install, got $splitlog_count"
+fi
+
 # ── Test 14b: Migration from old direct references to wrappers ────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Triage from a `/spec-split` + `/curate` run on jlsm surfaced 8 issues across `spec-split`, `curate-scan`, `index-verify`, and the installer template. All addressed with regression tests.

### Fixed

- **A — spec-split: compound annotations.** `@spec parent.R10,R20` now routes each R to its correct child via a pre-explosion pass. Previously the literal-substring rewrite matched the parent prefix and left subsequent Rs in the comma list dangling under the wrong child. Blocked the `query.sql-query-support` split where 54 of 195 R-level annotations were compound.
- **B — R-name regex extension.** Hyphenated sub-numbered Rs (`R37b-1`, `R83-1`, `R76a-1`, `R71b-2`, `R78g-3`) recognized across `spec-split`, `spec-validate`, `spec-trace`, `spec-lib`, `spec-resolve`, `spec-ambiguity-score`, `curate-scan`. Previously silently swallowed when first under a section header.
- **C — spec-split: manifest version sync.** Parent's manifest entry version now bumps in lockstep with the file frontmatter version. Previously file v14 vs manifest v13 left downstream tooling stale.
- **D — curate-scan: empty open_obligations.** `open_obligations: []` no longer false-positives. Switched to `jq`-based array-length detection. Previously the shell stripper left punctuation behind and registered as content (drowning the real signal at ~79 false-positive specs in real scans).
- **E — curate-scan: JDK type blocklist.** `IllegalArgumentException`, `NullPointerException`, common collections, IO, time, and concurrency primitives excluded from "unspecified shared types" so genuine project value-types surface above the noise.
- **F — curate-scan: bare-only annotations.** Specs with bare `@spec engine.foo` (no R-suffix) classified as new `BARE_ONLY` class instead of being lumped into "no annotations at all". Different remediation (refine vs. add from scratch). Heading renamed: "no annotations at all" → "no @spec annotations of any kind".
- **G — index-verify: decisions index overflow.** Implemented actual overflow to `history.md` when over the 80-line cap. Tunable via `VALLORCINE_DECISIONS_KEEP` (default 5 most-recent rows kept). Previously warn-and-proceed: index grew unbounded after auto-repair (e.g. 46 reconstructed ADRs → 151 lines).
- **H — install: gitignore template.** Ships `.spec/.split-log/` and `.spec/.split-plan.json`. Existing installs (with the runtime block already present) pick up the new entries on re-install via a new idempotent per-entry append path.

### Decisions worth flagging

- **G:** Picked "implement overflow" over "bump cap" because bumping just postpones the silent-growth complaint, and "fail unless `--allow-overflow`" violates the script's never-block contract on this hook.
- **C:** Picked "fix" over "document" — the file/manifest version mismatch is a correctness bug, not a stylistic one.
- **F:** New `BARE_ONLY` class required a heading rename. `scenario-curate-drift.sh` updated to match.

### Snapshot-based rollback for spec-split

The compound-annotation explosion can rewrite multiple lines on a single source line, which line-level rewrite reversal can't faithfully undo. Source files are now snapshotted before any sweep edit; `replay_rollback` restores from snapshots when present, falls back to the legacy per-rewrite sed reversal for older logs.

## Test plan

- [x] `bash tests/scenario-spec-split.sh` — 38/38 (3 new layers: manifest sync, cross-child compound annotations, hyphenated Rs)
- [x] `bash tests/scenario-curate-scan.sh` — 61/61 (3 new tests: empty obligations, JDK blocklist, bare-only)
- [x] `bash tests/scenario-index-verify.sh` — 19/19 (2 new tests: overflow + env var, under-cap idempotency)
- [x] `bash tests/scenario-curate-drift.sh` — 27/27 (heading rename propagated)
- [x] `bash tests/test-install.sh` — 64/64 (3 new tests: ships entries, upgrade path, idempotent re-run)
- [x] Cross-touched: `spec-validate`, `spec-trace`, `spec-resolve`, `spec-ambiguity-score`, `spec-author-layered`, `spec-layering`, `curate-subdivision-candidates` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)