### PR TITLE
fix(curate): persist deferrals + use full-window thresholds

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -99,6 +99,7 @@
 .claude/scripts/adr-validate.sh
 .claude/scripts/token-stop-hook.sh
 .claude/scripts/curate-scan.sh
+.claude/scripts/curate-review-log.sh
 .claude/scripts/decisions-scan.sh
 .claude/scripts/index-verify.sh
 .claude/scripts/statusline.sh

--- a/install.sh
+++ b/install.sh
@@ -273,6 +273,7 @@ install_file "$SCRIPT_DIR/scripts/kb-search.js" "$TARGET/.claude/scripts/kb-sear
 install_file "$SCRIPT_DIR/scripts/adr-validate.sh" "$TARGET/.claude/scripts/adr-validate.sh"
 install_file "$SCRIPT_DIR/scripts/token-stop-hook.sh" "$TARGET/.claude/scripts/token-stop-hook.sh"
 install_file "$SCRIPT_DIR/scripts/curate-scan.sh" "$TARGET/.claude/scripts/curate-scan.sh"
+install_file "$SCRIPT_DIR/scripts/curate-review-log.sh" "$TARGET/.claude/scripts/curate-review-log.sh"
 install_file "$SCRIPT_DIR/scripts/lens-registry.txt" "$TARGET/.claude/scripts/lens-registry.txt"
 install_file "$SCRIPT_DIR/scripts/decisions-scan.sh" "$TARGET/.claude/scripts/decisions-scan.sh"
 install_file "$SCRIPT_DIR/scripts/audit-budget.sh" "$TARGET/.claude/scripts/audit-budget.sh"
@@ -398,6 +399,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
   "permissions": {
     "allow": [
       "Bash(bash .claude/scripts/curate-scan.sh:*)",
+      "Bash(bash .claude/scripts/curate-review-log.sh:*)",
       "Bash(bash .claude/scripts/kb-freshness-check.sh:*)",
       "Bash(bash .claude/scripts/version-check.sh:*)",
       "Bash(bash .claude/scripts/ensure-merge-driver.sh:*)",
@@ -509,6 +511,7 @@ HOOKJSON
     elif [[ -f "$SETTINGS_FILE" ]] && command -v jq &>/dev/null; then
         jq '.permissions.allow = ((.permissions.allow // []) + [
             "Bash(bash .claude/scripts/curate-scan.sh:*)",
+      "Bash(bash .claude/scripts/curate-review-log.sh:*)",
             "Bash(bash .claude/scripts/kb-freshness-check.sh:*)",
             "Bash(bash .claude/scripts/version-check.sh:*)",
             "Bash(bash .claude/scripts/ensure-merge-driver.sh:*)",

--- a/scripts/curate-review-log.sh
+++ b/scripts/curate-review-log.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# curate-review-log.sh — append-only review log for /curate findings
+#
+# Replaces the prior pattern of a Review Log table embedded in
+# .curate/curation-state.md, which the /curate skill rewrote on every run
+# and so silently lost every prior `deferred`/`suggested` row. This tool
+# manages a separate .curate/review-log.md that:
+#   - is append-only (never overwritten in whole),
+#   - records each finding with a stable structured key,
+#   - exposes an `unresolved` query so the /curate skill can re-present
+#     items the user previously deferred or noted-for-later.
+#
+# Subcommands:
+#   migrate <state-md> <log-md>
+#       If <state-md> contains a "## Review Log" section, copy its rows
+#       into <log-md> (creating it with a header if needed) and remove
+#       the Review Log section from <state-md>. Idempotent — re-running
+#       on a migrated state file is a no-op.
+#
+#   append <log-md> <date> <key> "<description>" <status> ["<notes>"]
+#       Append a row. Idempotent within a (date, key, status, notes)
+#       tuple — repeated calls with identical values do not duplicate.
+#
+#   unresolved <log-md>
+#       Emit `<key>|<latest-status>|<latest-description>|<latest-date>`
+#       for each key whose most-recent row has status `deferred` or
+#       `suggested`. A later `resolved` or `dismissed` row for the same
+#       key supersedes earlier deferrals and excludes the key.
+#
+#   report <log-md>
+#       One-line counts: total rows / unresolved keys / resolved keys.
+#
+# Status values:
+#   deferred  — user picked Skip / Defer; should resurface next /curate.
+#   suggested — user noted-for-later (closed session without acting).
+#   resolved  — user took action (ran /architect, /research, etc.).
+#   dismissed — user explicitly dismissed (will not resurface).
+#   explored  — user investigated; no further action; treat as resolved.
+
+set -euo pipefail
+
+require_cmds() {
+  for c in "$@"; do
+    command -v "$c" >/dev/null 2>&1 || { echo "ERROR: '$c' is required but not found." >&2; exit 1; }
+  done
+}
+require_cmds awk grep sed
+
+usage() {
+  cat <<'EOF' >&2
+curate-review-log.sh — append-only review log
+
+Usage:
+  curate-review-log.sh migrate <state-md> <log-md>
+  curate-review-log.sh append  <log-md> <date> <key> "<description>" <status> ["<notes>"]
+  curate-review-log.sh unresolved <log-md>
+  curate-review-log.sh report <log-md>
+EOF
+  exit 2
+}
+
+# ── header ──────────────────────────────────────────────────────────────────
+LOG_HEADER='# Curate Review Log
+
+> **Append-only.** Managed by `/curate`. Each row records a finding and
+> the user'\''s response on a specific run. Never edit by hand; never
+> delete rows. Use `curate-review-log.sh unresolved <log-md>` to query
+> items pending re-presentation on the next run.
+
+| Date | Key | Description | Status | Notes |
+|------|-----|-------------|--------|-------|'
+
+ensure_log_header() {
+  local log="$1"
+  if [[ ! -f "$log" ]]; then
+    mkdir -p "$(dirname "$log")"
+    printf '%s\n' "$LOG_HEADER" > "$log"
+    return
+  fi
+  # File exists — make sure it has the header. If not, prepend.
+  if ! grep -q '^# Curate Review Log' "$log"; then
+    local tmp; tmp=$(mktemp)
+    { printf '%s\n' "$LOG_HEADER"; cat "$log"; } > "$tmp"
+    mv "$tmp" "$log"
+  fi
+}
+
+# Strip an outer pair of `|` then trim each cell of leading/trailing spaces.
+# Awk function — used internally.
+TRIM_AWK='
+function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+'
+
+# ── migrate ─────────────────────────────────────────────────────────────────
+cmd_migrate() {
+  local state="${1:-}" log="${2:-}"
+  [[ -z "$state" || -z "$log" ]] && { echo "ERROR: migrate requires <state-md> <log-md>" >&2; exit 2; }
+  [[ ! -f "$state" ]] && return 0   # nothing to migrate
+
+  # Extract any rows under "## Review Log" with the legacy column shape:
+  #   | <date> | <item> | <status> | <notes> |
+  # Map to the new five-column shape (Key reuses Item value when no
+  # structured key is present in the legacy row — old free-text Items
+  # become best-effort keys; nothing depends on perfect uniqueness post-
+  # migration since old free-text rows simply won't match new structured
+  # findings and become benign history).
+  local migrated
+  migrated=$(awk "$TRIM_AWK"'
+    /^## Review Log/ { in_log = 1; next }
+    in_log && /^## /  { in_log = 0 }
+    in_log && /^\|/   {
+      n = split($0, c, "|")
+      # Legacy: | empty | date | item | status | notes | empty (4 cells, 6 fields after split).
+      # Filter the header row and the divider row.
+      if (n < 5) next
+      d = trim(c[2]); item = trim(c[3]); st = trim(c[4]); nt = trim(c[5])
+      if (d == "Date" || d == "" || d ~ /^[-]+$/) next
+      # Mirror Item into Key column (free-text legacy keys are fine).
+      printf("%s|%s|%s|%s|%s\n", d, item, item, st, nt)
+    }
+  ' "$state")
+
+  if [[ -n "$migrated" ]]; then
+    ensure_log_header "$log"
+    while IFS='|' read -r d k desc st nt; do
+      [[ -z "$d" ]] && continue
+      # Append directly here (the append subcommand handles dedup, so use it).
+      cmd_append "$log" "$d" "$k" "$desc" "$st" "$nt" >/dev/null
+    done <<<"$migrated"
+  fi
+
+  # Remove the Review Log section from the state file (also idempotent —
+  # if the section is absent we leave the file untouched).
+  if grep -q '^## Review Log' "$state"; then
+    local tmp; tmp=$(mktemp)
+    awk '
+      /^## Review Log/ { skip = 1; next }
+      skip && /^## /   { skip = 0 }
+      !skip { print }
+    ' "$state" > "$tmp"
+    mv "$tmp" "$state"
+  fi
+}
+
+# ── append ──────────────────────────────────────────────────────────────────
+cmd_append() {
+  local log="${1:-}" date="${2:-}" key="${3:-}" desc="${4:-}" status="${5:-}" notes="${6:-}"
+  [[ -z "$log" || -z "$date" || -z "$key" || -z "$desc" || -z "$status" ]] && {
+    echo "ERROR: append requires <log-md> <date> <key> <description> <status> [notes]" >&2
+    exit 2
+  }
+  ensure_log_header "$log"
+
+  # De-dup: skip if an identical row already exists (compares date|key|status|notes).
+  if awk -F'|' "$TRIM_AWK"'
+      /^\|/ && !/^\| Date /  && !/^\|[-: ]+\|/ {
+        d  = trim($2); k = trim($3); s = trim($5); nt = trim($6)
+        if (d == DATE && k == KEY && s == STATUS && nt == NOTES) { found = 1 }
+      }
+      END { exit (found ? 0 : 1) }
+    ' DATE="$date" KEY="$key" STATUS="$status" NOTES="$notes" "$log"; then
+    return 0
+  fi
+  printf "| %s | %s | %s | %s | %s |\n" "$date" "$key" "$desc" "$status" "$notes" >> "$log"
+}
+
+# ── unresolved ──────────────────────────────────────────────────────────────
+cmd_unresolved() {
+  local log="${1:-}"
+  [[ -z "$log" ]] && { echo "ERROR: unresolved requires <log-md>" >&2; exit 2; }
+  [[ ! -f "$log" ]] && return 0   # no log → nothing unresolved
+
+  # For each key, find the most-recent (last) row in file order. Emit if its
+  # status is `deferred` or `suggested`. File order doubles as recency
+  # because the log is append-only (later rows have later dates).
+  awk -F'|' "$TRIM_AWK"'
+    /^\|/ && !/^\| Date /  && !/^\|[-: ]+\|/ {
+      d = trim($2); k = trim($3); desc = trim($4); s = trim($5)
+      if (k == "" || s == "") next
+      latest_status[k] = s
+      latest_desc[k]   = desc
+      latest_date[k]   = d
+    }
+    END {
+      for (k in latest_status) {
+        s = latest_status[k]
+        if (s == "deferred" || s == "suggested") {
+          print k "|" s "|" latest_desc[k] "|" latest_date[k]
+        }
+      }
+    }
+  ' "$log" | sort
+}
+
+# ── report ──────────────────────────────────────────────────────────────────
+cmd_report() {
+  local log="${1:-}"
+  [[ -z "$log" ]] && { echo "ERROR: report requires <log-md>" >&2; exit 2; }
+  [[ ! -f "$log" ]] && { echo "Curate review log: 0 rows · 0 unresolved · 0 resolved"; return 0; }
+
+  awk -F'|' "$TRIM_AWK"'
+    /^\|/ && !/^\| Date /  && !/^\|[-: ]+\|/ {
+      total++
+      k = trim($3); s = trim($5)
+      if (k != "") {
+        latest_status[k] = s
+      }
+    }
+    END {
+      total = total + 0
+      unres = 0; res = 0
+      for (k in latest_status) {
+        s = latest_status[k]
+        if (s == "deferred" || s == "suggested") unres++
+        else if (s == "resolved" || s == "dismissed" || s == "explored") res++
+      }
+      printf("Curate review log: %d rows · %d unresolved · %d resolved\n", total, unres, res)
+    }
+  ' "$log"
+}
+
+# ── dispatch ────────────────────────────────────────────────────────────────
+sub="${1:-}"
+shift || true
+case "$sub" in
+  migrate)    cmd_migrate    "$@" ;;
+  append)     cmd_append     "$@" ;;
+  unresolved) cmd_unresolved "$@" ;;
+  report)     cmd_report     "$@" ;;
+  ""|-h|--help|help) usage ;;
+  *) echo "ERROR: unknown subcommand '$sub'" >&2; usage ;;
+esac

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -75,20 +75,29 @@ fi
 CURRENT_SHA="$(git rev-parse HEAD)"
 SINCE_DATE="$(date -d "-${WINDOW_MONTHS} months" +%Y-%m-%d 2>/dev/null || date -v-${WINDOW_MONTHS}m +%Y-%m-%d 2>/dev/null || echo "")"
 
-if [[ -n "$LAST_SHA" && "$LAST_SHA" != "$CURRENT_SHA" ]]; then
-    # Incremental scan from last position
-    SCAN_RANGE="${LAST_SHA}..HEAD"
-    SCAN_MODE="incremental"
-elif [[ -n "$LAST_SHA" && "$LAST_SHA" == "$CURRENT_SHA" ]]; then
+if [[ -n "$LAST_SHA" && "$LAST_SHA" == "$CURRENT_SHA" ]]; then
     echo "No new commits since last scan." >&2
     exit 0
+fi
+
+# Threshold analyses (pressure, gravity, drift, staleness, hub files) ALWAYS
+# run against the full configured window. The previous behavior — restricting
+# the scan range to LAST_SHA..HEAD on every incremental run — caused signals
+# to dilute below thresholds as scans grew more frequent, reporting false
+# "0 actionable items" results for projects that legitimately had standing
+# pressure or drift findings.
+if [[ -n "$SINCE_DATE" ]]; then
+    SCAN_RANGE="--since=$SINCE_DATE"
 else
-    # Full scan with time window
-    if [[ -n "$SINCE_DATE" ]]; then
-        SCAN_RANGE="--since=$SINCE_DATE"
-    else
-        SCAN_RANGE="-n $MAX_COMMITS"
-    fi
+    SCAN_RANGE="-n $MAX_COMMITS"
+fi
+
+# SCAN_MODE is now a label-only field. "incremental" means a prior LAST_SHA
+# is on file (so findings can be tagged new vs ongoing); "full" means a
+# first-run scan with no LAST_SHA reference.
+if [[ -n "$LAST_SHA" ]]; then
+    SCAN_MODE="incremental"
+else
     SCAN_MODE="full"
 fi
 
@@ -101,17 +110,22 @@ EXCLUDE_PATTERN='(node_modules|vendor|dist|build|\.git|package-lock\.json|yarn\.
 TMPDIR_SCAN="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_SCAN"' EXIT
 
-if [[ "$SCAN_MODE" == "incremental" ]]; then
-    git log --name-only --pretty=format:'%H' "$SCAN_RANGE" -n "$MAX_COMMITS" \
+# Always run analyses across the full window (see comment above on SCAN_RANGE).
+if [[ -n "$SINCE_DATE" ]]; then
+    git log --name-only --pretty=format:'%H' --since="$SINCE_DATE" -n "$MAX_COMMITS" \
         | grep -v '^$' > "$TMPDIR_SCAN/raw-log.txt" 2>/dev/null || true
 else
-    if [[ -n "$SINCE_DATE" ]]; then
-        git log --name-only --pretty=format:'%H' --since="$SINCE_DATE" -n "$MAX_COMMITS" \
-            | grep -v '^$' > "$TMPDIR_SCAN/raw-log.txt" 2>/dev/null || true
-    else
-        git log --name-only --pretty=format:'%H' -n "$MAX_COMMITS" \
-            | grep -v '^$' > "$TMPDIR_SCAN/raw-log.txt" 2>/dev/null || true
-    fi
+    git log --name-only --pretty=format:'%H' -n "$MAX_COMMITS" \
+        | grep -v '^$' > "$TMPDIR_SCAN/raw-log.txt" 2>/dev/null || true
+fi
+
+# Files changed in the incremental window (used to tag findings as "new
+# since last scan" vs "ongoing"). Empty when no LAST_SHA is on file.
+INCREMENTAL_FILES_FILE="$TMPDIR_SCAN/incremental-files.txt"
+> "$INCREMENTAL_FILES_FILE"
+if [[ -n "$LAST_SHA" ]]; then
+    git diff --name-only "${LAST_SHA}..HEAD" 2>/dev/null \
+        | grep -vE "$EXCLUDE_PATTERN" | sort -u > "$INCREMENTAL_FILES_FILE" || true
 fi
 
 # Count commits processed
@@ -271,7 +285,37 @@ if [[ -d ".decisions" ]] && [[ -s "$TMPDIR_SCAN/artifact-hits.txt" ]]; then
         # Floor: total can't be less than changed
         [[ "$total" -ge "$changed" ]] || total="$changed"
         pct=$(( (changed * 100) / total ))
-        echo "PRESSURE|$slug|$changed|$total|$pct" >> "$TMPDIR_SCAN/adr-pressure.txt"
+
+        # Tag finding as new vs ongoing relative to LAST_SHA. The classification
+        # walks each file the slug constrained-and-changed and checks whether
+        # it lies inside the incremental window. Findings whose every file
+        # falls in the incremental window are "new since last scan"; findings
+        # with one or more files that pre-date the window are "ongoing" — the
+        # signal was visible to a prior scan and should resurface until the
+        # user resolves it.
+        tag=""
+        if [[ -s "$INCREMENTAL_FILES_FILE" ]]; then
+            slug_changed_files=$(awk -F'|' -v s="$slug" '$1 == s {print $2}' "$TMPDIR_SCAN/adr-slug-files.txt")
+            new_count=0; total_for_slug=0
+            while IFS= read -r cf; do
+                [[ -z "$cf" ]] && continue
+                total_for_slug=$((total_for_slug + 1))
+                grep -qxF "$cf" "$INCREMENTAL_FILES_FILE" 2>/dev/null && new_count=$((new_count + 1))
+            done <<< "$slug_changed_files"
+            if (( new_count == 0 )); then
+                tag="ongoing since prior scan"
+            elif (( new_count == total_for_slug )); then
+                tag="new since last scan"
+            else
+                tag="ongoing (with $new_count new since last scan)"
+            fi
+        elif [[ -n "$LAST_SHA" ]]; then
+            tag="ongoing since prior scan"
+        else
+            tag="initial scan"
+        fi
+
+        echo "PRESSURE|$slug|$changed|$total|$pct|$tag" >> "$TMPDIR_SCAN/adr-pressure.txt"
     done < "$TMPDIR_SCAN/adr-pressure-counts.txt"
 
     sort -t'|' -k5 -rn "$TMPDIR_SCAN/adr-pressure.txt" -o "$TMPDIR_SCAN/adr-pressure.txt" 2>/dev/null || true
@@ -1844,10 +1888,11 @@ if [[ -s "$TMPDIR_SCAN/adr-pressure.txt" ]]; then
     echo "## ADR Pressure" >> "$SUMMARY_FILE"
     echo "Decisions with concentrated file changes (2+ constrained files changed):" >> "$SUMMARY_FILE"
     echo "" >> "$SUMMARY_FILE"
-    echo "| ADR | Changed | Total | Pressure |" >> "$SUMMARY_FILE"
-    echo "|-----|---------|-------|----------|" >> "$SUMMARY_FILE"
-    while IFS='|' read -r _ slug changed total pct; do
-        echo "| $slug | $changed | $total | ${pct}% |" >> "$SUMMARY_FILE"
+    echo "| ADR | Changed | Total | Pressure | Status |" >> "$SUMMARY_FILE"
+    echo "|-----|---------|-------|----------|--------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ slug changed total pct tag; do
+        [[ -z "$tag" ]] && tag="ongoing"
+        echo "| $slug | $changed | $total | ${pct}% | $tag |" >> "$SUMMARY_FILE"
     done < "$TMPDIR_SCAN/adr-pressure.txt"
     echo "" >> "$SUMMARY_FILE"
 fi

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -83,8 +83,32 @@ When the user picks "skip" instead of "dismiss", nothing is recorded
 
 Check that `.curate/` directory exists. If not, create it.
 
-Read `.curate/curation-state.md` if it exists — extract last-scanned SHA and
-any previously deferred items from the review log.
+Read `.curate/curation-state.md` if it exists — extract the last-scanned SHA
+from the Scan State section. (Older installs may still carry a Review Log
+section in this file. Migrate it to the append-only review log on first run:)
+
+```bash
+if [[ -f .curate/curation-state.md ]]; then
+  bash .claude/scripts/curate-review-log.sh migrate \
+    .curate/curation-state.md .curate/review-log.md
+fi
+```
+
+Migration is idempotent — re-running on a migrated state file is a no-op.
+After this point, the review log lives at `.curate/review-log.md` and is
+append-only. Never edit it by hand.
+
+Read the unresolved items the user previously deferred or noted-for-later.
+These will be re-surfaced in Step 2.5 alongside any new findings:
+
+```bash
+PRIOR_UNRESOLVED=$(bash .claude/scripts/curate-review-log.sh unresolved \
+  .curate/review-log.md 2>/dev/null || true)
+```
+
+`PRIOR_UNRESOLVED` is a list of `<key>|<status>|<description>|<date>`
+records. Empty when this is the first run or every prior finding was
+resolved/dismissed.
 
 Display opening header:
 ```
@@ -570,6 +594,49 @@ For each candidate, use AskUserQuestion with options:
 The "Decline — concerns are interlocked" option is important. Subdivision
 fragments a coherent contract when forced; it should never be automatic.
 Honest declines are a feature, not a failure.
+
+---
+
+## Step 2.5 — Merge in unresolved prior items
+
+The pre-flight (Step 0) read `PRIOR_UNRESOLVED` from the append-only review
+log. These are items the user previously chose to defer or noted-for-later
+without acting on. They are NOT new findings — they are the kit's promise
+to the user that "skipped items will resurface next /curate run" (see the
+closing report's wording).
+
+For each line in `PRIOR_UNRESOLVED` (`<key>|<status>|<description>|<date>`):
+
+1. Check whether the same `<key>` is already represented in the current
+   scan's findings (e.g., `adr-pressure:auth-session-storage` is in both
+   the scan's pressure list and the prior unresolved set). If so, leave
+   it as a current-scan finding — no duplicate; the act of seeing it
+   again is what the user needs.
+2. If the key is not represented in the current scan (the underlying
+   signal aged out, OR thresholds shifted), surface it anyway as a
+   "previously-deferred" item, with its description and the date the
+   user deferred it. The user explicitly didn't resolve it; they should
+   see it again.
+
+Build a deprioritized "Previously deferred" group for the pick list. It
+appears AFTER all current-scan groups in Step 3, so new findings get
+attention first but old commitments aren't lost.
+
+Format for the group:
+
+```
+Previously deferred (from prior /curate runs):
+  N. <description> — deferred <date>, key: <key>
+     → I'll re-present the same options as last time
+```
+
+Routing for prior-deferred picks: re-read the key prefix to determine
+which Step-2 sub-section's resolution flow applies (e.g.,
+`adr-pressure:` → 2a path, `spec-drift:` → 2h path,
+`kb-stale:` → 2b path, `link-rot:` → 2p path, etc.). If a key prefix
+doesn't match any current sub-section (rare — usually means the kit
+was upgraded and a category was renamed), present the description and
+let the user describe what to do next via "Other".
 
 ---
 
@@ -1074,13 +1141,52 @@ Proceed to Step 5.
 
 ### Automatic persistence
 
-All findings are written to the review log regardless of user action:
-- Items the user acts on → `resolved`
-- Items the user explicitly defers → `deferred`
-- Items the user doesn't address (says "done" or session ends) → `suggested`
+Every finding gets a row in the append-only review log via:
+
+```bash
+bash .claude/scripts/curate-review-log.sh append \
+  .curate/review-log.md \
+  <YYYY-MM-DD> \
+  <key> \
+  "<description>" \
+  <status> \
+  ["<notes>"]
+```
+
+Where `<status>` is one of:
+- `resolved` — user acted on it (ran /architect, /research, etc.)
+- `deferred` — user explicitly chose Skip / Defer; resurface next run
+- `suggested` — user said "done" without addressing this item
+- `dismissed` — verify-mode only; persistent skip
+- `explored` — user investigated, no action needed
+
+`<key>` is a structured identifier so the same finding maps consistently
+across runs. Use these conventions:
+
+| Finding type | Key format |
+|--------------|-----------|
+| ADR pressure | `adr-pressure:<slug>` |
+| ADR gravity | `adr-gravity:<slug>` (or `adr-gravity:<slug>:<file>` for per-file) |
+| ADR drift / revisit | `adr-drift:<slug>` |
+| Hub file | `hub-file:<file>` |
+| Stale KB | `kb-stale:<topic>/<category>/<subject>` |
+| Spec-code drift | `spec-drift:<spec-id>` |
+| Test-source drift | `test-drift:<file>` |
+| Backfill candidate | `backfill:<source>:<problem-slug>` |
+| Out-of-scope item | `out-of-scope:<parent-slug>:<idx>` |
+| Spec annotation gap | `annotation-gap:<spec-id>` |
+| Aging obligation | `obligation-aging:<obligation-id>` |
+| Link rot | `link-rot:<url>` |
+| Falsification stale | `falsification-stale:<spec-id>:<lens>` |
+| Cross-ref repair | `crossref:<artifact-id>` |
+| Subdivision candidate | `subdivision:<spec-id>` |
+| Bookkeeping repair | `scan-bookkeeping:<repair-name>` |
+
+The append helper is duplicate-safe — re-appending an identical row is a
+no-op, so resuming a previous /curate session does not duplicate entries.
 
 Nothing gets lost. The next `/curate` run resurfaces `suggested` and `deferred`
-items, deprioritized below new findings.
+items via Step 2.5 deprioritized below new findings.
 
 ---
 
@@ -1088,7 +1194,11 @@ items, deprioritized below new findings.
 
 After the user is done (explored items, deferred, or noted for later):
 
-Update `.curate/curation-state.md`:
+Update `.curate/curation-state.md` with **only the Scan State section**.
+The Review Log lives in `.curate/review-log.md` (append-only) and is
+managed exclusively via `curate-review-log.sh`. Writing the Review Log
+inline in curation-state.md would silently destroy prior rows on every
+run — that is the bug this design replaces.
 
 ```markdown
 # Curation State
@@ -1098,22 +1208,26 @@ Last scanned: <current HEAD SHA>
 Last scanned date: <YYYY-MM-DD>
 Window: <months used>
 Commits scanned: <N>
-
-## Review Log
-| Date | Item | Status | Notes |
-|------|------|--------|-------|
-| <date> | <item> | <explored / deferred / suggested / resolved> | <notes> |
 ```
 
-**Status values:**
-- `explored` — user investigated, no further action needed
-- `deferred` — user chose to defer, resurface next time (deprioritized)
-- `suggested` — flagged but user noted for later
-- `resolved` — was flagged, user took action (ran /architect, /research, etc.)
+(The original Step 5 template emitted both Scan State and Review Log into
+this file, which is what destroyed the persistence guarantee. Do not
+re-introduce the Review Log section here.)
+
+After updating curation-state.md, do not write to review-log.md directly
+— Step 4 already appended every finding via `curate-review-log.sh append`.
 
 ---
 
 ## Step 6 — Closing report
+
+Read the current review-log totals so the closing line reflects the
+append-only log, not just this session's actions:
+
+```bash
+LOG_REPORT=$(bash .claude/scripts/curate-review-log.sh report \
+  .curate/review-log.md 2>/dev/null || echo "")
+```
 
 ```
 ───────────────────────────────────────────────
@@ -1121,10 +1235,10 @@ Commits scanned: <N>
 ───────────────────────────────────────────────
 Scanned: <N> commits (<scan mode>)
 Found: <N> items across <N> categories
-Explored: <N>  Deferred: <N>  Noted: <N>
-
+This session: <N> resolved · <N> deferred · <N> noted
+$LOG_REPORT
 Next scan will pick up from <current SHA short>.
-Run /curate anytime — incremental scans are fast.
+Run /curate anytime — scans run on the full <N>-month window.
 ───────────────────────────────────────────────
 ```
 
@@ -1135,7 +1249,7 @@ Run /curate anytime — incremental scans are fast.
 - [ ] Scan script ran successfully and produced scan-summary.md
 - [ ] Findings presented conversationally, not as a raw dump
 - [ ] Each finding includes why it matters and an offer to help
-- [ ] User responses recorded in curation-state.md review log
-- [ ] Last-scanned SHA updated in curation-state.md
+- [ ] Every finding got an append row via `curate-review-log.sh append`
+- [ ] curation-state.md updated with Scan State only (no Review Log section)
 - [ ] No commands assigned — only offers made
 - [ ] Cold start findings are prioritized bootstrapping suggestions, not a wall of "everything is orphaned"

--- a/tests/scenario-curate-defer-and-thresholds.sh
+++ b/tests/scenario-curate-defer-and-thresholds.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# Scenario: /curate review-log persistence + full-window thresholds.
+#
+# Empirical bug surfaced during jlsm /curate run on 2026-05-04: the scan
+# reported "0 actionable items" even though the user had skipped multiple
+# items on the prior run. Diagnosis identified three coupled defects:
+#
+#   Bug 1 — Step 5's curation-state.md template was a full-file
+#           replacement, wiping every prior Review Log row each run.
+#   Bug 2 — Step 0 read "previously deferred items from the review log"
+#           but no Step actually re-presented them in the pick list.
+#   Bug 3 — Pressure / gravity / drift thresholds ran against the
+#           incremental commit window only. Small windows diluted
+#           signals below thresholds and reported them as "flat
+#           artifact correlations" instead of actionable findings.
+#
+# This scenario locks in the fix:
+#   - .curate/review-log.md is append-only and survives multiple scans.
+#   - `curate-review-log.sh unresolved` returns rows where the latest
+#     status is `deferred` or `suggested`.
+#   - `curate-review-log.sh migrate` lifts any legacy Review Log rows
+#     out of curation-state.md (idempotent).
+#   - curate-scan.sh runs threshold analyses against the full configured
+#     window regardless of LAST_SHA, and tags findings as "new since
+#     last scan" vs "ongoing" rather than gating on incremental delta.
+#
+# Run from repo root: bash tests/scenario-curate-defer-and-thresholds.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-curate-defer-and-thresholds"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+    return 0
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+    return 0
+}
+
+cleanup() { rm -rf "$TEST_BASE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: /curate review-log persistence + full-window thresholds"
+echo "──────────────────────────────────────────────────────────────────"
+
+cleanup
+mkdir -p "$TEST_BASE"
+
+PROJECT="$TEST_BASE/project"
+git init --initial-branch=main "$PROJECT" >/dev/null 2>&1
+git -C "$PROJECT" config user.email "test@test.com"
+git -C "$PROJECT" config user.name "Test"
+
+mkdir -p "$PROJECT/.claude/scripts" "$PROJECT/.decisions/auth-session-storage" \
+         "$PROJECT/src/auth"
+
+cp "$REPO_ROOT/scripts/curate-scan.sh"        "$PROJECT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh"           "$PROJECT/.claude/scripts/"
+cp "$REPO_ROOT/scripts/curate-review-log.sh"  "$PROJECT/.claude/scripts/" 2>/dev/null \
+    || echo "(curate-review-log.sh not yet present — fix-side test will fill in once script lands)"
+
+cat > "$PROJECT/.decisions/auth-session-storage/adr.md" <<'ADR'
+---
+slug: auth-session-storage
+status: accepted
+files: ["src/auth/session.ts", "src/auth/middleware.ts", "src/auth/cookies.ts"]
+---
+# auth-session-storage
+
+This ADR governs three files that together implement session storage.
+ADR
+
+# Seed three files covered by the ADR.
+echo "// session" > "$PROJECT/src/auth/session.ts"
+echo "// middleware" > "$PROJECT/src/auth/middleware.ts"
+echo "// cookies" > "$PROJECT/src/auth/cookies.ts"
+echo "# project" > "$PROJECT/README.md"
+
+git -C "$PROJECT" add -A
+git -C "$PROJECT" commit -m "initial" >/dev/null 2>&1
+INITIAL_SHA=$(git -C "$PROJECT" rev-parse HEAD)
+
+# Touch each ADR-constrained file in distinct commits across history.
+# 5 separate single-file commits produces ADR pressure: 3 changed files /
+# 3 listed → 100% pct, well above any reasonable threshold. This creates
+# the "old, large window" signal for the full-window test below.
+for i in 1 2 3 4 5; do
+    target=$(( i % 3 ))
+    case "$target" in
+        0) f="$PROJECT/src/auth/session.ts" ;;
+        1) f="$PROJECT/src/auth/middleware.ts" ;;
+        2) f="$PROJECT/src/auth/cookies.ts" ;;
+    esac
+    echo "// edit $i" >> "$f"
+    git -C "$PROJECT" add -A
+    git -C "$PROJECT" commit -m "auth edit $i" >/dev/null 2>&1
+done
+
+PRE_RECENT_SHA=$(git -C "$PROJECT" rev-parse HEAD)
+
+# Two more very recent commits that touch only ONE ADR-constrained file.
+# This is the tiny incremental window — the cumulative window above still
+# shows full pressure, but the incremental window alone would dilute below
+# the >=2 threshold.
+echo "// recent A" >> "$PROJECT/src/auth/session.ts"
+git -C "$PROJECT" add -A
+git -C "$PROJECT" commit -m "tiny recent A" >/dev/null 2>&1
+echo "// recent B" >> "$PROJECT/src/auth/session.ts"
+git -C "$PROJECT" add -A
+git -C "$PROJECT" commit -m "tiny recent B" >/dev/null 2>&1
+
+CURRENT_SHA=$(git -C "$PROJECT" rev-parse HEAD)
+
+cd "$PROJECT"
+
+# ── Test 1: Full-window thresholds fire even with LAST_SHA set ──────────────
+# Bug 3 contract: pressure must be reported because the full window has
+# changes across all three ADR-constrained files, even though the
+# incremental delta from PRE_RECENT_SHA..HEAD only touches one file twice.
+
+echo ""
+echo "── Test 1: pressure reported on full window despite tiny LAST_SHA delta"
+
+mkdir -p .curate
+cat > .curate/curation-state.md <<EOF
+# Curation State
+
+## Scan State
+Last scanned: $PRE_RECENT_SHA
+Last scanned date: 2026-05-03
+EOF
+
+output=$(bash .claude/scripts/curate-scan.sh 2>&1 || true)
+
+# Pressure section must include auth-session-storage.
+if echo "$output" | grep -q "Scan complete"; then
+    if grep -q "auth-session-storage" .curate/scan-summary.md 2>/dev/null \
+       && sed -n '/^## ADR Pressure/,/^## /p' .curate/scan-summary.md \
+            | grep -q "auth-session-storage"; then
+        pass "ADR pressure on auth-session-storage reported on full-window analysis"
+    else
+        fail "auth-session-storage pressure missing despite full-window scan" \
+             "scan-summary head:\n$(head -40 .curate/scan-summary.md 2>/dev/null)"
+    fi
+else
+    fail "scan did not complete cleanly" "got: $output"
+fi
+
+# ── Test 2: Findings tagged "new" vs "ongoing" relative to LAST_SHA ─────────
+# Bug 3 fix preserves the LAST_SHA semantic: an ADR whose changes occurred
+# ONLY in the incremental window is "new"; one whose pressure was already
+# present pre-LAST_SHA is "ongoing".
+
+echo ""
+echo "── Test 2: scan-summary tags pressure findings as new vs ongoing"
+
+if grep -qE "^## ADR Pressure" .curate/scan-summary.md \
+   && grep -qE "(new since last scan|ongoing since)" .curate/scan-summary.md; then
+    pass "scan-summary annotates findings with new/ongoing tag"
+else
+    fail "no new/ongoing annotation in scan-summary" \
+         "ADR Pressure section:\n$(sed -n '/## ADR Pressure/,/^## /p' .curate/scan-summary.md)"
+fi
+
+# ── Test 3: review-log.md migration from legacy curation-state.md ───────────
+# Bug 1 fix: rows previously written to curation-state.md's Review Log
+# section are migrated to .curate/review-log.md on first run. Migration
+# is idempotent — re-running does not duplicate rows.
+
+echo ""
+echo "── Test 3: legacy review-log rows migrate to .curate/review-log.md"
+
+cat > .curate/curation-state.md <<EOF
+# Curation State
+
+## Scan State
+Last scanned: $PRE_RECENT_SHA
+Last scanned date: 2026-05-03
+
+## Review Log
+| Date | Item | Status | Notes |
+|------|------|--------|-------|
+| 2026-05-01 | adr-pressure:auth-session-storage | deferred | wait for WD-03 |
+| 2026-05-02 | spec-drift:foo                    | suggested | low priority |
+EOF
+
+bash .claude/scripts/curate-review-log.sh migrate \
+    .curate/curation-state.md .curate/review-log.md 2>&1 >/dev/null || true
+
+if [[ -f .curate/review-log.md ]] \
+   && grep -q "adr-pressure:auth-session-storage" .curate/review-log.md \
+   && grep -q "spec-drift:foo" .curate/review-log.md; then
+    pass "two legacy rows migrated to review-log.md"
+else
+    fail "migration did not move rows" \
+         "review-log: $(cat .curate/review-log.md 2>/dev/null || echo '(missing)')"
+fi
+
+# After migration, curation-state.md must NOT carry the Review Log section.
+if grep -q "^## Review Log" .curate/curation-state.md; then
+    fail "curation-state.md still has Review Log section after migrate"
+else
+    pass "curation-state.md cleaned of Review Log section"
+fi
+
+# Migration is idempotent — re-running adds no duplicate rows.
+rows_before=$(grep -cE '^\|.*\|.*\|' .curate/review-log.md || true)
+bash .claude/scripts/curate-review-log.sh migrate \
+    .curate/curation-state.md .curate/review-log.md 2>&1 >/dev/null || true
+rows_after=$(grep -cE '^\|.*\|.*\|' .curate/review-log.md || true)
+if [[ "$rows_before" == "$rows_after" ]]; then
+    pass "migrate is idempotent"
+else
+    fail "migrate duplicated rows on re-run" "before=$rows_before after=$rows_after"
+fi
+
+# ── Test 4: append preserves prior rows across simulated runs ───────────────
+# Bug 1 contract: each run appends; nothing is rewritten.
+
+echo ""
+echo "── Test 4: append preserves prior rows across multiple runs"
+
+bash .claude/scripts/curate-review-log.sh append \
+    .curate/review-log.md 2026-05-04 \
+    "adr-gravity:cache-strategy" \
+    "ADR gravity on cache-strategy (3 unconstrained files)" \
+    "deferred" "needs architect review" >/dev/null 2>&1
+
+bash .claude/scripts/curate-review-log.sh append \
+    .curate/review-log.md 2026-05-04 \
+    "scan-bookkeeping:index-overflow" \
+    "decisions index overflow repair" \
+    "resolved" "archived 12 rows" >/dev/null 2>&1
+
+if grep -q "adr-pressure:auth-session-storage" .curate/review-log.md \
+   && grep -q "adr-gravity:cache-strategy" .curate/review-log.md \
+   && grep -q "scan-bookkeeping:index-overflow" .curate/review-log.md; then
+    pass "all four rows present (2 migrated + 2 newly appended)"
+else
+    fail "rows lost between writes" \
+         "review-log: $(cat .curate/review-log.md)"
+fi
+
+# ── Test 5: append is duplicate-safe within the same run ────────────────────
+# Re-appending the exact same (date, key, status, notes) row no-ops.
+
+echo ""
+echo "── Test 5: append is duplicate-safe"
+
+before=$(grep -cE '^\|.*\|.*\|' .curate/review-log.md || true)
+bash .claude/scripts/curate-review-log.sh append \
+    .curate/review-log.md 2026-05-04 \
+    "adr-gravity:cache-strategy" \
+    "ADR gravity on cache-strategy (3 unconstrained files)" \
+    "deferred" "needs architect review" >/dev/null 2>&1
+after=$(grep -cE '^\|.*\|.*\|' .curate/review-log.md || true)
+if [[ "$before" == "$after" ]]; then
+    pass "append no-ops on identical row"
+else
+    fail "append duplicated identical row" "before=$before after=$after"
+fi
+
+# ── Test 6: unresolved query returns deferred/suggested rows ────────────────
+# Bug 2 contract: items with most-recent status `deferred` or `suggested`
+# (and no later resolved/dismissed for the same key) are emitted by the
+# unresolved query so the SKILL can re-present them.
+
+echo ""
+echo "── Test 6: unresolved query returns deferred + suggested rows"
+
+unresolved_out=$(bash .claude/scripts/curate-review-log.sh unresolved \
+    .curate/review-log.md 2>&1)
+
+# adr-pressure (deferred), spec-drift (suggested), adr-gravity (deferred) — 3 rows.
+# scan-bookkeeping (resolved) — must NOT appear.
+if echo "$unresolved_out" | grep -q "adr-pressure:auth-session-storage" \
+   && echo "$unresolved_out" | grep -q "spec-drift:foo" \
+   && echo "$unresolved_out" | grep -q "adr-gravity:cache-strategy"; then
+    pass "all three deferred/suggested rows surface"
+else
+    fail "unresolved query missed rows" "got: $unresolved_out"
+fi
+
+if echo "$unresolved_out" | grep -q "scan-bookkeeping:index-overflow"; then
+    fail "unresolved query incorrectly returned a resolved row"
+else
+    pass "resolved row correctly excluded"
+fi
+
+# ── Test 7: later resolved/dismissed supersedes earlier deferred ────────────
+# When a row appears with status `resolved` AFTER a deferred row for the
+# same key, the unresolved query must NOT return that key.
+
+echo ""
+echo "── Test 7: later resolution supersedes earlier deferral"
+
+bash .claude/scripts/curate-review-log.sh append \
+    .curate/review-log.md 2026-05-05 \
+    "adr-gravity:cache-strategy" \
+    "ADR gravity on cache-strategy" \
+    "resolved" "addressed via /architect" >/dev/null 2>&1
+
+unresolved_out=$(bash .claude/scripts/curate-review-log.sh unresolved \
+    .curate/review-log.md 2>&1)
+if echo "$unresolved_out" | grep -q "adr-gravity:cache-strategy"; then
+    fail "later-resolved row still appearing in unresolved set"
+else
+    pass "later-resolved supersedes earlier deferred"
+fi
+
+# ── Test 8: scan after re-scan still emits the same pressure finding ────────
+# Bug 3 contract: running /curate twice in close succession (the
+# user-reported symptom) does not cause pressure to vanish. The signal
+# stays visible until either resolved or pre-recent activity ages out.
+
+echo ""
+echo "── Test 8: pressure persists across consecutive scans"
+
+# Touch one more ADR-constrained file to advance HEAD.
+echo "// edit 6" >> "$PROJECT/src/auth/middleware.ts"
+git -C "$PROJECT" add -A
+git -C "$PROJECT" commit -m "another edit" >/dev/null 2>&1
+
+# Update LAST_SHA to current HEAD-1 (so we have a 1-commit incremental window).
+NEW_LAST=$(git -C "$PROJECT" rev-parse HEAD~1)
+cat > .curate/curation-state.md <<EOF
+# Curation State
+
+## Scan State
+Last scanned: $NEW_LAST
+Last scanned date: 2026-05-04
+EOF
+
+bash .claude/scripts/curate-scan.sh >/dev/null 2>&1 || true
+
+if sed -n '/^## ADR Pressure/,/^## /p' .curate/scan-summary.md \
+        | grep -q "auth-session-storage"; then
+    pass "pressure on auth-session-storage still reported on consecutive scan"
+else
+    fail "pressure vanished on consecutive small-delta scan" \
+         "scan-summary: $(cat .curate/scan-summary.md | head -30)"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "──────────────────────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+echo ""
+
+exit $failed


### PR DESCRIPTION
## Summary

User-reported bug (jlsm, 2026-05-04): `/curate` reported "0 actionable items" on a 13-commit incremental scan despite the user having skipped multiple items on a prior run. Diagnosis identified three coupled defects in the persistence and threshold layers — fixed together because Bug 3 alone would still cause "0 actionable" reports even with Bugs 1+2 patched.

### Bugs fixed

1. **Review log overwritten on each run.** Step 5's curation-state.md template emitted a full-file replacement that wiped every prior Review Log row. The skill's own promise — *"They'll resurface next time you run /curate"* — was structurally unfulfillable.
2. **`unresolved` was read but never used.** Step 0 read previously-deferred items but no subsequent step took them and surfaced them in the pick list.
3. **Thresholds ran against the incremental window only.** `LAST_SHA..HEAD` collapsed analysis to small deltas; signals diluted below the `>=2` floor on frequent-cadence runs. The displayed "3-month Window" applied only to first runs.

### Fix shape

- **`scripts/curate-review-log.sh`** (new): append-only review log manager with `migrate / append / unresolved / report` subcommands. Backed by `.curate/review-log.md`. Append is duplicate-safe; unresolved supersession is timestamp-ordered.
- **`scripts/curate-scan.sh`**: threshold analyses now always run against the full configured window. `LAST_SHA` is preserved as a tag — findings carry a Status column (`new since last scan` / `ongoing since prior scan` / `ongoing (with N new)` / `initial scan`). Early-exit on `HEAD == LAST_SHA` preserved.
- **`skills/curate/SKILL.md`**:
  - Step 0 pre-flight migrates legacy in-state Review Log rows (idempotent).
  - **New Step 2.5** merges previously-deferred items into the pick list as a deprioritized "Previously deferred" group, routed by key prefix.
  - Step 4 persists every finding with a structured key taxonomy (16 prefixes — `adr-pressure:`, `kb-stale:`, `link-rot:`, etc.) so findings match across runs.
  - Step 5 writes ONLY the Scan State section to curation-state.md. The Review Log inline template is removed with a "do not re-introduce" note for future maintainers.

### Validation

- `scenario-curate-defer-and-thresholds`: 11/11 (new — full-window threshold tagging, migration, append idempotency, unresolved query, supersession, consecutive-scan persistence)
- `scenario-curate-scan`: 61/61 (no regression including the no-new-commits early-exit)
- `test-install`: 64/64
- MANIFEST ↔ source: clean both directions
- Fresh install: 146 files written, new helper installed with exec bit + Bash allowlist entry

## Test plan

- [ ] Run `/curate` on a project with prior deferred items and verify they resurface in Step 2.5 (Previously deferred group)
- [ ] Verify pressure/gravity findings are reported even on a 1-commit incremental scan when the underlying signal pre-dates LAST_SHA
- [ ] Confirm migration runs once on first /curate after upgrade and is idempotent thereafter
- [ ] Confirm `.curate/review-log.md` rows survive multiple `/curate` runs

## What this does not do

- Does not retroactively migrate existing `curation-state.md` files in user projects until next `/curate` run (Step 0 pre-flight handles it on the next invocation).
- Does not change threshold values themselves. Pressure stays at `>=2` changed files; gravity at `>=3` unconstrained co-changers. Only the WINDOW thresholds apply to changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)