### PR TITLE
feat(curate): verification detection gaps + verify mode

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -123,6 +123,7 @@
 .claude/scripts/spec-obligations-gc.sh
 .claude/scripts/spec-trace.sh
 .claude/scripts/spec-split.sh
+.claude/scripts/lens-registry.txt
 .claude/scripts/work-lib.sh
 .claude/scripts/work-resolve.sh
 .claude/scripts/work-validate.sh

--- a/install.sh
+++ b/install.sh
@@ -273,6 +273,7 @@ install_file "$SCRIPT_DIR/scripts/kb-search.js" "$TARGET/.claude/scripts/kb-sear
 install_file "$SCRIPT_DIR/scripts/adr-validate.sh" "$TARGET/.claude/scripts/adr-validate.sh"
 install_file "$SCRIPT_DIR/scripts/token-stop-hook.sh" "$TARGET/.claude/scripts/token-stop-hook.sh"
 install_file "$SCRIPT_DIR/scripts/curate-scan.sh" "$TARGET/.claude/scripts/curate-scan.sh"
+install_file "$SCRIPT_DIR/scripts/lens-registry.txt" "$TARGET/.claude/scripts/lens-registry.txt"
 install_file "$SCRIPT_DIR/scripts/decisions-scan.sh" "$TARGET/.claude/scripts/decisions-scan.sh"
 install_file "$SCRIPT_DIR/scripts/audit-budget.sh" "$TARGET/.claude/scripts/audit-budget.sh"
 install_file "$SCRIPT_DIR/scripts/extract-findings.sh" "$TARGET/.claude/scripts/extract-findings.sh"

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1553,6 +1553,232 @@ if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
     fi
 fi
 
+# ── Analysis 21: Link rot in KB entries ─────────────────────────────────────
+# Scan KB body text for URLs and verify they still resolve. Cached results in
+# .curate/link-rot-cache.txt with 7-day TTL prevent thrashing on every scan.
+# A bounded number of URLs per run keeps wall-clock predictable on large KBs.
+#
+# Detection: URLs are extracted via two patterns (markdown links + bare URLs)
+# with code-fence exclusion (URLs inside fenced code blocks are example text,
+# not citations). Each URL gets a HEAD request via curl; status codes 4xx and
+# connection failures (000) are flagged as rot. 5xx are considered transient
+# and skipped to avoid surfacing flaky-server noise.
+#
+# Tunables (env-var overrides; safe defaults for typical KBs):
+#   MAX_LINK_ROT_URLS    — fresh-curl budget per run (default 100)
+#   LINK_ROT_CACHE_TTL   — cache TTL in seconds (default 7 days)
+
+> "$TMPDIR_SCAN/link-rot.txt"
+
+if [[ -d ".kb" ]] && command -v curl >/dev/null 2>&1; then
+    : "${MAX_LINK_ROT_URLS:=100}"
+    : "${LINK_ROT_CACHE_TTL:=$((7 * 24 * 3600))}"
+
+    LINK_ROT_CACHE="$CURATE_DIR/link-rot-cache.txt"
+    [[ -f "$LINK_ROT_CACHE" ]] || : > "$LINK_ROT_CACHE"
+    LINK_ROT_NOW=$(date +%s)
+    LINK_ROT_URL_COUNT=0
+
+    # Build a transient cache lookup: URL -> "status|timestamp"
+    declare -A LINK_ROT_CACHE_MAP=()
+    while IFS='|' read -r cached_url cached_status cached_time; do
+        [[ -z "$cached_url" ]] && continue
+        LINK_ROT_CACHE_MAP["$cached_url"]="$cached_status|$cached_time"
+    done < "$LINK_ROT_CACHE"
+
+    # Track URLs we've already processed this run (dedupe across files)
+    declare -A LINK_ROT_SEEN=()
+
+    # Accumulate cache updates for a single atomic write at the end.
+    LINK_ROT_CACHE_UPDATES="$TMPDIR_SCAN/link-rot-cache-updates.txt"
+    : > "$LINK_ROT_CACHE_UPDATES"
+
+    while IFS= read -r kb_file; do
+        [[ -z "$kb_file" ]] && continue
+
+        # Strip fenced code blocks so URLs inside ``` ... ``` are ignored.
+        no_fence=$(awk '
+            /^[[:space:]]*```/ { in_fence = !in_fence; next }
+            in_fence { next }
+            { print }
+        ' "$kb_file" 2>/dev/null || true)
+        [[ -z "$no_fence" ]] && continue
+
+        # Markdown links: [text](http://...) — extract the URL part only.
+        mdlink_urls=$(grep -oE '\[[^]]+\]\(https?://[^)]+\)' <<< "$no_fence" 2>/dev/null \
+                      | sed -E 's/^\[[^]]+\]\(([^)]+)\)$/\1/' || true)
+
+        # Strip markdown-link expressions before extracting bare URLs to avoid
+        # double-counting and to prevent the bare-URL pattern from grabbing
+        # the parenthesised tail of a markdown link.
+        no_links=$(sed -E 's/\[[^]]+\]\([^)]+\)//g' <<< "$no_fence" 2>/dev/null || true)
+        # `]` placed first in the negated bracket expression is literal
+        # (POSIX-portable). GNU grep does not honor `\]` inside character
+        # classes — it treats `\` as literal and `]` as the class terminator,
+        # which silently breaks URL extraction. Place `]` first to avoid that.
+        bare_urls=$(grep -oE 'https?://[^][:space:]<>")]+' <<< "$no_links" 2>/dev/null || true)
+
+        all_urls=$(printf "%s\n%s\n" "$mdlink_urls" "$bare_urls" \
+                   | grep -v '^$' | sort -u 2>/dev/null || true)
+        [[ -z "$all_urls" ]] && continue
+
+        while IFS= read -r url; do
+            [[ -z "$url" ]] && continue
+            # Strip trailing punctuation often glued to bare URLs in prose.
+            url="${url%[.,;:!?]}"
+            [[ -z "$url" ]] && continue
+            [[ -n "${LINK_ROT_SEEN[$url]:-}" ]] && continue
+            LINK_ROT_SEEN["$url"]=1
+
+            # Cache hit?
+            cached="${LINK_ROT_CACHE_MAP[$url]:-}"
+            cache_status=""
+            cache_time=""
+            if [[ -n "$cached" ]]; then
+                cache_status="${cached%|*}"
+                cache_time="${cached#*|}"
+                age=$(( LINK_ROT_NOW - cache_time ))
+                if (( age < LINK_ROT_CACHE_TTL )); then
+                    # Use cached value. Emit only if rot-shaped.
+                    if [[ "$cache_status" =~ ^4 ]] || [[ "$cache_status" == "000" ]]; then
+                        echo "LINK_ROT|$kb_file|$url|$cache_status|$cache_time" \
+                            >> "$TMPDIR_SCAN/link-rot.txt"
+                    fi
+                    continue
+                fi
+            fi
+
+            # Fresh check is gated by per-run budget. Over-budget URLs are
+            # left for next run; cached confirmed-dead URLs still surface.
+            if (( LINK_ROT_URL_COUNT >= MAX_LINK_ROT_URLS )); then
+                continue
+            fi
+            LINK_ROT_URL_COUNT=$(( LINK_ROT_URL_COUNT + 1 ))
+
+            status=$(curl -sI -m 5 -L -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || true)
+            [[ -z "$status" ]] && status="000"
+
+            echo "$url|$status|$LINK_ROT_NOW" >> "$LINK_ROT_CACHE_UPDATES"
+            LINK_ROT_CACHE_MAP["$url"]="$status|$LINK_ROT_NOW"
+
+            if [[ "$status" =~ ^4 ]] || [[ "$status" == "000" ]]; then
+                echo "LINK_ROT|$kb_file|$url|$status|$LINK_ROT_NOW" \
+                    >> "$TMPDIR_SCAN/link-rot.txt"
+            fi
+        done <<< "$all_urls"
+    done < <(find .kb -name '*.md' \
+                     -not -name 'CLAUDE.md' \
+                     -not -path '*/_refs/*' \
+                     -not -path '*/_archive*' \
+                     2>/dev/null || true)
+
+    # Atomic cache write: merge old + updates, dedupe by URL keeping latest.
+    if [[ -s "$LINK_ROT_CACHE_UPDATES" ]]; then
+        cat "$LINK_ROT_CACHE" "$LINK_ROT_CACHE_UPDATES" 2>/dev/null \
+            | awk -F'|' 'NF >= 3 { cache[$1] = $0 } END { for (k in cache) print cache[k] }' \
+            > "$LINK_ROT_CACHE.new"
+        mv "$LINK_ROT_CACHE.new" "$LINK_ROT_CACHE"
+    fi
+
+    # Stable output ordering by KB file, then URL.
+    if [[ -s "$TMPDIR_SCAN/link-rot.txt" ]]; then
+        sort -t'|' -k2,2 -k3,3 "$TMPDIR_SCAN/link-rot.txt" -o "$TMPDIR_SCAN/link-rot.txt" 2>/dev/null || true
+    fi
+fi
+
+# ── Analysis 22: Falsification-lens staleness ───────────────────────────────
+# APPROVED specs authored before a falsification lens shipped may have
+# shallow Pass 2 coverage by current standards (e.g., specs from before
+# the security lens in v0.14.2 lack adversary-model attack pattern checks).
+# Heuristic: if the spec's first-commit date predates a lens's introduction
+# AND the spec body matches a keyword associated with that lens, surface as
+# a re-falsification candidate. Per-candidate confirmation in /curate verify
+# mode (or manual /spec-author --depth-pass-only) decides whether the
+# depth pass is worth running.
+#
+# lens-registry.txt format (pipe-separated, one lens per line):
+#   <lens_name>|<introduction_date>|<keyword>|<keyword>|...
+#
+# Keywords are matched as case-insensitive whole words (\bword\b regex).
+
+> "$TMPDIR_SCAN/falsification-stale.txt"
+
+# Locate lens-registry.txt — install layout vs dev-repo layout.
+LENS_REGISTRY=""
+if [[ -f ".claude/scripts/lens-registry.txt" ]]; then
+    LENS_REGISTRY=".claude/scripts/lens-registry.txt"
+elif [[ -f "scripts/lens-registry.txt" ]]; then
+    LENS_REGISTRY="scripts/lens-registry.txt"
+fi
+
+if [[ -n "$LENS_REGISTRY" ]] && [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
+    FALSIFICATION_STALE_MANIFEST=".spec/registry/manifest.json"
+
+    while IFS= read -r fid; do
+        [[ -z "$fid" ]] && continue
+
+        spec_state=$(spec_manifest_state "$FALSIFICATION_STALE_MANIFEST" "$fid")
+        # Only APPROVED specs — DRAFT/INVALIDATED don't need re-falsification
+        # surfaced (DRAFT is in flight; INVALIDATED is historical).
+        [[ "$spec_state" != "APPROVED" ]] && continue
+
+        spec_file=$(spec_file_for_id "$FALSIFICATION_STALE_MANIFEST" "$fid")
+        [[ -z "$spec_file" || ! -f "$spec_file" ]] && continue
+
+        # Determine spec creation date. Prefer git first-commit-touched date;
+        # fall back to file mtime for uncommitted specs (test fixtures, work
+        # in flight). Both formats normalised to ISO date (YYYY-MM-DD).
+        spec_created=$(git log --diff-filter=A --format=%aI -- "$spec_file" 2>/dev/null \
+                       | tail -1 | cut -dT -f1 || true)
+        if [[ -z "$spec_created" ]]; then
+            mtime_epoch=$(stat -c %Y "$spec_file" 2>/dev/null \
+                          || stat -f %m "$spec_file" 2>/dev/null || true)
+            if [[ -n "$mtime_epoch" ]]; then
+                spec_created=$(date -d "@$mtime_epoch" +%Y-%m-%d 2>/dev/null \
+                               || date -r "$mtime_epoch" +%Y-%m-%d 2>/dev/null || true)
+            fi
+        fi
+        [[ -z "$spec_created" ]] && continue
+
+        # For each lens, decide whether this spec qualifies as stale.
+        while IFS= read -r lens_line; do
+            # Skip empty lines and comments.
+            [[ -z "$lens_line" || "$lens_line" =~ ^[[:space:]]*# ]] && continue
+
+            lens_name=$(cut -d'|' -f1 <<< "$lens_line")
+            lens_date=$(cut -d'|' -f2 <<< "$lens_line")
+            lens_keywords=$(cut -d'|' -f3- <<< "$lens_line")
+
+            [[ -z "$lens_name" || -z "$lens_date" || -z "$lens_keywords" ]] && continue
+
+            # Spec authored on or after lens introduction date is not stale.
+            if [[ ! "$spec_created" < "$lens_date" ]]; then
+                continue
+            fi
+
+            # Build a word-boundary regex from the keyword list. Awk's
+            # printf interprets `\\b` as a single backslash-b, which grep
+            # then reads as the word-boundary anchor.
+            keyword_regex=$(echo "$lens_keywords" | tr '|' '\n' \
+                            | awk 'NF { printf "%s\\b%s\\b", (NR>1?"|":""), $0 }')
+            [[ -z "$keyword_regex" ]] && continue
+
+            # First matching keyword (case-insensitive) is enough to flag.
+            matched=$(grep -ioE "$keyword_regex" "$spec_file" 2>/dev/null | head -1 || true)
+            if [[ -n "$matched" ]]; then
+                echo "FALSIFICATION_STALE|$fid|$spec_created|$lens_name|$matched" \
+                    >> "$TMPDIR_SCAN/falsification-stale.txt"
+            fi
+        done < "$LENS_REGISTRY"
+    done < <(spec_manifest_ids "$FALSIFICATION_STALE_MANIFEST" 2>/dev/null || true)
+
+    # Stable ordering: spec id, lens name.
+    if [[ -s "$TMPDIR_SCAN/falsification-stale.txt" ]]; then
+        sort -t'|' -k2,2 -k4,4 "$TMPDIR_SCAN/falsification-stale.txt" \
+             -o "$TMPDIR_SCAN/falsification-stale.txt" 2>/dev/null || true
+    fi
+fi
+
 # ── Write summary file ──────────────────────────────────────────────────────
 
 SCAN_DATE="$(date +%Y-%m-%d)"
@@ -2000,6 +2226,44 @@ if [[ -s "$TMPDIR_SCAN/spec-subdivision-candidates.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# Link rot in KB entries (Analysis 21)
+if [[ -s "$TMPDIR_SCAN/link-rot.txt" ]]; then
+    echo "## Link Rot in KB Entries" >> "$SUMMARY_FILE"
+    echo "URLs cited in KB entries that no longer resolve. Status \`000\` means" >> "$SUMMARY_FILE"
+    echo "connection failure (DNS, timeout, refused); \`4xx\` means the host" >> "$SUMMARY_FILE"
+    echo "responded but the resource is gone." >> "$SUMMARY_FILE"
+    echo "Route to \`/research <subject>\` to refresh the citation, or run" >> "$SUMMARY_FILE"
+    echo "\`/curate --verify\` to confirm before refreshing." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Status | KB Entry | URL | Last Checked |" >> "$SUMMARY_FILE"
+    echo "|--------|----------|-----|--------------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ kb_file url status checked_epoch; do
+        # Convert epoch back to ISO date for display.
+        checked_disp=$(date -d "@$checked_epoch" +%Y-%m-%d 2>/dev/null \
+                       || date -r "$checked_epoch" +%Y-%m-%d 2>/dev/null \
+                       || echo "$checked_epoch")
+        echo "| $status | $kb_file | $url | $checked_disp |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/link-rot.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+# Falsification lens staleness (Analysis 22)
+if [[ -s "$TMPDIR_SCAN/falsification-stale.txt" ]]; then
+    echo "## Falsification Lens Staleness" >> "$SUMMARY_FILE"
+    echo "APPROVED specs authored before a falsification lens shipped that" >> "$SUMMARY_FILE"
+    echo "match keywords associated with that lens. The original Pass 2 may" >> "$SUMMARY_FILE"
+    echo "have missed lens-specific attack categories. Surfaced as candidates;" >> "$SUMMARY_FILE"
+    echo "confirmation in \`/curate --verify\` decides whether to dispatch a" >> "$SUMMARY_FILE"
+    echo "depth pass via \`/spec-author <id> --depth-pass-only --lens <name>\`." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Spec | Created | Missing Lens | Matched Keyword |" >> "$SUMMARY_FILE"
+    echo "|------|---------|--------------|-----------------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ sid created lens matched; do
+        echo "| $sid | $created | $lens | $matched |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/falsification-stale.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # ── Report ───────────────────────────────────────────────────────────────────
 
 echo "Scan complete: $COMMIT_COUNT commits analyzed"
@@ -2034,6 +2298,8 @@ echo "  Unannotated APPROVED specs: $(wc -l < "$TMPDIR_SCAN/spec-unannotated.txt
 echo "  Bare-only annotated specs: $(wc -l < "$TMPDIR_SCAN/spec-bare-only.txt" 2>/dev/null || echo 0)"
 echo "  Aging obligations: $(wc -l < "$TMPDIR_SCAN/aging-obligations.txt" 2>/dev/null || echo 0)"
 echo "  Subdivision candidates: $(wc -l < "$TMPDIR_SCAN/spec-subdivision-candidates.txt" 2>/dev/null || echo 0)"
+echo "  Link rot in KB: $(wc -l < "$TMPDIR_SCAN/link-rot.txt" 2>/dev/null || echo 0)"
+echo "  Falsification staleness: $(wc -l < "$TMPDIR_SCAN/falsification-stale.txt" 2>/dev/null || echo 0)"
 
 # ── Update curation state ─────────────────────────────────────────────────
 

--- a/scripts/lens-registry.txt
+++ b/scripts/lens-registry.txt
@@ -1,0 +1,23 @@
+# vallorcine falsification lens registry
+#
+# Used by curate-scan.sh Analysis 22 (falsification-lens staleness) to
+# detect APPROVED specs whose original Pass 2 falsification predates a
+# given lens shipping. Specs authored before a lens's introduction date
+# AND containing keywords associated with that lens are surfaced as
+# re-falsification candidates.
+#
+# Format (one lens per line, pipe-separated):
+#   <lens_name>|<introduction_date>|<keyword_1>|<keyword_2>|...
+#
+# Rules:
+#   - introduction_date is YYYY-MM-DD (the date the lens shipped to users
+#     via a release tag, NOT the commit date of the lens-registry.txt
+#     update). Lookups compare via lexicographic string comparison.
+#   - Keywords are matched as case-insensitive whole words (\bword\b).
+#     Keep keywords specific enough to avoid common-word false positives.
+#   - Lines starting with `#` and blank lines are ignored.
+#
+# When you ship a new falsification lens, add a line here. The single
+# source of truth for "which lenses exist and when did they ship."
+
+security|2026-04-21|credential|password|token|encrypt|decrypt|crypto|cipher|nonce|PII|secret

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -1,9 +1,9 @@
 ---
 description: "Review codebase quality — find stale decisions, knowledge gaps, and implicit dependencies"
-argument-hint: "[--init] [--deeper]"
+argument-hint: "[--init] [--deeper] [--verify [--analysis link-rot|falsification-stale|all]]"
 ---
 
-# /curate [--init] [--deeper]
+# /curate [--init] [--deeper] [--verify]
 
 Correlation engine that combines vallorcine's structured history with git data
 to find things that individual features, decisions, and research sessions
@@ -23,15 +23,59 @@ couldn't see because they each had a narrower scope.
 11. Cross-reference gaps — KB entries and ADRs with missing related/source links
 12. Missing `@spec` annotations — APPROVED specs with reqs that lack impl-side or test-side annotations
 13. Aging open obligations — obligations on specs that haven't been committed in 30+ days
+14. Link rot — KB-cited URLs that no longer resolve (4xx or connection failures)
+15. Falsification-lens staleness — APPROVED specs authored before a falsification lens shipped that match the lens's keywords (candidates for re-falsification under the newer lens)
 
 **Flags:**
 - `--init` — first-time scan (ignores last-scanned SHA, good for new installs)
 - `--deeper` — scan 6 months instead of default 3
 - `--obligation-age-days <n>` — override aging threshold for open obligations (default: 30)
 - `--max-specs-traced <n>` — cap @spec annotation traces per run (default: 50)
+- `--verify` — focused pass over verification-shaped candidates only
+  (link-rot, falsification-staleness). Skips the broader correlation
+  flow. Dismissals persist to `.curate/verify-dismissed.txt` so future
+  scans don't re-prompt the same items.
+- `--analysis <name>` — when used with `--verify`, restrict to a single
+  analysis: `link-rot`, `falsification-stale`, or `all` (default: `all`).
 
 This command feels like a colleague who noticed something and is offering to help,
 not a task manager assigning work.
+
+## Verify mode
+
+When invoked with `--verify`, this skill runs the same scan but presents
+ONLY the verification-shaped candidates from Analyses 21 (link rot) and
+22 (falsification staleness). The broader correlation flow (ADR
+pressure, hub files, spec-code drift, cross-ref repair, etc.) is
+skipped — those signals belong to the regular `/curate` cadence.
+
+Verify mode is a separate cadence: run it before major work (release
+prep, audit kickoff) or monthly, when the heavier verification pass
+is justified. Regular `/curate` stays drift-shaped; verify mode is
+verification-shaped.
+
+**Per-candidate flow:**
+- Each link-rot row → AskUserQuestion with options: refresh via
+  `/research`, mark accepted, dismiss, skip.
+- Each falsification-stale row → AskUserQuestion with options: run
+  depth pass via `/spec-author <id> --depth-pass-only --lens <name>`,
+  decline (lens does not apply), dismiss, skip.
+
+**Dismissal persistence.** When the user picks "dismiss" in verify
+mode, append a row to `.curate/verify-dismissed.txt`:
+
+```
+<analysis>|<candidate-key>|<dismiss-date>|<reason>
+```
+
+Where `<candidate-key>` is the URL for link-rot or `<spec-id>:<lens>`
+for falsification-staleness. Future verify-mode runs read this file
+and skip any candidate whose key is dismissed (the underlying
+`scan-summary.md` still surfaces them for non-verify `/curate` runs;
+the dismissal only applies to the verify-mode prompt loop).
+
+When the user picks "skip" instead of "dismiss", nothing is recorded
+— the candidate resurfaces next verify-mode run.
 
 ---
 
@@ -81,9 +125,45 @@ bash .claude/scripts/curate-scan.sh [--init] [--window <months>] \
 - If `--init` flag: pass `--init`
 - If `--deeper` flag: pass `--window 6`
 - If the user passes `--obligation-age-days` or `--max-specs-traced`, forward them
+- The `--verify` flag does NOT change the scan invocation — the script still
+  runs every analysis. Verify mode only narrows which candidates the
+  pick-list presents in Step 3.
 
 Run the script. If it exits with "No new commits since last scan," report that
 and ask if the user wants to force a rescan with `--init`.
+
+---
+
+## Step 1.5 — Verify-mode branch
+
+If the user invoked `/curate --verify`:
+
+1. **Filter Step 2 to subsections 2p (link rot) and 2q (falsification
+   staleness) only.** Skip 2a-2o and 2r entirely. The other signals
+   belong to the regular `/curate` cadence.
+2. **Apply the analysis filter.** If the user passed
+   `--analysis link-rot`, only run 2p. If `--analysis falsification-stale`,
+   only run 2q. Default (or `--analysis all`) runs both.
+3. **Read the dismissed-state file** at `.curate/verify-dismissed.txt`
+   (touch it if missing). The format is one row per dismissal:
+   `<analysis>|<candidate-key>|<date>|<reason>`. Build a transient set
+   of dismissed keys.
+4. **Filter candidates by dismissed-state.** When walking the candidate
+   list from the scan summary, skip any candidate whose key matches a
+   dismissed entry. The user already declined to act on it; don't
+   re-prompt until the dismissed entry is manually removed.
+5. **Step 3 pick list shows ONLY verify-mode items.** No other findings
+   surface. The cold-start framing is also skipped — verify mode
+   assumes structured artifacts already exist.
+6. **Step 4 routing in verify mode.** When the user picks "dismiss" on
+   a candidate, append a new row to `.curate/verify-dismissed.txt`:
+   - For link-rot: `link-rot|<url>|<YYYY-MM-DD>|<one-line reason>`
+   - For falsification-stale: `falsification-stale|<spec-id>:<lens>|<YYYY-MM-DD>|<one-line reason>`
+   When the user picks "skip", do NOT write to the dismissed file —
+   "skip" defers; "dismiss" persists.
+
+If the user did NOT pass `--verify`, skip this entire section and run
+Step 2 normally with all subsections.
 
 ---
 
@@ -386,6 +466,75 @@ For each aging obligation, use AskUserQuestion with options:
   design narrative explaining the closure
 - **"Skip for now"** — defer to next /curate pass
 
+### 2p — Link rot in KB entries
+
+**Guard:** Only run this step if "Link Rot in KB Entries" section exists in
+the scan summary. If absent, skip entirely.
+
+From "Link Rot in KB Entries" in the scan summary:
+
+1. Each row shows a status code, the KB entry path, the URL, and when it
+   was last checked. Status `000` indicates a connection failure (DNS,
+   timeout, refused). Status `4xx` indicates the server responded but the
+   resource is gone.
+2. Dead URLs in KB entries silently rot the knowledge: the stored fact
+   looks authoritative but the source it claims to ground no longer
+   exists. Higher-impact when the KB entry is heavily cross-referenced.
+3. The script caches per-URL results (7-day TTL) so the same dead URLs
+   don't trigger fresh `curl` requests on every scan.
+
+For each candidate, use AskUserQuestion with options:
+- **"Refresh via /research"** (description: "Run /research <subject> to
+  re-investigate the topic and replace the dead citation with a current
+  source")
+- **"Verify via /curate --verify"** (description: "Confirm via WebFetch
+  that the URL is genuinely gone before refreshing — useful when transient
+  connection failures may have produced false positives")
+- **"Mark as accepted"** (description: "The URL is gone but the cited
+  fact is still valid in the KB; record acceptance in the curation
+  review log so the same URL doesn't resurface")
+- **"Skip"** — defer to next /curate pass
+
+If "Refresh": invoke `/research "<subject inferred from KB entry>" context: "curate: dead citation at <kb-path>, URL <url> returned <status>"`.
+If "Mark as accepted": append the URL to a `link-rot-accepted` block in
+`.curate/curation-state.md`. The cache continues to track it; future scans
+surface it but the review log shows the user's prior acceptance.
+
+### 2q — Falsification-lens staleness
+
+**Guard:** Only run this step if "Falsification Lens Staleness" section
+exists in the scan summary. If absent, skip entirely.
+
+From "Falsification Lens Staleness" in the scan summary:
+
+1. Each row shows an APPROVED spec, its git first-commit-touched date,
+   the lens whose introduction date post-dates the spec, and the keyword
+   from the spec body that matched the lens's pattern.
+2. The signal: the spec's original Pass 2 falsification predates this
+   lens shipping, so attack categories the lens covers (e.g., adversary-
+   model patterns from the security lens shipped in v0.14.2) may not
+   have been considered.
+3. The match is heuristic. A spec mentioning "auth" doesn't necessarily
+   need a security depth pass; the user judges whether the lens applies.
+
+For each candidate, use AskUserQuestion with options:
+- **"Run depth pass via /spec-author"** (description: "Run
+  `/spec-author <spec-id> --depth-pass-only --lens <lens>` to re-falsify
+  the spec under the named lens; findings flow through the standard
+  arbitration UI")
+- **"Decline — lens does not apply"** (description: "The keyword match
+  is incidental; the spec's scope does not actually need the lens's
+  attack categories. Records a decline so future scans don't resurface
+  this lens for this spec")
+- **"Skip"** — defer to next /curate pass
+
+If "Run depth pass": invoke
+`/spec-author <spec-id> --depth-pass-only --lens <lens>` directly.
+If "Decline": append a `falsification-decline` row to
+`.curate/curation-state.md` keyed by `<spec-id>:<lens>`. The script
+continues to surface this candidate, but the review log shows the
+user's prior decline.
+
 ### 2o — Subdivision candidates (mature specs that may want to subdivide)
 
 **Guard:** Only run this step if "Subdivision Candidates" section exists in
@@ -517,6 +666,12 @@ I scanned <N> commits since last review and found <N> items:
 
  17. Spec <ID> — open obligation aging <N> days (spec file not committed in that time)
      → I'll route to /spec-author or /spec-resolve to close or resolve it
+
+ 18. <KB entry> — <N> dead citation URLs (status <code>)
+     → I'll show each one so you can refresh via /research or accept the rot
+
+ 19. Spec <ID> — authored <date>, predates <lens> lens (matched keyword "<word>")
+     → I'll show the lens scope so you can run a depth pass or decline
 
 Items you don't address are saved automatically — run /curate anytime to pick them up.
 ```
@@ -827,6 +982,73 @@ If "Close as stale": edit the spec file — remove the obligation entry from the
 design narrative (e.g., "Closed aging obligation on `<date>`: `<text>` — no
 longer relevant because …"), and stage the change. Do not commit unless the
 user explicitly requests it.
+
+**Link rot in KB entry:** Read the KB entry and locate the dead URL in
+context (one or two surrounding lines so the user sees what the URL was
+backing). Present: "KB entry `<path>` cites `<url>` — last check returned
+`<status>` on `<date>`."
+
+Use AskUserQuestion. The options depend on whether `--verify` is active:
+
+In normal `/curate` mode:
+  - "Refresh via /research" (description: "Re-investigate the topic and
+    replace the dead citation with a current source")
+  - "Verify via /curate --verify" (description: "Re-check via verify
+    mode for confirmation before action")
+  - "Mark as accepted" (description: "The URL is gone but the cited fact
+    is still valid; record acceptance so it doesn't resurface")
+  - "Skip" (description: "Defer to next /curate pass")
+
+In `--verify` mode:
+  - "Refresh via /research" (description: same as above)
+  - "Mark as accepted" (description: same as above)
+  - "Dismiss" (description: "Persistent skip — record in
+    .curate/verify-dismissed.txt so future verify runs don't re-prompt")
+  - "Skip" (description: "Defer to next verify pass")
+
+If "Refresh": invoke
+`/research "<subject>" context: "curate: dead citation at <kb-path>, URL <url> returned <status>"`.
+Infer the subject from the KB entry's title or topic context.
+If "Mark as accepted": append the URL to a `link-rot-accepted` block in
+`.curate/curation-state.md` with a one-line justification. The cache
+continues tracking it; future scans surface but the review log shows
+prior acceptance.
+If "Dismiss" (verify mode only): append
+`link-rot|<url>|<YYYY-MM-DD>|<reason>` to `.curate/verify-dismissed.txt`.
+Prompt the user for a one-line reason; default to "user dismissed".
+
+**Falsification-lens staleness candidate:** Read the spec file and the
+named lens reference (e.g., `prompts/audit/lens-security.md` for the
+security lens). Present: "Spec `<id>` was authored `<date>`, before the
+`<lens>` lens shipped on `<lens-date>`. The spec mentions `<keyword>`,
+which suggests the lens may apply. Running a depth pass under this lens
+will look for attack categories the original Pass 2 may have missed."
+
+Use AskUserQuestion. The options depend on whether `--verify` is active:
+
+In normal `/curate` mode:
+  - "Run depth pass via /spec-author" (description: "Re-falsify the spec
+    under the named lens; findings flow through standard arbitration")
+  - "Decline — lens does not apply" (description: "Keyword match is
+    incidental; spec scope does not actually need the lens's coverage")
+  - "Skip" (description: "Defer to next /curate pass")
+
+In `--verify` mode:
+  - "Run depth pass via /spec-author" (description: same as above)
+  - "Decline — lens does not apply" (description: same as above)
+  - "Dismiss" (description: "Persistent skip — record in
+    .curate/verify-dismissed.txt so future verify runs don't re-prompt")
+  - "Skip" (description: "Defer to next verify pass")
+
+If "Run depth pass": invoke
+`/spec-author <spec-id> --depth-pass-only --lens <lens-name>`.
+If "Decline": append a `falsification-decline` row to
+`.curate/curation-state.md` keyed by `<spec-id>:<lens>`. The scan
+continues to surface; the review log shows the prior decline.
+If "Dismiss" (verify mode only): append
+`falsification-stale|<spec-id>:<lens>|<YYYY-MM-DD>|<reason>` to
+`.curate/verify-dismissed.txt`. Prompt for a one-line reason; default
+to "user dismissed".
 
 After completing the action, mark it `resolved` in the review log. Then
 **ALWAYS re-present the remaining items** (renumbered) so the user can

--- a/skills/spec-author/SKILL.md
+++ b/skills/spec-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: "Author a hardened spec through multi-pass adversarial review"
-argument-hint: "<feature-id> <title>"
+argument-hint: "<feature-id> <title> | <spec-id> --depth-pass-only [--lens <name>]"
 effort: high
 ---
 
@@ -16,6 +16,15 @@ read during authoring is pre-existing components (for prerequisite stubs).
 Checking the spec against the feature's implementation is `/spec-verify`'s
 job, not this skill's.
 
+**Two entry paths:**
+
+- **Default (fresh authoring):** `/spec-author <feature-id> <title>` — runs
+  Pass 1 (draft) → Pass 2 (falsification) → Pass 3 (depth pass) → register.
+- **Depth-pass-only:** `/spec-author <spec-id> --depth-pass-only [--lens <name>]`
+  — re-falsify an existing APPROVED spec under the current lens corpus
+  (or a specific lens). Skips Pass 1 and Pass 2. See the **Depth-pass-only
+  mode** section below.
+
 ---
 
 ## Inputs expected in context
@@ -25,6 +34,82 @@ job, not this skill's.
 - The domain analysis (from `.feature/<slug>/domains.md` if available)
 - The work plan (from `.feature/<slug>/work-plan.md` if available)
 - Optionally, a resolved spec context bundle from `/spec-resolve`
+
+---
+
+## Depth-pass-only mode
+
+When invoked with `--depth-pass-only`, this skill skips Pass 1 (drafting)
+and Pass 2 (initial falsification) and runs only the Pass 3 depth pass
+against an existing APPROVED spec. Use this to re-falsify a mature spec
+under the current lens corpus — typically because `/curate` flagged the
+spec as authored before a falsification lens shipped (e.g., specs from
+before the security lens added in v0.14.2).
+
+**Invocation:**
+
+```
+/spec-author <spec-id> --depth-pass-only [--lens <lens_name>]
+```
+
+- `<spec-id>` — must resolve to an APPROVED spec via the manifest. DRAFT
+  specs go through normal Pass 1/2/3; depth-pass-only refuses them.
+- `--lens <name>` — optional. Bias the depth pass toward a specific lens
+  reference. Without it, the full lens corpus applies. Lens references
+  live at `prompts/audit/lens-<name>.md` (e.g., `lens-security.md`).
+  See `scripts/lens-registry.txt` for the current set of lens names and
+  their introduction dates.
+
+**Behavior:**
+
+1. **Resolve the target spec.** Look up `<spec-id>` via
+   `spec_file_for_id` in the manifest. If state is not APPROVED, refuse
+   and tell the user to use the default `/spec-author` flow instead.
+2. **Validate the lens (if `--lens` given).** Check that
+   `.claude/prompts/audit/lens-<name>.md` exists (installed layout) or
+   `prompts/audit/lens-<name>.md` (dev-repo). If neither exists, list
+   the available lenses (from `scripts/lens-registry.txt`) and stop.
+3. **Skip the fresh-authoring pre-flight steps** (revival detection,
+   work-group context, layered-spec family load) — they are scoped to
+   new authoring. The only pre-flight needed for depth-pass-only is:
+   - Read the spec body via the resolved file path.
+   - If the spec has `parent_spec` set, run the layered-spec family
+     load (Pre-flight Step 6) so siblings are visible to the depth pass.
+   - Read any KB adversarial findings for the spec's domains (Pass 2
+     "KB adversarial findings" loader).
+4. **Skip Pass 1 and Pass 2.**
+5. **Run Pass 3 with adapted inputs.** Dispatch the depth-pass subagent
+   with:
+   - The full spec body as input (not "Pass 1 draft").
+   - Empty prior-findings set (the original Pass 2 findings are not
+     retrieved — too lossy across kit versions; the depth pass starts
+     fresh against the spec as it stands).
+   - If `--lens <name>` was given: include the named lens reference
+     prompt as additional context, with framing: "Focus your
+     falsification on attack categories surfaced by this lens. Other
+     lenses may apply but are secondary."
+   - If `--lens` was not given: the full standard lens corpus.
+6. **Standard arbitration UI.** Findings flow through the Pass 2/3
+   arbitration grouping (confirmed gaps, implementation constraints,
+   observability, uncertain). User accepts/declines per finding.
+7. **Apply accepted findings** to the spec via the standard amendment
+   flow (in-place edits + spec-write re-registration; the manifest's
+   `version:` field bumps).
+
+**Signal-to-noise expectation.** Lower than a fresh Pass 2 — specs in
+production have already encountered real-world inputs and survived
+many edge cases. A strong-model depth pass under a newer lens commonly
+surfaces 5-15 findings on mature specs that predate the lens; some
+will be already-mitigated in code (the spec just doesn't say so) and
+others will be genuine gaps. The arbitration UI lets the user judge.
+
+**Decline routing back to /curate.** If the user's arbitration declines
+all findings as not-applicable, that's a signal the lens really doesn't
+apply to this spec. Append a `falsification-decline` row to
+`.curate/curation-state.md` keyed by `<spec-id>:<lens>` so future
+`/curate` scans show the prior decline. This step only runs when
+invoked via `/curate --verify` routing — manual invocations don't
+record declines (the user can still surface them via /curate).
 
 ---
 
@@ -612,6 +697,11 @@ just informs the user that natural subdivision has become an option.
 
 After applying the user's arbitration decisions from Pass 2, automatically
 run a depth pass. Do not prompt — this is mandatory.
+
+(Pass 3 is also the entry point for **depth-pass-only mode** — see the
+top-of-file section. When entered via `--depth-pass-only`, the depth
+pass runs against the existing spec body with empty prior-findings,
+optionally biased toward a single lens reference.)
 
 Round 2 fixes create new attack surface that round 1 could not see.
 Empirical data across multiple specs shows round 2 consistently finds

--- a/tests/scenario-curate-falsification-stale.sh
+++ b/tests/scenario-curate-falsification-stale.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# Scenario: /curate falsification-lens staleness detector (Analysis 22).
+#
+# Validates curate-scan.sh's falsification-staleness detection: APPROVED
+# specs authored before a falsification lens shipped that match the lens's
+# keyword pattern are surfaced as re-falsification candidates. Specs
+# authored after the lens, or pre-lens specs without lens keywords, are
+# NOT surfaced (no false positives).
+#
+# Layered cover:
+#
+#   1. Pre-lens spec WITH lens keywords IS flagged.
+#   2. Post-lens spec is NOT flagged (no staleness signal).
+#   3. Pre-lens spec WITHOUT lens keywords is NOT flagged.
+#   4. DRAFT and INVALIDATED specs are NOT flagged (only APPROVED).
+#   5. Output section + table format match the schema downstream readers
+#      expect (Spec | Created | Missing Lens | Matched Keyword columns).
+#   6. Lens registry comment lines and blank lines are skipped.
+#   7. Multiple lenses can apply to the same spec (one row per lens).
+#
+# Run from repo root: bash tests/scenario-curate-falsification-stale.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: /curate falsification-lens staleness (Analysis 22)"
+echo "────────────────────────────────────────────────"
+
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine-curate-falsification.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.spec/registry" \
+         "$PROJ/.spec/domains/auth" \
+         "$PROJ/.spec/domains/storage" \
+         "$PROJ/.spec/domains/util" \
+         "$PROJ/.curate" \
+         "$PROJ/scripts"
+cd "$PROJ"
+
+# Initialize git so the script's first-commit-date logic works.
+git init -q
+git config user.email test@example.com
+git config user.name "Test"
+git commit -q --allow-empty --date='2026-01-01T00:00:00Z' -m "initial"
+
+# ── Build synthetic lens registry ──────────────────────────────────────────
+#
+# Two lenses with different introduction dates and keyword patterns.
+# Comment + blank lines included to exercise the parser.
+
+cat > "$PROJ/scripts/lens-registry.txt" <<'EOF'
+# Test lens registry — comments must be skipped
+
+security|2026-04-21|credential|password|encrypt|cipher|secret
+
+concurrency|2026-02-01|deadlock|race|mutex|lock_order
+EOF
+
+# ── Build synthetic specs ──────────────────────────────────────────────────
+
+build_spec() {
+  local file="$1" id="$2" state="$3" body="$4"
+  cat > "$file" <<EOF
+---
+{
+  "id": "$id",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "$state",
+  "domains": ["auth"],
+  "requires": [],
+  "invalidates": [],
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+
+# $id
+
+$body
+EOF
+}
+
+# (a) Pre-security-lens APPROVED spec with security keywords — should flag.
+build_spec "$PROJ/.spec/domains/auth/credential-store.md" \
+           "auth.credential-store" "APPROVED" \
+           "R1. The credential vault must encrypt secrets at rest.
+R2. Password rotation must run every 90 days.
+R3. Cipher suites must be FIPS-approved."
+
+# (b) Post-security-lens APPROVED spec with security keywords — should NOT
+#     flag (added in a separate commit at a date AFTER the lens shipped,
+#     so its git first-add date is post-lens).
+
+# (c) Pre-security-lens APPROVED spec WITHOUT security keywords — should
+#     NOT flag (no keyword match means no signal).
+build_spec "$PROJ/.spec/domains/storage/format-v2.md" \
+           "storage.format-v2" "APPROVED" \
+           "R1. Records must be sorted by primary key on flush.
+R2. Compaction must run when level size exceeds threshold.
+R3. Page checksums must be verified on read."
+
+# (d) Pre-security-lens DRAFT spec with security keywords — should NOT
+#     flag (only APPROVED specs surface).
+build_spec "$PROJ/.spec/domains/auth/oauth-flow.md" \
+           "auth.oauth-flow" "DRAFT" \
+           "R1. Encrypt all OAuth tokens at rest.
+R2. Credentials must rotate hourly."
+
+# (e) Pre-security-lens INVALIDATED spec with security keywords — should
+#     NOT flag (INVALIDATED is historical, not a candidate).
+build_spec "$PROJ/.spec/domains/auth/legacy-cipher.md" \
+           "auth.legacy-cipher" "INVALIDATED" \
+           "R1. Use legacy cipher for backwards compatibility."
+
+# (f) Pre-both-lenses APPROVED spec matching BOTH lenses (security +
+#     concurrency) — should flag once per matching lens.
+build_spec "$PROJ/.spec/domains/util/multi-lens.md" \
+           "util.multi-lens" "APPROVED" \
+           "R1. Encrypt session keys before sharing across threads.
+R2. Avoid deadlock by enforcing lock_order on shared mutex."
+
+# Manifest with all 6 specs (token-issuer added later in a separate commit).
+cat > "$PROJ/.spec/registry/manifest.json" <<'EOF'
+{
+  "schema_version": 2,
+  "generated_at": "2026-01-15T00:00:00Z",
+  "spec_count": 6,
+  "specs": [
+    {"id":"auth.credential-store",
+     "path":".spec/domains/auth/credential-store.md",
+     "state":"APPROVED","version":1,"domains":["auth"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"auth.token-issuer",
+     "path":".spec/domains/auth/token-issuer.md",
+     "state":"APPROVED","version":1,"domains":["auth"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"storage.format-v2",
+     "path":".spec/domains/storage/format-v2.md",
+     "state":"APPROVED","version":1,"domains":["storage"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"auth.oauth-flow",
+     "path":".spec/domains/auth/oauth-flow.md",
+     "state":"DRAFT","version":1,"domains":["auth"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"auth.legacy-cipher",
+     "path":".spec/domains/auth/legacy-cipher.md",
+     "state":"INVALIDATED","version":1,"domains":["auth"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]},
+    {"id":"util.multi-lens",
+     "path":".spec/domains/util/multi-lens.md",
+     "state":"APPROVED","version":1,"domains":["util"],
+     "requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]}
+  ]
+}
+EOF
+
+# Empty obligations registry (curate-scan reads it).
+echo '{"obligations": []}' > "$PROJ/.spec/registry/_obligations.json"
+
+# Set spec creation dates via git commits at specific dates. Pre-lens
+# specs (2026-01-15): credential-store, format-v2, oauth-flow,
+# legacy-cipher, multi-lens. The manifest is also committed here.
+git add .spec
+git commit -q --date='2026-01-15T00:00:00Z' -m "pre-lens specs" \
+           --author='Test <test@example.com>' \
+           >/dev/null
+
+# Post-security-lens (2026-04-25): token-issuer added in a separate
+# commit at a later date. Its git first-add date is what the script
+# uses to determine staleness.
+build_spec "$PROJ/.spec/domains/auth/token-issuer.md" \
+           "auth.token-issuer" "APPROVED" \
+           "R1. Tokens must be encrypted in transit.
+R2. Cipher choice must follow current NIST guidance."
+git add .spec/domains/auth/token-issuer.md
+git commit -q --date='2026-04-25T00:00:00Z' -m "post-lens token-issuer added" \
+           --author='Test <test@example.com>' \
+           >/dev/null
+
+# Empty curate state.
+echo "Last scanned: " > "$PROJ/.curate/curation-state.md"
+
+# ── Run curate-scan ────────────────────────────────────────────────────────
+
+echo ""
+echo "── Running curate-scan against synthetic project"
+
+cd "$PROJ"
+SUMMARY_FILE="$PROJ/.curate/scan-summary.md"
+bash "$REPO_ROOT/scripts/curate-scan.sh" --init >/tmp/curate-fals-out.log 2>&1
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+  pass "curate-scan completed without error"
+else
+  fail "curate-scan exited $rc" "$(tail -10 /tmp/curate-fals-out.log)"
+  echo ""
+  echo "────────────────────────────────────────────────"
+  echo "FAILED  $failed/$total"
+  exit 1
+fi
+
+if [[ -f "$SUMMARY_FILE" ]]; then
+  pass "summary file written"
+else
+  fail "summary file missing"
+  exit 1
+fi
+
+# ── Layer 1: pre-lens spec with keywords IS flagged ────────────────────────
+
+echo ""
+echo "── Layer 1: pre-lens spec with security keywords IS flagged"
+
+if grep -q '^| auth.credential-store ' "$SUMMARY_FILE"; then
+  pass "auth.credential-store appears in Falsification Lens Staleness"
+else
+  fail "pre-lens spec with keywords NOT flagged" \
+       "$(grep -A 10 'Falsification Lens Staleness' "$SUMMARY_FILE" || echo '(no section)')"
+fi
+
+# ── Layer 2: post-lens spec is NOT flagged ─────────────────────────────────
+
+echo ""
+echo "── Layer 2: post-lens spec is NOT flagged"
+
+# auth.token-issuer was first-committed at 2026-04-25, after security lens
+# (2026-04-21) shipped — it should NOT appear.
+if grep -qE '\| auth.token-issuer \|.*\| security \|' "$SUMMARY_FILE"; then
+  fail "post-lens spec was incorrectly flagged for security lens"
+else
+  pass "post-lens spec is not flagged"
+fi
+
+# ── Layer 3: pre-lens spec without keywords is NOT flagged ─────────────────
+
+echo ""
+echo "── Layer 3: pre-lens spec without keywords is NOT flagged"
+
+if grep -qE '\| storage.format-v2 \|.*\| security \|' "$SUMMARY_FILE"; then
+  fail "pre-lens spec without security keywords was incorrectly flagged"
+else
+  pass "pre-lens spec without keywords is not flagged"
+fi
+
+# ── Layer 4: DRAFT and INVALIDATED specs are NOT flagged ───────────────────
+
+echo ""
+echo "── Layer 4: DRAFT and INVALIDATED specs are NOT flagged"
+
+if grep -q '^| auth.oauth-flow ' "$SUMMARY_FILE"; then
+  fail "DRAFT spec was incorrectly flagged"
+else
+  pass "DRAFT spec is not flagged"
+fi
+
+if grep -q '^| auth.legacy-cipher ' "$SUMMARY_FILE"; then
+  fail "INVALIDATED spec was incorrectly flagged"
+else
+  pass "INVALIDATED spec is not flagged"
+fi
+
+# ── Layer 5: section header + table format ─────────────────────────────────
+
+echo ""
+echo "── Layer 5: section header + table format"
+
+if grep -q '^## Falsification Lens Staleness' "$SUMMARY_FILE"; then
+  pass "Falsification Lens Staleness section present"
+else
+  fail "section header missing"
+fi
+
+if grep -qE '^\| Spec \| Created \| Missing Lens \| Matched Keyword \|' "$SUMMARY_FILE"; then
+  pass "table header has expected columns"
+else
+  fail "table header missing or malformed"
+fi
+
+# Sample row sanity: should have a date column with YYYY-MM-DD format.
+if grep -qE '\| auth.credential-store \| [0-9]{4}-[0-9]{2}-[0-9]{2} \| security \|' "$SUMMARY_FILE"; then
+  pass "row format has spec | YYYY-MM-DD date | lens"
+else
+  fail "row format malformed" \
+       "$(grep '^| auth.credential-store' "$SUMMARY_FILE" || echo '(no row)')"
+fi
+
+# ── Layer 6: multi-lens spec flagged for both lenses ───────────────────────
+
+echo ""
+echo "── Layer 6: multi-lens spec flagged for each matching lens"
+
+# util.multi-lens has both security and concurrency keywords; it was
+# committed at 2026-01-15 (pre both 2026-02-01 concurrency and 2026-04-21
+# security lenses). Both rows should appear.
+sec_rows=$(grep -cE '\| util.multi-lens \|.*\| security \|' "$SUMMARY_FILE" || true)
+con_rows=$(grep -cE '\| util.multi-lens \|.*\| concurrency \|' "$SUMMARY_FILE" || true)
+
+if [[ "$sec_rows" -ge 1 ]]; then
+  pass "multi-lens spec flagged for security lens"
+else
+  fail "multi-lens spec missing security row"
+fi
+
+if [[ "$con_rows" -ge 1 ]]; then
+  pass "multi-lens spec flagged for concurrency lens"
+else
+  fail "multi-lens spec missing concurrency row" \
+       "$(grep '^| util.multi-lens' "$SUMMARY_FILE" || echo '(no rows)')"
+fi
+
+# ── Layer 7: lens-registry comments and blanks are skipped ─────────────────
+
+echo ""
+echo "── Layer 7: lens-registry parser tolerates comments + blank lines"
+
+# We injected comment + blank lines in the registry. If the parser misread
+# them, a malformed lens row would either crash the script or appear in
+# the summary as garbled output. Check both: no crash (already verified),
+# and no garbled lens names in the rendered table.
+malformed=$(grep -E '^\| [A-Za-z0-9_.-]+ \| [^|]+ \| (#|$| ) \|' "$SUMMARY_FILE" || true)
+if [[ -z "$malformed" ]]; then
+  pass "no malformed lens rows from comment/blank-line parsing"
+else
+  fail "malformed lens row" "$malformed"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+  echo "ALL PASSED  ($passed/$total)"
+  exit 0
+else
+  echo "FAILED  $failed/$total  ($passed passed)"
+  exit 1
+fi

--- a/tests/scenario-curate-link-rot.sh
+++ b/tests/scenario-curate-link-rot.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# Scenario: /curate link-rot detector (Analysis 21).
+#
+# Validates curate-scan.sh's link-rot detection: KB entries with citation
+# URLs are scanned, dead URLs (4xx + connection failures) are flagged,
+# and the cache prevents re-checking confirmed-dead URLs on every scan.
+#
+# Layered cover:
+#
+#   1. Unreachable URL (curl returns 000) is flagged.
+#   2. Cached-as-200 URL is NOT flagged.
+#   3. URLs inside fenced code blocks are NOT extracted.
+#   4. Cached confirmed-dead URLs surface from cache without re-curling.
+#   5. Markdown-link URLs `[text](url)` are extracted correctly.
+#   6. Bare URLs `https://...` are extracted correctly.
+#   7. Trailing prose punctuation is stripped from bare URLs.
+#   8. Output section + table format match the schema downstream readers
+#      expect (status, KB entry, URL, last-checked columns).
+#   9. Cache file is updated atomically with new entries.
+#  10. KB excluded paths (_refs, _archive, CLAUDE.md) are skipped.
+#
+# Run from repo root: bash tests/scenario-curate-link-rot.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: /curate link-rot detector (Analysis 21)"
+echo "────────────────────────────────────────────────"
+
+# Skip if curl missing — link-rot analysis silently degrades but the test
+# harness can't validate behavior without it.
+if ! command -v curl >/dev/null 2>&1; then
+  echo "  SKIP  curl not available"
+  exit 0
+fi
+
+# Synthetic project tree under /tmp/vallorcine/* for permission pre-grant.
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine-curate-link-rot.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.kb/storage/format" \
+         "$PROJ/.kb/_refs" \
+         "$PROJ/.kb/security/_archive" \
+         "$PROJ/.curate"
+cd "$PROJ"
+
+# Initialize empty git repo so curate-scan's git operations don't crash.
+git init -q
+git config user.email test@example.com
+git config user.name "Test"
+git commit -q --allow-empty -m "initial"
+
+# ── Build synthetic KB entries ─────────────────────────────────────────────
+
+# (a) Entry with one unreachable URL (will resolve to status 000 — connection
+#     refused on port 1). Plus a markdown-linked URL we'll pre-cache as 200.
+cat > "$PROJ/.kb/storage/format/lsm-tree.md" <<'EOF'
+---
+title: LSM-tree storage
+type: pattern
+applies_to: [src/storage/lsm.go]
+related: []
+research_status: active
+last_researched: "2026-04-01"
+---
+
+# LSM-tree storage
+
+Bare URL pointing to a guaranteed-unreachable port:
+http://127.0.0.1:1/dead-citation.
+
+A markdown-linked source: [Wikipedia entry](https://example.org/wiki/LSM_tree).
+
+Trailing punctuation should be stripped: see http://127.0.0.1:1/another-dead.
+
+```
+# Code fence — URLs in here MUST NOT be extracted.
+http://127.0.0.1:1/inside-fence
+[Decoy](http://127.0.0.1:1/decoy-in-fence)
+```
+
+A second bare URL in prose: https://example.org/wiki/Bloom_filter.
+EOF
+
+# (b) Entry under _refs — must be excluded by the find filter.
+cat > "$PROJ/.kb/_refs/refs-only.md" <<'EOF'
+---
+title: Refs-only
+---
+This URL must not be processed: http://127.0.0.1:1/ref-only-dead
+EOF
+
+# (c) Entry under _archive — must be excluded.
+cat > "$PROJ/.kb/security/_archive/archived.md" <<'EOF'
+---
+title: Archived
+---
+This URL must not be processed: http://127.0.0.1:1/archive-dead
+EOF
+
+# (d) CLAUDE.md inside a category — must be excluded by name filter.
+cat > "$PROJ/.kb/storage/CLAUDE.md" <<'EOF'
+# Storage topic index
+- format/lsm-tree.md
+EOF
+
+# Pre-populate the cache so example.org URLs do not get fresh-curled
+# (avoids real-network dependency in CI). Both example.org URLs cache as
+# status 200 (reachable) so they should NOT appear in the rot output.
+NOW=$(date +%s)
+cat > "$PROJ/.curate/link-rot-cache.txt" <<EOF
+https://example.org/wiki/LSM_tree|200|$NOW
+https://example.org/wiki/Bloom_filter|200|$NOW
+EOF
+
+# ── Run curate-scan (first invocation: fresh) ──────────────────────────────
+
+echo ""
+echo "── Run 1: fresh scan, unreachable URLs should curl + cache + flag"
+
+cd "$PROJ"
+SUMMARY_FILE="$PROJ/.curate/scan-summary.md"
+bash "$REPO_ROOT/scripts/curate-scan.sh" --init >/tmp/curate-link-rot-1.log 2>&1
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+  pass "curate-scan run 1 completed without error"
+else
+  fail "curate-scan run 1 exited $rc" "$(tail -10 /tmp/curate-link-rot-1.log)"
+  echo ""
+  echo "────────────────────────────────────────────────"
+  echo "FAILED  $failed/$total"
+  exit 1
+fi
+
+if [[ -f "$SUMMARY_FILE" ]]; then
+  pass "summary file written"
+else
+  fail "summary file missing"
+  exit 1
+fi
+
+# ── Layer 1: unreachable URL flagged ───────────────────────────────────────
+
+echo ""
+echo "── Layer 1: unreachable URLs are flagged"
+
+if grep -q 'http://127.0.0.1:1/dead-citation' "$SUMMARY_FILE"; then
+  pass "first unreachable URL appears in summary"
+else
+  fail "first unreachable URL not flagged" "$(grep -A 10 'Link Rot' "$SUMMARY_FILE" || echo '(no section)')"
+fi
+
+if grep -q 'http://127.0.0.1:1/another-dead' "$SUMMARY_FILE"; then
+  pass "second bare URL is flagged with trailing punctuation stripped"
+else
+  fail "second bare URL not flagged or punctuation not stripped"
+fi
+
+# ── Layer 2: cached-as-200 URLs NOT flagged ────────────────────────────────
+
+echo ""
+echo "── Layer 2: cached-200 URLs are NOT flagged"
+
+if grep -q 'example.org/wiki/LSM_tree' "$SUMMARY_FILE"; then
+  fail "cached-as-200 markdown link was incorrectly flagged"
+else
+  pass "cached-as-200 markdown link is not flagged"
+fi
+
+if grep -q 'example.org/wiki/Bloom_filter' "$SUMMARY_FILE"; then
+  fail "cached-as-200 bare URL was incorrectly flagged"
+else
+  pass "cached-as-200 bare URL is not flagged"
+fi
+
+# ── Layer 3: URLs inside code fence excluded ────────────────────────────────
+
+echo ""
+echo "── Layer 3: URLs inside fenced code blocks are NOT extracted"
+
+if grep -q 'inside-fence' "$SUMMARY_FILE" || grep -q 'decoy-in-fence' "$SUMMARY_FILE"; then
+  fail "code-fenced URL leaked into the rot output"
+else
+  pass "code-fenced URLs are excluded"
+fi
+
+# ── Layer 4: excluded paths (_refs, _archive, CLAUDE.md) ───────────────────
+
+echo ""
+echo "── Layer 4: excluded paths are not scanned"
+
+if grep -q 'ref-only-dead' "$SUMMARY_FILE"; then
+  fail "_refs path was scanned (should be excluded)"
+else
+  pass "_refs path is excluded"
+fi
+
+if grep -q 'archive-dead' "$SUMMARY_FILE"; then
+  fail "_archive path was scanned (should be excluded)"
+else
+  pass "_archive path is excluded"
+fi
+
+# ── Layer 5: section header + table format ─────────────────────────────────
+
+echo ""
+echo "── Layer 5: section header + table format"
+
+if grep -q '^## Link Rot in KB Entries' "$SUMMARY_FILE"; then
+  pass "Link Rot section header present"
+else
+  fail "Link Rot section header missing"
+fi
+
+if grep -qE '^\| Status \| KB Entry \| URL \| Last Checked \|' "$SUMMARY_FILE"; then
+  pass "table header has expected columns"
+else
+  fail "table header missing or malformed"
+fi
+
+# Status code "000" should appear in at least one row (since unreachable
+# URLs all hit 127.0.0.1:1 which refuses connection).
+if grep -qE '^\| 000 \|' "$SUMMARY_FILE"; then
+  pass "rows include 000 status for connection failures"
+else
+  fail "no row with 000 status — connection-refused detection broken"
+fi
+
+# ── Layer 6: cache file updated ────────────────────────────────────────────
+
+echo ""
+echo "── Layer 6: cache updated with new dead-URL entries"
+
+CACHE_FILE="$PROJ/.curate/link-rot-cache.txt"
+if grep -q 'http://127.0.0.1:1/dead-citation|000|' "$CACHE_FILE"; then
+  pass "cache contains dead-citation entry"
+else
+  fail "cache missing dead-citation entry" "$(cat "$CACHE_FILE")"
+fi
+
+# Pre-existing example.org entries should still be present after merge.
+if grep -q 'example.org/wiki/LSM_tree|200|' "$CACHE_FILE"; then
+  pass "pre-existing cache entries preserved across run"
+else
+  fail "cache merge dropped pre-existing entries"
+fi
+
+# ── Layer 7: cache hit prevents re-curl on second run ──────────────────────
+
+echo ""
+echo "── Run 2: cache hit, no fresh curl, dead URLs still surfaced"
+
+# Capture cache mtime to detect whether the cache was rewritten.
+cache_mtime_before=$(stat -c %Y "$CACHE_FILE" 2>/dev/null \
+                     || stat -f %m "$CACHE_FILE" 2>/dev/null)
+
+# Sleep 1s so any rewrite would have a different mtime.
+sleep 1
+
+bash "$REPO_ROOT/scripts/curate-scan.sh" --init >/tmp/curate-link-rot-2.log 2>&1
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+  pass "curate-scan run 2 completed without error"
+else
+  fail "curate-scan run 2 exited $rc" "$(tail -10 /tmp/curate-link-rot-2.log)"
+fi
+
+# Dead URLs should still be flagged (from cache).
+if grep -q 'http://127.0.0.1:1/dead-citation' "$SUMMARY_FILE"; then
+  pass "cached dead URLs still surfaced on run 2"
+else
+  fail "dead URLs lost between runs (cache lookup broken)"
+fi
+
+cache_mtime_after=$(stat -c %Y "$CACHE_FILE" 2>/dev/null \
+                    || stat -f %m "$CACHE_FILE" 2>/dev/null)
+
+# Cache should NOT have been rewritten this run (no new fresh-curl entries).
+if [[ "$cache_mtime_before" == "$cache_mtime_after" ]]; then
+  pass "cache not rewritten on run 2 (TTL hit, no fresh curls)"
+else
+  # Some bash builtins or filesystems may touch the file even on
+  # no-op writes; treat as a soft assertion.
+  echo "  NOTE  cache mtime changed between runs (acceptable on some FSes)"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+  echo "ALL PASSED  ($passed/$total)"
+  exit 0
+else
+  echo "FAILED  $failed/$total  ($passed passed)"
+  exit 1
+fi

--- a/tests/scenario-curate-verify-routing.sh
+++ b/tests/scenario-curate-verify-routing.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Scenario: /curate --verify mode (structural).
+#
+# Validates that the curate SKILL.md prompt declares the --verify flag,
+# describes the verify-mode branch (skips correlation, focuses on
+# verification-shaped candidates), documents the dismissed-state file at
+# .curate/verify-dismissed.txt, and routes both link-rot and
+# falsification-staleness candidates to the right repair commands.
+#
+# Layered cover:
+#
+#   1. Frontmatter argument-hint advertises --verify.
+#   2. The flags list documents --verify and --analysis.
+#   3. A "Verify mode" section exists at the top of the skill.
+#   4. The verify-mode branch (Step 1.5 or equivalent) describes the
+#      filter to subsections 2p + 2q only.
+#   5. The dismissed-state file path .curate/verify-dismissed.txt is
+#      documented with a row format that includes analysis name + key.
+#   6. Link-rot routing in verify mode includes a "Dismiss" option AND
+#      writes to the dismissed file.
+#   7. Falsification-stale routing in verify mode includes a "Dismiss"
+#      option AND writes to the dismissed file.
+#   8. The skill explicitly states that verify mode does NOT change the
+#      scan invocation (the script still runs all analyses).
+#   9. The --analysis filter values include link-rot, falsification-stale,
+#      and all.
+#
+# Behavioral correctness — does the model actually filter the pick list
+# and skip non-verify subsections in practice — is exercised manually,
+# since it depends on the LLM's interpretation of the prompt.
+#
+# Run from repo root: bash tests/scenario-curate-verify-routing.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+SKILL="$REPO_ROOT/skills/curate/SKILL.md"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: /curate --verify mode (structural)"
+echo "────────────────────────────────────────────────"
+
+# ── Layer 1: argument-hint includes --verify ───────────────────────────────
+
+echo ""
+echo "── Layer 1: argument-hint advertises --verify"
+
+argument_hint=$(grep -E '^argument-hint:' "$SKILL" | head -1)
+if [[ -z "$argument_hint" ]]; then
+  fail "no argument-hint in curate SKILL.md"
+elif echo "$argument_hint" | grep -q '\-\-verify'; then
+  pass "argument-hint includes --verify"
+else
+  fail "argument-hint missing --verify" "$argument_hint"
+fi
+
+# ── Layer 2: flags list documents --verify and --analysis ──────────────────
+
+echo ""
+echo "── Layer 2: flags list documents --verify and --analysis"
+
+if grep -qE '^- `--verify`' "$SKILL"; then
+  pass "flags list documents --verify"
+else
+  fail "flags list missing --verify entry"
+fi
+
+if grep -qE '^- `--analysis' "$SKILL"; then
+  pass "flags list documents --analysis"
+else
+  fail "flags list missing --analysis entry"
+fi
+
+# ── Layer 3: Verify mode section exists ────────────────────────────────────
+
+echo ""
+echo "── Layer 3: 'Verify mode' section exists"
+
+if grep -qE '^## Verify mode' "$SKILL"; then
+  pass "## Verify mode section present"
+else
+  fail "## Verify mode section missing"
+fi
+
+# ── Layer 4: verify-mode branch filters to 2p and 2q ──────────────────────
+
+echo ""
+echo "── Layer 4: verify-mode branch filters Step 2 to 2p + 2q only"
+
+# Look for the branch block by name (Step 1.5 or any heading mentioning
+# verify-mode branching).
+branch_block=$(awk '
+  /^## (Step 1\.5|.*[Vv]erify-mode branch)/ { capturing=1; print; next }
+  capturing && /^## / { exit }
+  capturing { print }
+' "$SKILL")
+
+if [[ -z "$branch_block" ]]; then
+  fail "no Step 1.5 / verify-mode branch section found"
+else
+  if echo "$branch_block" | grep -qE '2p.*2q|2p.*falsification|link.rot.*falsification' ; then
+    pass "branch section names the 2p/2q filter"
+  else
+    fail "branch section does not name 2p (link rot) and 2q (falsification staleness)"
+  fi
+fi
+
+# ── Layer 5: dismissed-state file documented ───────────────────────────────
+
+echo ""
+echo "── Layer 5: dismissed-state file path and format documented"
+
+if grep -q '\.curate/verify-dismissed\.txt' "$SKILL"; then
+  pass ".curate/verify-dismissed.txt path is documented"
+else
+  fail ".curate/verify-dismissed.txt not referenced anywhere"
+fi
+
+# Format hint: should mention <analysis>|<key>|<date> shape (or similar
+# pipe-delimited layout).
+if grep -qE 'link-rot\|.*\|.*\||falsification-stale\|.*:' "$SKILL"; then
+  pass "dismissed-state row format is documented"
+else
+  fail "dismissed-state row format not explicit"
+fi
+
+# ── Layer 6: link-rot dismiss option in verify mode ────────────────────────
+
+echo ""
+echo "── Layer 6: link-rot routing in verify mode includes Dismiss"
+
+# Find the link-rot routing block in Step 4. It starts at "**Link rot in KB entry:**"
+linkrot_block=$(awk '
+  /\*\*Link rot in KB entry:\*\*/ { capturing=1; print; next }
+  capturing && /^\*\*[A-Z]/ { exit }
+  capturing { print }
+' "$SKILL")
+
+if [[ -z "$linkrot_block" ]]; then
+  fail "no Link rot routing block found in Step 4"
+else
+  if echo "$linkrot_block" | grep -qE '"Dismiss"' ; then
+    pass "link-rot routing includes Dismiss option"
+  else
+    fail "link-rot routing missing Dismiss option"
+  fi
+
+  if echo "$linkrot_block" | grep -qE 'verify-dismissed\.txt'; then
+    pass "link-rot Dismiss writes to verify-dismissed.txt"
+  else
+    fail "link-rot Dismiss action does not reference verify-dismissed.txt"
+  fi
+fi
+
+# ── Layer 7: falsification-stale dismiss option in verify mode ─────────────
+
+echo ""
+echo "── Layer 7: falsification-stale routing in verify mode includes Dismiss"
+
+fals_block=$(awk '
+  /\*\*Falsification-lens staleness candidate:\*\*/ { capturing=1; print; next }
+  capturing && /^\*\*[A-Z]/ { exit }
+  capturing && /^### / { exit }
+  capturing { print }
+' "$SKILL")
+
+if [[ -z "$fals_block" ]]; then
+  fail "no Falsification-lens staleness routing block found in Step 4"
+else
+  if echo "$fals_block" | grep -qE '"Dismiss"' ; then
+    pass "falsification-stale routing includes Dismiss option"
+  else
+    fail "falsification-stale routing missing Dismiss option"
+  fi
+
+  if echo "$fals_block" | grep -qE 'verify-dismissed\.txt'; then
+    pass "falsification-stale Dismiss writes to verify-dismissed.txt"
+  else
+    fail "falsification-stale Dismiss does not reference verify-dismissed.txt"
+  fi
+fi
+
+# ── Layer 8: verify mode does NOT change scan invocation ───────────────────
+
+echo ""
+echo "── Layer 8: verify mode does NOT change scan invocation"
+
+if grep -qE 'verify.*does NOT change the scan|--verify flag does NOT|verify does not change the scan' "$SKILL"; then
+  pass "scan-invariance under --verify is documented"
+else
+  fail "no statement that --verify does not change the scan invocation"
+fi
+
+# ── Layer 9: --analysis filter values ──────────────────────────────────────
+
+echo ""
+echo "── Layer 9: --analysis filter values are explicit"
+
+if grep -qE 'link-rot' "$SKILL" && grep -qE 'falsification-stale' "$SKILL"; then
+  pass "--analysis values include link-rot and falsification-stale"
+else
+  fail "--analysis values not fully documented"
+fi
+
+# Look for 'all' in --analysis context (default value).
+if grep -qE '\-\-analysis.*all|all \(default\)|default: `all`|or `all`' "$SKILL"; then
+  pass "--analysis 'all' default is documented"
+else
+  fail "--analysis 'all' default not documented"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+  echo "ALL PASSED  ($passed/$total)"
+  exit 0
+else
+  echo "FAILED  $failed/$total  ($passed passed)"
+  exit 1
+fi

--- a/tests/scenario-spec-author-depth-pass-only.sh
+++ b/tests/scenario-spec-author-depth-pass-only.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Scenario: /spec-author --depth-pass-only mode (structural).
+#
+# Validates that the spec-author skill prompt includes the depth-pass-only
+# entry path with all the load-bearing instructions: argument-hint mentions
+# the flag, a dedicated "Depth-pass-only mode" section exists, the spec
+# state check is documented, lens validation is documented, the link to
+# Pass 3 is present, and the kit's lens-registry references lens names
+# that have corresponding lens-*.md prompt files (cross-kit consistency).
+#
+# Layered cover:
+#
+#   1. Frontmatter argument-hint declares --depth-pass-only.
+#   2. SKILL.md has a "## Depth-pass-only mode" section.
+#   3. The mode section requires APPROVED state (refuses DRAFT).
+#   4. The mode section documents --lens validation against the registry.
+#   5. The mode section explains the Pass 1 + Pass 2 skip.
+#   6. The mode section explains Pass 3 input adaptation (full spec body,
+#      empty prior-findings).
+#   7. Pass 3 section cross-references the depth-pass-only entry path.
+#   8. lens-registry.txt names match lens-*.md prompt files (no orphans
+#      in either direction).
+#   9. The decline routing back to /curate is documented.
+#
+# Behavioral correctness (does the model actually follow the prompt and
+# skip Pass 1/2 correctly?) is exercised manually — it requires running
+# /spec-author against a real APPROVED spec, which is outside the scope
+# of a fast scenario test.
+#
+# Run from repo root: bash tests/scenario-spec-author-depth-pass-only.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+SKILL="$REPO_ROOT/skills/spec-author/SKILL.md"
+LENS_REGISTRY="$REPO_ROOT/scripts/lens-registry.txt"
+PROMPTS_DIR="$REPO_ROOT/prompts/audit"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: /spec-author --depth-pass-only mode"
+echo "────────────────────────────────────────────────"
+
+# ── Layer 1: argument-hint ──────────────────────────────────────────────────
+
+echo ""
+echo "── Layer 1: frontmatter argument-hint advertises the flag"
+
+argument_hint=$(grep -E '^argument-hint:' "$SKILL" | head -1)
+if [[ -z "$argument_hint" ]]; then
+  fail "no argument-hint in spec-author SKILL.md"
+elif echo "$argument_hint" | grep -q '\-\-depth-pass-only'; then
+  pass "argument-hint includes --depth-pass-only"
+else
+  fail "argument-hint missing --depth-pass-only" "$argument_hint"
+fi
+
+if echo "$argument_hint" | grep -q '\-\-lens'; then
+  pass "argument-hint includes --lens"
+else
+  fail "argument-hint missing --lens" "$argument_hint"
+fi
+
+# ── Layer 2: dedicated section exists ──────────────────────────────────────
+
+echo ""
+echo "── Layer 2: 'Depth-pass-only mode' section exists"
+
+if grep -q '^## Depth-pass-only mode' "$SKILL"; then
+  pass "## Depth-pass-only mode section present"
+else
+  fail "missing ## Depth-pass-only mode section"
+fi
+
+# ── Layer 3: APPROVED state requirement documented ─────────────────────────
+
+echo ""
+echo "── Layer 3: APPROVED state requirement documented"
+
+if grep -qiE 'must be APPROVED|state.*APPROVED|state is not APPROVED|refuse.*DRAFT' "$SKILL"; then
+  pass "APPROVED state precondition is documented"
+else
+  fail "no documentation that the target spec must be APPROVED"
+fi
+
+# ── Layer 4: lens validation against registry ──────────────────────────────
+
+echo ""
+echo "── Layer 4: lens validation references the registry"
+
+if grep -q 'lens-registry.txt' "$SKILL"; then
+  pass "SKILL.md references lens-registry.txt"
+else
+  fail "SKILL.md does not reference lens-registry.txt"
+fi
+
+if grep -qE 'prompts/audit/lens-' "$SKILL"; then
+  pass "SKILL.md references lens prompt path layout"
+else
+  fail "SKILL.md does not document lens prompt path"
+fi
+
+# ── Layer 5: Pass 1 + Pass 2 skip is documented ───────────────────────────
+
+echo ""
+echo "── Layer 5: Pass 1 + Pass 2 skip is documented"
+
+if grep -qE 'Skip Pass 1|skips Pass 1|skip.*Pass 2|Skip Pass 2' "$SKILL"; then
+  pass "Pass 1 / Pass 2 skip is documented"
+else
+  fail "no documentation that Pass 1 + Pass 2 are skipped"
+fi
+
+# ── Layer 6: Pass 3 input adaptation ──────────────────────────────────────
+
+echo ""
+echo "── Layer 6: Pass 3 input adaptation documented"
+
+if grep -qE 'empty prior-findings|empty prior findings|prior-findings set|prior findings set' "$SKILL"; then
+  pass "empty prior-findings adaptation documented"
+else
+  fail "no documentation that prior-findings is empty for depth-pass-only"
+fi
+
+# ── Layer 7: Pass 3 section cross-references depth-pass-only ──────────────
+
+echo ""
+echo "── Layer 7: Pass 3 section cross-references depth-pass-only"
+
+# Find the Pass 3 section body (between '## Pass 3' and the next sibling
+# heading that isn't itself '## Pass 3'). Awk's `,` range matches both
+# endpoints, so we filter explicitly.
+pass3_block=$(awk '
+  /^## Pass 3/ { capturing=1; print; next }
+  capturing && /^## / { exit }
+  capturing { print }
+' "$SKILL")
+if echo "$pass3_block" | grep -q 'depth-pass-only'; then
+  pass "Pass 3 section cross-references the depth-pass-only entry"
+else
+  fail "Pass 3 section does not cross-reference depth-pass-only" \
+       "first 5 lines: $(echo "$pass3_block" | head -5)"
+fi
+
+# ── Layer 8: lens-registry ↔ prompts cross-consistency ─────────────────────
+
+echo ""
+echo "── Layer 8: lens-registry lens names align with prompts/audit/lens-*.md"
+
+if [[ ! -f "$LENS_REGISTRY" ]]; then
+  fail "lens-registry.txt missing at $LENS_REGISTRY"
+elif [[ ! -d "$PROMPTS_DIR" ]]; then
+  fail "prompts/audit dir missing at $PROMPTS_DIR"
+else
+  registry_lenses=$(grep -vE '^[[:space:]]*(#|$)' "$LENS_REGISTRY" \
+                    | cut -d'|' -f1 | sort -u)
+  prompt_lenses=$(find "$PROMPTS_DIR" -maxdepth 1 -name 'lens-*.md' -type f \
+                  -printf '%f\n' 2>/dev/null \
+                  | sed -E 's/^lens-(.*)\.md$/\1/' | sort -u)
+
+  missing_prompt=""
+  while IFS= read -r lens; do
+    [[ -z "$lens" ]] && continue
+    if ! echo "$prompt_lenses" | grep -qx "$lens"; then
+      missing_prompt="${missing_prompt}${lens} "
+    fi
+  done <<< "$registry_lenses"
+
+  if [[ -z "$missing_prompt" ]]; then
+    pass "every lens in registry has a corresponding prompts/audit/lens-*.md"
+  else
+    fail "registry lenses without matching prompt file: $missing_prompt"
+  fi
+
+  # Also flag prompt files with no registry entry — they're either
+  # not-yet-shipped or dead. Soft assertion (not a fail; just a note).
+  while IFS= read -r lens; do
+    [[ -z "$lens" ]] && continue
+    if ! echo "$registry_lenses" | grep -qx "$lens"; then
+      echo "  NOTE  prompts/audit/lens-${lens}.md has no registry entry"
+    fi
+  done <<< "$prompt_lenses"
+fi
+
+# ── Layer 9: decline routing documented ────────────────────────────────────
+
+echo ""
+echo "── Layer 9: decline routing back to /curate documented"
+
+if grep -qE 'falsification-decline|decline.*curate|curate.*decline' "$SKILL"; then
+  pass "decline-back-to-curate routing documented"
+else
+  fail "no documentation of decline routing back to /curate"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+  echo "ALL PASSED  ($passed/$total)"
+  exit 0
+else
+  echo "FAILED  $failed/$total  ($passed passed)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Closes the artifact↔world drift-detection gap in `/curate` with two new
mechanical analyses, plus a focused verify mode that routes those
candidates through existing repair commands.

- **Analysis 21 — link rot in KB entries.** Extracts URLs from KB body
  text (markdown links + bare URLs, code-fence excluded), curls each
  via HEAD with a 7-day cache, flags 4xx + connection failures.
- **Analysis 22 — falsification-lens staleness.** APPROVED specs whose
  git first-commit-touched date predates a falsification lens AND
  whose body matches the lens's keyword pattern. Lens registry at
  `scripts/lens-registry.txt` is the single source of truth for lens
  names + introduction dates.
- **`/spec-author --depth-pass-only [--lens <name>]`** — re-falsify an
  existing APPROVED spec without going through Pass 1/2. Independently
  useful, also the target of /curate verify routing.
- **`/curate --verify`** — focused pass over verification-shaped
  candidates only (Analyses 21 + 22). Dismissals persist to
  `.curate/verify-dismissed.txt` so future verify runs don't re-prompt.

## Scope

Plan deliberately excludes ADR-side detection (existing analyses 3b/6/11c
already cover code↔ADR drift; ADR re-evaluation needs humans), library
version staleness (low actionability), and code↔world API probes (high
cost, tests catch when broken). Schema additions to KB / spec frontmatter
deferred — git first-commit-date and heuristic body URL scan are
sufficient for initial detection.

One subtle bug surfaced + fixed during development: the bare-URL regex
`[^[:space:]<>")\]]+` works in Claude Code's wrapped `ugrep` but fails
in GNU grep (`\]` isn't honored as escaped `]` inside a bracket
expression). Corrected to put `]` first in the negated class —
POSIX-portable, works across grep implementations.

## Test plan

- [x] `bash tests/scenario-curate-link-rot.sh` — 17/17
- [x] `bash tests/scenario-curate-falsification-stale.sh` — 13/13
- [x] `bash tests/scenario-spec-author-depth-pass-only.sh` — 11/11
- [x] `bash tests/scenario-curate-verify-routing.sh` — 14/14
- [x] `bash tests/test-install.sh` — 64/64 (verifies `lens-registry.txt`
      installed via MANIFEST + install.sh)
- [x] Full scenario regression — no new failures (one pre-existing
      `scenario-pipefail-sigpipe.sh` failure predates this branch and
      is unrelated)
- [x] MANIFEST → source-file check — every entry resolves
- [x] Source → MANIFEST reverse check — every installable file listed
- [x] Fresh install test — `lens-registry.txt` lands at
      `.claude/scripts/lens-registry.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)