### PR TITLE
fix(feature-pr): run retro before PR creation; commit capabilities + work

### DIFF
--- a/skills/feature-pr/SKILL.md
+++ b/skills/feature-pr/SKILL.md
@@ -284,6 +284,52 @@ Append `pr-drafted` entry to cycle-log.md:
 
 ---
 
+## Step 4.5 — Run retrospective (if not already run)
+
+The retrospective writes feature footprints, adversarial findings, capability
+index updates, and work-definition status changes back to `.kb/`,
+`.capabilities/`, and `.work/`. These artifacts MUST land in this PR — if they
+land after the PR is created, they end up outside the merge and force a
+follow-up "fix retro artifacts" PR. The next step (Step 5) commits whatever
+the retro produces, so retro must run *before* Step 5.
+
+### Skip if already run
+
+Check `cycle-log.md` for an existing `retro-complete` entry. If present, the
+retrospective has already run for this feature — skip to Step 5 silently.
+
+### If not run
+
+Display:
+```
+── Retrospective ──────────────────────────────────
+The retro captures what worked / what didn't while the feature is fresh, and
+writes feature-footprint + adversarial-finding entries back to `.kb/` so the
+next feature benefits. Its outputs (KB entries, capability index updates,
+work-definition status) MUST be in this PR — running retro after the PR is
+created strands the artifacts outside the merge.
+```
+
+Use AskUserQuestion with options:
+  - "Run retro now (recommended)"
+  - "Skip — accept follow-up retro PR"
+
+**If "Run retro now":** invoke `/feature-retro "<slug>"` as a sub-agent. Wait
+for it to complete. Step 5 will pick up its outputs.
+
+**If "Skip":** proceed but note in the PR description that retro was skipped
+and a follow-up artifacts PR will be needed:
+
+```markdown
+## Retrospective
+Retro deferred. Run `/feature-retro "<slug>"` after merge — outputs will need
+their own follow-up PR (kb/capabilities/work-tracking only).
+```
+
+This is the explicit-acknowledgement path. The default is to run retro inline.
+
+---
+
 ## Step 5 — Finalize feature records
 
 Before creating the PR, finalize the feature's knowledge and index records so
@@ -334,22 +380,29 @@ Move the feature row from Active Features to Completed / Archived:
 
 ### 5c — Commit feature records
 
-Stage and commit all feature-produced files that aren't yet committed:
+Stage and commit all feature-produced files that aren't yet committed. This
+deliberately covers four trees because the feature pipeline writes to all of
+them: `.kb/` (knowledge), `.decisions/` (ADRs), `.capabilities/` (capability
+index updates from retro), and `.work/` (work-definition status from retro
++ work-resolve.sh). Missing any of these is the bug that produced repeated
+"fix retro artifacts" follow-up PRs.
 
 ```bash
 git add .feature/CLAUDE.md
-```
 
-Also check for and include any uncommitted `.decisions/` and `.kb/` files
-(indexes, history, ADRs, KB entries created during this feature's pipeline):
-
-```bash
-# Only add files that are actually modified or untracked
-git add .decisions/CLAUDE.md .decisions/history.md .kb/CLAUDE.md 2>/dev/null
-# Add any ADR directories created for this feature
+# Decisions tree (ADRs + indexes)
+git add .decisions/CLAUDE.md .decisions/history.md 2>/dev/null
 git add .decisions/*/adr.md .decisions/*/constraints.md .decisions/*/evaluation.md .decisions/*/log.md 2>/dev/null
-# Add any KB entries created for this feature
+
+# Knowledge base (entries + indexes at every level)
 git add .kb/ 2>/dev/null
+
+# Capability index (retro promotes feature into the capability map)
+git add .capabilities/ 2>/dev/null
+
+# Work tracking (retro flips WD status to COMPLETE; manifest re-syncs)
+git add .work/ 2>/dev/null
+
 git commit -m "chore: finalize <slug> — archive manifest, index updates, knowledge files"
 ```
 
@@ -376,20 +429,11 @@ gh CLI not found or not authenticated. To create the PR manually:
 
 When the PR merges, run:
   /feature-complete "<slug>"
-
-── Retrospective ──────────────────────────────
-A retrospective captures what worked and what didn't while the feature is fresh.
-It writes back to the KB and decisions store — making the next feature better.
-
 ───────────────────────────────────────────────
 ```
 
-Use AskUserQuestion with options:
-  - "Run retro now"
-  - "Skip"
-
-If "Run retro now": invoke `/feature-retro "<slug>"` as a sub-agent immediately.
-If "Skip": stop.
+Stop. (Retro already ran in Step 4.5 — its outputs are in the commit prepared
+by Step 5 and will be part of the PR you create.)
 
 **If `gh` is available:**
 
@@ -439,20 +483,12 @@ Display:
 ───────────────────────────────────────────────
 When the PR merges:
   /feature-complete "<slug>"
-
-── Retrospective ──────────────────────────────
-A retrospective captures what worked and what didn't while the feature is fresh.
-It writes back to the KB and decisions store — making the next feature better.
-
 ───────────────────────────────────────────────
 ```
 
-Use AskUserQuestion with options:
-  - "Run retro now"
-  - "Skip"
-
-If "Run retro now": invoke `/feature-retro "<slug>"` as a sub-agent immediately.
-If "Skip": stop.
+Stop. (Retro already ran in Step 4.5 — its outputs were committed in Step 5
+and are part of this PR. Do NOT offer a post-PR retro here — that was the
+bug that produced repeated "fix retro artifacts" follow-up PRs.)
 
 If `gh pr create` fails (e.g. branch not pushed, no remote): display the error
 and fall back to the manual instructions above. Do not retry automatically.

--- a/skills/feature-retro/SKILL.md
+++ b/skills/feature-retro/SKILL.md
@@ -7,11 +7,20 @@ argument-hint: "<feature-slug>"
 
 Post-feature retrospective. Reviews what actually happened against what was
 planned: scope divergence, invalidated assumptions, missed domain gaps, and
-lessons learned. Writes findings back to `.decisions/` and `.kb/` so future
-features benefit.
+lessons learned. Writes findings back to `.decisions/`, `.kb/`,
+`.capabilities/`, and `.work/` so future features benefit.
 
-Run after `/feature-pr` or after the PR merges — whenever the feature is fresh
-in memory.
+**When to run.** Invoked automatically by `/feature-pr` Step 4.5 *before* the
+PR is created — its outputs (feature footprints, adversarial findings,
+capability-index updates, work-definition status) need to land in the same
+commit that opens the PR. Running retro after a PR is opened (or merged)
+strands those artifacts on `main` and forces a follow-up "fix retro
+artifacts" PR. Don't do that.
+
+Direct invocation is supported for two cases: (a) re-running on an archived
+feature for late-discovered learnings, and (b) explicit recovery when retro
+was skipped during the PR flow. In case (b), expect to open a follow-up PR
+for the artifacts.
 
 ---
 
@@ -27,6 +36,25 @@ working files are still available locally.
 Check that cycle-log.md has at least one `implemented` or `refactor-complete`
 entry. If not: "Feature '<slug>' has not completed implementation. Run the
 retrospective after the TDD cycle finishes."
+
+### Idempotency — skip if already complete
+
+Check `cycle-log.md` for an existing `retro-complete` entry. If present, the
+retrospective has already run. Display:
+
+```
+── Retrospective already complete ─────────────
+Found existing retro-complete entry in cycle-log.md (dated <date>).
+Re-running would duplicate footprint / adversarial-finding KB entries.
+```
+
+Use AskUserQuestion with options:
+  - "Skip — retro already done"
+  - "Re-run anyway (late-discovered learnings)"
+
+**If "Skip":** stop with the message "Retro already complete — nothing to do."
+**If "Re-run anyway":** proceed; warn that any /research sub-agents will need
+to recognize and update existing entries rather than create duplicates.
 
 Display opening header:
 ```


### PR DESCRIPTION
## Summary

Fixes the repeated "fix retro artifacts" follow-up PRs (e.g. jlsm [#59](https://github.com/nathannorthcutt/jlsm/pull/59), [#56](https://github.com/nathannorthcutt/jlsm/pull/56)) caused by `/feature-pr` running retro *after* the PR was created.

### Root cause

```
Step 5  → commit .kb/ and .decisions/ only
Step 6  → gh pr create
Step 6+ → "Run retro now?" — too late
           retro produces .kb/ feature-footprint, adversarial findings,
           .capabilities/ index updates, .work/ status changes
           → stranded on branch (or main), never in the merged PR
```

### Fix

**1. Move retro inline (new `/feature-pr` Step 4.5).**
Invoke `/feature-retro` as a sub-agent *before* Step 5, so its outputs flow into Step 5's commit and ride the PR to merge. Idempotent via `cycle-log.md` `retro-complete` entry. The skip path requires explicit `AskUserQuestion` confirmation and adds a "retro deferred" note to the PR body so the user knows a follow-up is coming.

**2. Extend `/feature-pr` Step 5 to also stage `.capabilities/` and `.work/`.**
Even pre-PR retro would have stranded these — Step 5 only `git add`-ed `.kb/` and `.decisions/`. Now stages all four trees the feature pipeline writes to.

**3. Remove both post-PR "Run retro now" offers.**
They were the structural cause of stranded artifacts. Both deletion sites carry comments referencing this bug so future maintainers don't reintroduce them.

**4. `/feature-retro` reframed accordingly.**
Documented as invoked-by-`/feature-pr`-Step-4.5. Direct invocation supported for two cases: archived features (late-discovered learnings) and post-skip recovery (with warning that recovery needs a follow-up PR). Added idempotency check that prompts skip-vs-rerun when `retro-complete` already exists in `cycle-log.md`.

## Behavior change

- Default flow: retro outputs are part of the feature PR. No more follow-up artifacts PRs.
- Skip path: explicit acknowledgement required, PR body notes the deferral.
- Re-invocation: safe — prompts to skip if already complete.

## Test plan

- [x] `bash tests/test-install.sh` — 64/64 (skill prompt changes only; install validation passes)
- [x] No scenario tests for `/feature-pr` or `/feature-retro` at this layer (skill prompts, not script logic)
- [ ] Manual validation on next jlsm feature: confirm retro outputs appear in the feature PR diff, no follow-up artifacts PR needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)