### PR TITLE
feat(spec-backfill, work-resolve): /spec-backfill skill + curate drift + WD state-rank fix

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,114 +20,79 @@ state of the project — what's happening now and what's next.
 
 ## Current focus
 
-*Last updated: 2026-04-27*
+*Last updated: 2026-05-05*
 
-**PR #61 merged (v0.16.0 cut after release). Spec-layering initiative
-ships end-to-end: parent + child spec model with natural-progression
-triggers from /curate (housekeeping) and /spec-author (just-in-time).
-Manually-authored layered specs work after the schema-and-resolver
-piece; `/spec-split` provides transactional subdivision with
-auto-rollback; `/curate` flags subdivision candidates; `/spec-author`
-Pass 2 surfaces a `/spec-split` suggestion the moment an amendment
-tips a spec into subdivision territory and loads parent + siblings
-when amending a child. Bundle also lands two soak-followup fixes
-surfaced from the 4-day jlsm sweep (sed swap for WD status
-`Edit`-without-Read, SIGPIPE on `echo $var | grep` pipelines for
-large stdin under pipefail). Six commits, 42/42 scenarios + 59/59
-install green. Pilot reserved for user discretion: run `/spec-split
-encryption.primitives-lifecycle` against jlsm's 163-req / 33K-token
-canary spec.**
+**Three patch releases shipped 2026-05-04 → 2026-05-05, all driven by
+jlsm-surfaced kit defects: v0.16.4, v0.16.5, v0.16.6. The session also
+made `@spec` annotation enforcement a structural exit precondition
+across the writer pipeline (no longer advisory). One follow-up is
+parked in `WIP.md` and queued as "Do next" below: PR B (spec-backfill
++ /curate annotation-drift analysis) for cleaning up existing
+uncovered code in mature projects.**
 
-### What's shipped since 2026-04-21
+### What shipped 2026-05-04 → 2026-05-05
 
-**v0.14.1 → v0.14.2 release sequence:**
-- v0.14.1 (2026-04-21 evening, commit `35e8e31`) — bundled the `/curate`
-  drift detection analyses (18 + 19) that were staged at the end of the
-  spec migration day.
-- v0.14.2 (commit `7fc33dd`) — four GSD-gap capabilities from the
-  2026-04-21 competitive audit:
-  - **PR #51** — `/audit` FIX_IMPOSSIBLE escalation flow (relax-test /
-    wontfix / spec-author / defer), closing the graveyard path for
-    audit findings blocked by pin tests.
-  - **PR #52** — `/spec-write` quantitative ambiguity gate (GSD
-    capability #3): `spec-ambiguity-score.sh` computes
-    `([UNVERIFIED]+[UNRESOLVED]+[CONFLICT]) / total_requirements` and
-    surfaces the score at DRAFT → APPROVED promotion time.
-  - **PR #53** — `/audit` security lens (GSD capability #1):
-    `prompts/audit/lens-security.md` with TESTABLE vs ADVISORY finding
-    taxonomy, 4 new exploration signals (credential store, PII, auth
-    middleware, deserialization). Addresses the encryption-audit gap
-    (10 bugs found via generic lens, 3 classes missed: timing channels,
-    IV reuse, ciphertext integrity).
-  - **PR #54** — `/work-start --parallel [N]` (GSD capability #2):
-    wave-based multi-WD dispatch using the existing readiness model.
+**v0.16.4 (PR #65) — `/curate` persistence + threshold cumulation.**
+User-reported on jlsm: "/curate found 0 actionable items" after the
+user had skipped multiple findings on a prior run. Three coupled
+defects:
+- Step 5's curation-state.md template was a full-file replacement,
+  wiping every prior `deferred`/`suggested` row each run.
+- Pre-flight read deferred items but no step re-presented them in the
+  pick list.
+- Pressure / gravity / drift thresholds ran against `LAST_SHA..HEAD`
+  only, so signals diluted below thresholds on frequent-cadence runs.
 
-**Also merged post-v0.14.2:**
-- **PR #55** — docs: DESIGN manifest sync + `/feature` pipeline audit
-  surfacing.
-- **PR #56** — `/audit` wontfix findings now route through
-  `open_obligations` on the most-relevant spec, resurfacing via
-  `/curate` analysis 19 aging logic once past the threshold. Closes the
-  last graveyard path for FIX_IMPOSSIBLE outcomes.
+Fix: new `scripts/curate-review-log.sh` (append-only review log with
+`migrate / append / unresolved / report` subcommands), full-window
+analysis in `curate-scan.sh` with `new since last scan` / `ongoing`
+tagging, new Step 2.5 in the SKILL that merges previously-deferred
+items into the pick list, structured key taxonomy (16 prefixes:
+`adr-pressure:`, `kb-stale:`, `link-rot:`, etc.). 11/11 new tests +
+61/61 existing curate-scan green.
 
-### The v0.14.3 bundle (this PR on `chore/v0.14.3-bundle`)
+**v0.16.5 — bundled spec-resolve perf + `@spec` annotation enforcement.**
 
-Three workstreams collapsed into one PR for reviewability. Six commits:
+- **PR #66 — `spec-resolve.sh` budget + Step 7b/7c perf.** Default
+  budget bumped 8000 → 25000 (real specs run 9-12K tokens each — prior
+  default produced empty bundles). Step 7b conflict scan and Step 7c
+  displacement scan rewritten as single awk passes — 30+ second hangs
+  on multi-spec bundles eliminated. Output line format byte-identical;
+  `Force-included` header line guarantees the bundle is never empty
+  when there are direct candidates. 4/4 new + 21/21 existing tests.
+- **PR #67 — forward enforcement of `@spec` annotation coverage.**
+  Adversarial workflow audit found exactly one place in the kit
+  explicitly told writers to add `@spec` annotations (`/spec-verify`
+  Step 1.2), and it was gated behind a `spec-bundle.md` artifact no
+  upstream skill ever wrote. Every entry point converged on the same
+  broken handoff. Closed by:
+  - New always-loaded `rules/spec-annotation-protocol.md` defining
+    format, comment syntax per language, where/when to annotate.
+  - New `scripts/spec-coverage.sh` (init / update / gate / waive /
+    report) backed by `.feature/<slug>/spec-coverage.md`. Also
+    produces `spec-bundle.md`.
+  - Mandatory exit checks at `/feature-test` and `/feature-implement`.
+  - Hard gate at `/feature-pr` with annotate / waive / override paths.
+  - `/feature-quick` spec-aware mode.
+  - `/audit` reconcile writes `@spec` to fix code as it mints new
+    R-ids.
+  - `/feature-retro` and `/feature-complete` surface coverage state.
+  - 14/14 new spec-coverage scenario tests + 64/64 install.
 
-**Fixes:**
-- **`fix(spec): v2 manifest schema compatibility`** — dual-schema (v1 +
-  v2) manifest compat across `spec-resolve.sh`, `work-lib.sh`,
-  `work-finalize.sh`, `curate-scan.sh`, `spec-stats.sh`. Root cause:
-  the 2026-04-20 spec migration flipped the manifest from
-  `{features: {FXX: ...}}` (v1) to `{schema_version: 2, specs: [...]}`
-  (v2), and several read-path scripts were still hardcoded against v1
-  keys — they silently failed under `set -euo pipefail` or fell through
-  to `NEEDS_DOMAIN_INFERENCE=true` for every call, blocking
-  `/work-start`, `/spec-write`, `/feature-plan`, `/feature-test`,
-  `/spec-author`, and `/audit` on v2 repos. Added four dual-schema
-  manifest query helpers to `spec-lib.sh`.
-- **`fix(tests): close four pre-existing scenario-test failures`** —
-  found during the manifest-v2 sweep, closed here per the
-  fix-now-not-defer rule: `scenario-index-verify` arithmetic bug,
-  `scenario-narrative` stale exit-code assertions, `scenario-version-skew`
-  legacy install-layout reference, `scenario-work-pipeline` v1-manifest
-  fixture paired with v2-style WD deps.
-- **`fix(pipeline): prevent parallel-subagent hangs`** — mode-gates
-  every unconditional `AskUserQuestion` in the three pipeline skills
-  (`/feature-test`, `/feature-implement`, `/feature-refactor`) so they
-  bypass to `cycle-log.md` + `escalated-<reason>` substage + `ESCALATED`
-  return in parallel mode instead of hanging on a missing human.
-  Strengthens `/feature-refactor`'s parallel-mode exit with an explicit
-  termination contract ("your very next message MUST be the summary
-  line — no more tools"). Adds Step 1a to `/feature-coordinate`
-  documenting the subagent dispatch contract every coordinator must
-  embed. Root-caused from the 2026-04-23 jlsm WU-3 hang (subagent wrote
-  `status.md = COMPLETE` at 10:41:32, then kept running ~2 min before
-  the user had to Ctrl+C). Regression:
-  `scenario-parallel-subagent-hang-prevention.sh` (10 structural
-  invariants).
-
-**Documentation:**
-- **`docs: freshness pass through v0.14.2 + held branches`** — CONTEXT
-  refresh, 7 decisions graduated to SETTLED.md, DEFERRED marked
-  security-aware lens as done.
-- **`docs: add GETTING-STARTED + GETTING-STARTED-EXISTING guides`** —
-  two new repo-only onboarding docs (316 + 333 lines) for people
-  landing on the GitHub page. Not shipped via MANIFEST. README gains a
-  "New here?" link section; `/vallorcine-help` gains URL hints for
-  conceptual questions.
-- **`docs: spot-check fixes for EXAMPLES + COMPETITIVE + GETTING-STARTED`**
-  — corrected the `.spec/` bug I introduced in GETTING-STARTED (`.spec/`
-  is `/spec-init`-gated, not created by `/setup-vallorcine`); added
-  `/feature-harden` to the EXAMPLES.md walkthrough (was missing);
-  reconciled the split threshold in EXAMPLES to match SETTLED (~15K
-  tokens / 5+ constructs); added four new walkthrough sections to
-  EXAMPLES (parallel execution via `/feature-coordinate`, spec workflow,
-  standalone `/audit`, `/capabilities`); refreshed COMPETITIVE's "Closed
-  gaps" with the four v0.14.2 GSD-parity shipments and sharpened the
-  standalone-security-scanner boundary; added `/feature-harden` and
-  `/capabilities` to the `.claude/rules/kit-development.md` user-facing
-  command list.
+**v0.16.6 (PR #68) — ADR quote handling + narrative WD-slug parse.**
+- `work_check_adr_dep` had asymmetric quote handling: WD-side parser
+  stripped quotes; ADR-side didn't. ADRs with `status: "accepted"`
+  silently BLOCKED dependent WDs because `"accepted" != accepted`.
+  Fix: post-extraction strip of single + double quotes on the ADR
+  side.
+- Narrative parser dropped phases for `<group>--wd-NN` slugs because
+  the parent `/work-start "<group>" <N>` JSONL token had no `--wd-`
+  infix in args. Fix: structured group-prefix + WD-number match in
+  both `build_phase` first-pass filter and `parse_story` second-pass
+  state machine. Mirrored in `parse.js` (also closed pre-existing
+  parity gap by adding `/audit` to JS `COMMAND_TO_STAGE`).
+- 8/8 new + 16/16 existing narrative + all `scenario-work-*` and
+  `scenario-spec-*` and `scenario-curate-*` suites green.
 
 ---
 
@@ -179,6 +144,35 @@ snapshot-WD-DRAFT-status. See SETTLED.md.*
   so projects can migrate (or not) at their own pace. Shipped as
   bundled in `chore/v0.14.3-bundle` (this PR).
 
+- **`@spec` annotation is a structural exit precondition, not advisory**
+  (2026-05-04) — `/feature-test` and `/feature-implement` substages
+  refuse to advance until every loaded spec requirement has at least
+  one `@spec` annotation in tests or implementation. `/feature-pr`
+  hard-gates the PR draft on coverage. Override paths are surfaced
+  explicitly to the user (annotate / waive with reason / override gate
+  with reason recorded in PR description). The forward-enforcement
+  pattern stops new gaps from accumulating; backfill (PR B) cleans up
+  existing uncovered code. Shipped in PR #67 / v0.16.5.
+
+- **Append-only state files for cross-run persistence** (2026-05-04) —
+  When a SKILL.md template carries a full-file format that includes
+  rolling state (e.g. /curate's old Review Log section in
+  curation-state.md), Claude rewrites the full file each invocation
+  and silently destroys prior rows. Fix shape: separate the rolling
+  state into a dedicated append-only file managed exclusively by a
+  helper script (curate-review-log.sh, spec-coverage.sh). The SKILL
+  template only handles immutable scan-state. Pattern is reused by
+  PR #65 (curate review log) and PR #67 (spec coverage table).
+
+- **Threshold analyses run against the full configured window**
+  (2026-05-04) — `/curate` thresholds (pressure / gravity / drift /
+  staleness / hub files) operate on the configured 3-month window
+  regardless of `LAST_SHA`. `LAST_SHA` is preserved as a tag — findings
+  carry a Status column distinguishing `new since last scan` from
+  `ongoing since prior scan`. Prior incremental-window behavior caused
+  signals to dilute below thresholds on frequent-cadence runs.
+  Shipped in PR #65 / v0.16.4.
+
 *Live list — resolve into SETTLED.md or drop when addressed.*
 *Prioritised: do next → do soon → do when needed → do when scale demands it.*
 *Status tags: `[implemented]` = code exists, needs validation. `[designed]` = spec
@@ -186,110 +180,98 @@ exists, not yet coded. No tag = needs both design and implementation.*
 
 ### Do next
 
-**Merge the work-layer-followups PR, cut a release, then migrate
-jlsm's `implement-membership` cross-group dep.**
+**PR B — `/spec-backfill` + `/curate` annotation-drift analysis.**
+PR #67 (v0.16.5) made annotation a structural exit precondition for
+NEW pipeline runs but left existing uncovered code in mature corpora
+(jlsm has 75 specs / 12 domains, most authored before annotation
+enforcement existed). PR B closes that gap. Designed scope:
 
-Gap 3 + Gap 4 from the original `/ideate continue` WIP are landed on
-`fix/work-layer-followups` (2 commits). Once merged and released, jlsm
-can upgrade the kit and the prose cross-group-dep declaration in
-`.work/implement-membership/work.md` can be replaced with an
-`external_deps:` entry. Also archive `implement-sstable-enhancements`
-(all WDs COMPLETE per prior session notes — verify and archive).
+1. **`scripts/spec-trace.sh --uncovered <spec-id>`** — extend the
+   existing tool to emit a parseable list of R-ids with zero `@spec`
+   references. Used as the primitive by both the new skill and the
+   curate analysis.
+2. **`/spec-backfill <spec-id>` skill** (~150-line SKILL.md). Walks
+   uncovered requirements one at a time. For each R, runs subject-token
+   grep across the codebase looking for likely enforcement points (same
+   heuristic as the displacement scan in `spec-resolve.sh` Step 7c).
+   Presents candidates via AskUserQuestion ("R3 about
+   `TokenValidator.expiry_check` — likely sites: (a) ..., (b) ..., (c)
+   Other, (d) Skip"). Applies the annotation. Writes a backfill log so
+   progress survives interruption. Re-runs `spec-trace` at end to
+   confirm coverage moved.
+3. **`/spec-backfill --all`** — corpus-wide one-shot mode. Iterates
+   every APPROVED spec, runs the per-spec flow. The catch-up tool for
+   mature jlsm-style projects.
+4. **`/curate` annotation-drift analysis (#23)** — APPROVED specs
+   whose requirements have <50% annotation coverage, ordered by age +
+   churn of matching code. Routes to `/spec-backfill <id>`. Surfaces
+   the problem at regular curation cadence so it never re-accumulates.
+5. **`tests/scenario-spec-backfill.sh`** — covers per-spec walk,
+   candidate suggestion, annotation application, log resumption,
+   `--all` corpus iteration.
 
-**Shipped in v0.14.4 (2026-04-24):** KB actionable across coordinator /
-suspect / prove-fix, and prove-fix Phase 0c upstream-mitigation
-short-circuit. Empirical baseline on jlsm audit: $14.03/finding
-(95 findings, $1,333), projected floor ~$11/finding once fixes soak.
-Full narrative in SETTLED.md once graduated; summary preserved in
-git history via PR #58 + PR #59.
-
-**Landed on fix/work-layer-followups (not yet released):**
-- **Gap 4** — `external_deps:` on `work.md` lets a group declare that
-  all its WDs are BLOCKED until a sibling group reaches COMPLETE.
-  `scripts/work-resolve.sh` applies the gate to DRAFT and SPECIFIED
-  WDs; IMPLEMENTING/COMPLETE/SPECIFYING are left alone.
-  `scripts/work-validate.sh` checks shape and referenced-group
-  existence, and now rejects cross-group `wd:` artifact_deps so
-  validate and runtime agree on what's reachable.
-  Tests: `scenario-work-cross-group-deps.sh` (11/11).
-- **Gap 3** — `/work-plan` Step 4a brief template has an AUTHORITATIVE
-  "Group Envelope" section. `/feature-domains` Step 2 reads it,
-  classifies envelope-covered domains as `resolved` without a fresh
-  `/architect` dispatch, and escalates WD-local contradictions back to
-  `/work-decompose` via a new `escalate-decompose` classification.
-  `/work-plan` Step 5b dedupes spec authoring against the envelope.
-  Tests: 5 new invariants in `scenario-work-layer-alignment.sh` (25/25).
-- **Three pre-existing bugs surfaced empirically by dry-running the
-  kit against a local jlsm clone:**
-  - `work_fm_produces` parser dropped `slug:` for ADR produces (78
-    false-alarm validation errors across 13 jlsm decisions-backlog
-    WDs → 0).
-  - Validate-vs-resolve spec lookup asymmetry (single-WD validate was
-    ID-only; resolve accepted slash-paths). Both now share
-    `work_check_spec_dep` with Strategy 0 ID lookup + path fallbacks.
-  - `wd:` state mismatch was incorrectly a validation FAIL — natural
-    mid-flight state was being double-reported. Now resolver-only
-    (resolver continues to surface as BLOCKED). Test 17 inverted to
-    match the corrected contract.
-- **Four SKILL.md guidance refinements** from the same dry-run:
-  /work scoping interview leads with tradeoff analysis before
-  AskUserQuestion; /work-decompose Phase A research-dispatch criterion
-  ("dispatch when the answer changes WD shape"); Phase B decidability
-  test ("settle now when shape isn't decidable from any single WD's
-  perspective"); SPECIFIED-vs-COMPLETE choice for `wd:` deps surfaced
-  explicitly (default-by-precedent was COMPLETE → fully sequential;
-  SPECIFIED unlocks parallel planning under Group Envelope).
-- **Empirical Gap 3 still untested.** Structural tests prove the
-  SKILL.md says the right things; first real `/work-plan` run on a
-  WD with a Group Envelope is the actual validation.
-
-**Positioning shift (still outstanding — carries over from v0.14.3):**
-emphasize depth-of-spec-rigor axis over the "spec-driven" label across
-user-facing docs. Bundle with the next docs pass.
+Should reuse `spec-coverage.sh` (the artifact PR #67 introduced) as the
+"what's annotated and what isn't" book — keeps the user's mental model
+coherent.
 
 ### Do soon (medium effort, clear designs)
 
-- **Fix spec-layer gaps (11 identified)** — 4 critical: feature-implement spec
-  awareness, feature-refactor spec awareness, spec-write two-file invalidation,
-  work-decompose spec state validation. Full gap analysis in session memory.
-  Status: not started since 2026-04-21. Check first whether any are already
-  covered by the manifest-v2 dual-schema work before scoping.
+- **Empirical validation of the annotation gate.** The forward
+  enforcement is structural in tests, but no real `/feature` end-to-end
+  run on jlsm has exercised the new gate yet. First production run will
+  be the real validation. Watch for: false-positive PR blocks, format
+  ambiguity in real test code, override-path UX.
 
-- **Fix 6 pipeline failure patterns** — one-sided invalidation, audit outpacing
-  specs, assert-only guards, dead code wiring, spec asymmetry, feature-centric
-  organization. Each has root cause and fix task documented. Status:
-  feature-centric organization resolved by the 2026-04-20 spec migration
-  (behavioral domains). The others still stand.
+- **Empirical validation of /curate full-window thresholds.** PR #65 is
+  in v0.16.4. Re-run /curate on jlsm and confirm previously-deferred
+  items resurface and that `new since last scan` vs `ongoing` tagging
+  reads naturally in the pick list.
 
-- **Partial implementation state model** — binary APPROVED/DRAFT insufficient for
-  specs that are 90% implemented. Need either per-requirement states, split specs,
-  or APPROVED-with-obligations. Data from verification pass will inform design.
-  Revisit once 2-3 jlsm WDs have completed implementation and we can read
-  their emergent patterns.
+- **Partial implementation state model** — binary APPROVED/DRAFT
+  insufficient for specs that are 90% implemented. Revisit once 2-3
+  jlsm WDs have completed implementation. The new annotation coverage
+  table (PR #67) gives the per-requirement grain that may inform this
+  — explicit `pending` rows for not-yet-implemented requirements
+  could be the partial-implementation primitive.
 
 - **Flaky-test surfacing in `/feature-retro`** — scan cycle-log.md for
   flakiness signals (timeouts on first run + passed-on-rerun, "flaky",
-  "retry" keywords) and emit a dedicated retro section. Triggered by the
-  2026-04-23 jlsm WU-3 run which noted a pre-existing
-  `SharedStateAdversarialTest` timeout-then-pass that would otherwise be
-  buried. See `DEFERRED.md`.
+  "retry" keywords) and emit a dedicated retro section. See
+  `DEFERRED.md`.
+
+- **Positioning shift (still outstanding — carries over from v0.14.3):**
+  emphasize depth-of-spec-rigor axis over the "spec-driven" label
+  across user-facing docs. Bundle with the next docs pass.
 
 ### Do when needed (useful but workarounds exist)
 
-- **Large repo curation testing** — `/curate` needs testing on a repo with
-  1000+ commits, 30+ contributors.
+- **Large repo curation testing** — `/curate` needs testing on a repo
+  with 1000+ commits, 30+ contributors.
 
-- **spec-trace.sh sub-lettered IDs** — R39a-h pattern not matched by numeric-only
-  regex. Annotations exist in code but uncounted. Fix when reorg drops FXX IDs.
+- **spec-trace.sh sub-lettered IDs** — R39a-h pattern not matched by
+  numeric-only regex. Annotations exist in code but uncounted. Fix
+  when reorg drops FXX IDs.
 
-- **#45 cosmetic `upgrade.sh` output bug** — low priority; originally on the
-  v0.14.1 stack, still open.
+- **#45 cosmetic `upgrade.sh` output bug** — low priority; originally
+  on the v0.14.1 stack, still open.
+
+- **Fix the older spec-layer gaps (11 identified, 2026-04-21)** — 4
+  critical: feature-implement spec awareness, feature-refactor spec
+  awareness, spec-write two-file invalidation, work-decompose spec
+  state validation. PR #67 (annotation enforcement) likely covered or
+  changed several. Re-audit before scoping.
+
+- **Older 6 pipeline failure patterns (2026-04-21)** — one-sided
+  invalidation, audit outpacing specs, assert-only guards, dead code
+  wiring, spec asymmetry. Re-audit similarly — annotation enforcement
+  may have neutralized some.
 
 ### Do when scale demands it (team/scale features)
 
 - **Team KB commands** — `/kb sync`, `/kb consolidate`, `/kb status`.
 
-- **Pipeline observability** — velocity metrics, KB utilization tracking.
+- **Pipeline observability** — velocity metrics, KB utilization
+  tracking.
 
 - **Distributed work layer** — multi-party decomposition and merge
   (deferred — team-mode feature).

--- a/MANIFEST
+++ b/MANIFEST
@@ -37,6 +37,7 @@
 .claude/skills/spec-author/SKILL.md
 .claude/skills/spec-author/extraction-mode.md
 .claude/skills/spec-split/SKILL.md
+.claude/skills/spec-backfill/SKILL.md
 .claude/skills/spec/SKILL.md
 .claude/skills/work/SKILL.md
 .claude/skills/work-decompose/SKILL.md
@@ -126,6 +127,8 @@
 .claude/scripts/spec-trace.sh
 .claude/scripts/spec-split.sh
 .claude/scripts/spec-coverage.sh
+.claude/scripts/spec-backfill-candidates.sh
+.claude/scripts/spec-backfill-log.sh
 .claude/scripts/lens-registry.txt
 .claude/scripts/work-lib.sh
 .claude/scripts/work-resolve.sh

--- a/install.sh
+++ b/install.sh
@@ -302,6 +302,8 @@ install_file "$SCRIPT_DIR/scripts/spec-obligations-gc.sh" "$TARGET/.claude/scrip
 install_file "$SCRIPT_DIR/scripts/spec-trace.sh" "$TARGET/.claude/scripts/spec-trace.sh"
 install_file "$SCRIPT_DIR/scripts/spec-split.sh" "$TARGET/.claude/scripts/spec-split.sh"
 install_file "$SCRIPT_DIR/scripts/spec-coverage.sh" "$TARGET/.claude/scripts/spec-coverage.sh"
+install_file "$SCRIPT_DIR/scripts/spec-backfill-candidates.sh" "$TARGET/.claude/scripts/spec-backfill-candidates.sh"
+install_file "$SCRIPT_DIR/scripts/spec-backfill-log.sh" "$TARGET/.claude/scripts/spec-backfill-log.sh"
 install_file "$SCRIPT_DIR/scripts/work-lib.sh" "$TARGET/.claude/scripts/work-lib.sh"
 install_file "$SCRIPT_DIR/scripts/work-resolve.sh" "$TARGET/.claude/scripts/work-resolve.sh"
 install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/work-validate.sh"
@@ -332,6 +334,8 @@ chmod +x "$TARGET/.claude/scripts/spec-obligations-gc.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-trace.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-split.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-coverage.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/spec-backfill-candidates.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/spec-backfill-log.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
@@ -417,6 +421,8 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/spec-trace.sh:*)",
       "Bash(bash .claude/scripts/spec-split.sh:*)",
       "Bash(bash .claude/scripts/spec-coverage.sh:*)",
+      "Bash(bash .claude/scripts/spec-backfill-candidates.sh:*)",
+      "Bash(bash .claude/scripts/spec-backfill-log.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
@@ -530,6 +536,8 @@ HOOKJSON
       "Bash(bash .claude/scripts/spec-trace.sh:*)",
       "Bash(bash .claude/scripts/spec-split.sh:*)",
       "Bash(bash .claude/scripts/spec-coverage.sh:*)",
+      "Bash(bash .claude/scripts/spec-backfill-candidates.sh:*)",
+      "Bash(bash .claude/scripts/spec-backfill-log.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1279,6 +1279,7 @@ fi
 > "$TMPDIR_SCAN/spec-annotation-gaps.txt"
 > "$TMPDIR_SCAN/spec-unannotated.txt"
 > "$TMPDIR_SCAN/spec-bare-only.txt"
+> "$TMPDIR_SCAN/spec-annotation-drift.txt"
 
 # has_bare_annotations <spec-id> — returns 0 if the source tree contains a
 # bare `@spec <sid>` reference (no `.R<n>` suffix). Used to differentiate
@@ -1371,7 +1372,54 @@ if [[ -f ".spec/registry/manifest.json" ]] && command -v jq >/dev/null 2>&1; the
                 [[ -z "$req_count" ]] && req_count=0
                 echo "TEST_GAP|$sid|$req_count|$no_test_clean" >> "$TMPDIR_SCAN/spec-annotation-gaps.txt"
             fi
+
+            # Annotation drift: APPROVED specs with > 50% of requirements
+            # uncovered. Reuses the trace_out we already have (via the
+            # `**Requirements traced:**` count) and counts total R-ids in
+            # the spec file. Specs reported as fully UNANNOTATED above are
+            # excluded — they're a more severe class with their own
+            # remediation (already in spec-unannotated.txt).
+            spec_file_path=""
+            spec_file_path="$(spec_file_for_id "$MANIFEST" "$sid" 2>/dev/null || true)"
+            if [[ -n "$spec_file_path" && -f "$spec_file_path" ]]; then
+                total_rids="$(awk '
+                    /^## Requirements *$/ { in_req = 1; next }
+                    /^## / && in_req     { in_req = 0 }
+                    in_req && /^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\./ { count++ }
+                    END { print count+0 }
+                ' "$spec_file_path")"
+                annotated_rids="$(grep -m1 -oE '\*\*Requirements traced:\*\* [0-9]+' <<< "$trace_out" \
+                    | grep -oE '[0-9]+' || echo 0)"
+                if [[ "$total_rids" -gt 0 && "$annotated_rids" -le "$total_rids" ]]; then
+                    uncov=$(( total_rids - annotated_rids ))
+                    pct=$(( (uncov * 100) / total_rids ))
+                    # Threshold: > 50% uncovered AND at least one annotation
+                    # exists (avoids overlap with the UNANNOTATED bucket).
+                    if (( pct > 50 && annotated_rids > 0 )); then
+                        # Spec-file age in days since last commit (best
+                        # effort — non-git repos report 0).
+                        age_days=0
+                        last_commit_date="$(git log -1 --format=%cs -- "$spec_file_path" 2>/dev/null || true)"
+                        if [[ -n "$last_commit_date" ]]; then
+                            today_epoch=$(date +%s)
+                            commit_epoch=$(date -d "$last_commit_date" +%s 2>/dev/null || echo "$today_epoch")
+                            age_days=$(( (today_epoch - commit_epoch) / 86400 ))
+                        fi
+                        echo "ANNOTATION_DRIFT|$sid|$uncov|$total_rids|$pct|$age_days" \
+                            >> "$TMPDIR_SCAN/spec-annotation-drift.txt"
+                    fi
+                fi
+            fi
         done <<< "$approved_ids"
+
+        # Sort drift findings by uncovered-pct descending, then by age
+        # descending (older specs surface first within the same coverage
+        # tier — they've drifted longer without attention).
+        sort -t'|' -k5,5 -k6,6 -rn "$TMPDIR_SCAN/spec-annotation-drift.txt" \
+            -o "$TMPDIR_SCAN/spec-annotation-drift.txt" 2>/dev/null || true
+        head -20 "$TMPDIR_SCAN/spec-annotation-drift.txt" \
+            > "$TMPDIR_SCAN/spec-annotation-drift.capped.txt" 2>/dev/null || true
+        mv "$TMPDIR_SCAN/spec-annotation-drift.capped.txt" "$TMPDIR_SCAN/spec-annotation-drift.txt" 2>/dev/null || true
 
         # Sort: IMPL_GAPs first (bigger deal — code missing), then TEST_GAPs, by count desc.
         sort -t'|' -k1,1 -k3 -rn "$TMPDIR_SCAN/spec-annotation-gaps.txt" \
@@ -2240,6 +2288,23 @@ if [[ -s "$TMPDIR_SCAN/spec-bare-only.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# Annotation drift (Analysis 18, drift bucket): partially-annotated specs
+# whose coverage has slipped below 50%. Distinct from the unannotated bucket
+# above — these have at least one annotation, so the remediation is targeted
+# backfill via /spec-backfill <id> rather than starting from scratch.
+if [[ -s "$TMPDIR_SCAN/spec-annotation-drift.txt" ]]; then
+    echo "### Annotation drift — APPROVED specs below 50% coverage" >> "$SUMMARY_FILE"
+    echo "Partially-annotated specs whose @spec coverage has slipped below 50%. Sorted by uncovered-percentage descending; ties broken by spec-file age (older first)." >> "$SUMMARY_FILE"
+    echo "Route to \`/spec-backfill <spec-id>\` to walk the uncovered requirements one at a time. For multiple drifted specs, \`/spec-backfill --all\` covers the corpus." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Spec | Uncovered | Total | % Uncovered | Spec age (days) |" >> "$SUMMARY_FILE"
+    echo "|------|-----------|-------|-------------|------------------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ sid uncov total pct age_days; do
+        echo "| $sid | $uncov | $total | ${pct}% | $age_days |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/spec-annotation-drift.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # Aging obligations (Analysis 19)
 if [[ -s "$TMPDIR_SCAN/aging-obligations.txt" ]]; then
     echo "## Aging Open Obligations" >> "$SUMMARY_FILE"
@@ -2340,6 +2405,7 @@ echo "  Stalled work groups: $(wc -l < "$TMPDIR_SCAN/work-stalled.txt" 2>/dev/nu
 echo "  Work artifact drift: $(wc -l < "$TMPDIR_SCAN/work-drift.txt" 2>/dev/null || echo 0)"
 echo "  Spec annotation gaps: $(wc -l < "$TMPDIR_SCAN/spec-annotation-gaps.txt" 2>/dev/null || echo 0)"
 echo "  Unannotated APPROVED specs: $(wc -l < "$TMPDIR_SCAN/spec-unannotated.txt" 2>/dev/null || echo 0)"
+echo "  Annotation drift (<50% coverage): $(wc -l < "$TMPDIR_SCAN/spec-annotation-drift.txt" 2>/dev/null || echo 0)"
 echo "  Bare-only annotated specs: $(wc -l < "$TMPDIR_SCAN/spec-bare-only.txt" 2>/dev/null || echo 0)"
 echo "  Aging obligations: $(wc -l < "$TMPDIR_SCAN/aging-obligations.txt" 2>/dev/null || echo 0)"
 echo "  Subdivision candidates: $(wc -l < "$TMPDIR_SCAN/spec-subdivision-candidates.txt" 2>/dev/null || echo 0)"

--- a/scripts/spec-backfill-candidates.sh
+++ b/scripts/spec-backfill-candidates.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# spec-backfill-candidates.sh — find code locations likely enforcing a
+# requirement, ranked by subject-token overlap.
+#
+# Usage:
+#   spec-backfill-candidates.sh <spec-id> <R-id> [--top N] [project-root]
+#
+# Output (stdout, one row per candidate, ranked by score descending):
+#   <score>\t<rel-path>:<line>\t<truncated-context>
+#
+# Stderr:
+#   [backfill] <spec-id>.<R-id> text: <requirement text>
+#   [backfill] <spec-id>.<R-id> tokens: <tok1>, <tok2>, ...
+#   [backfill] <N> candidate(s) above threshold
+#
+# The ranking heuristic mirrors `spec-resolve.sh` Step 7c displacement
+# detection: extract subject tokens from the requirement text (CamelCase or
+# snake_case identifiers >=4 chars, deduped, common stopwords excluded),
+# grep the codebase for each token, and score each line by how many distinct
+# requirement tokens appear on or within +/-2 lines of it. Lines are filtered
+# below a minimum score (default 2) to prune noise.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=spec-lib.sh disable=SC1091
+source "$SCRIPT_DIR/spec-lib.sh"
+
+SPEC_ID=""
+R_ID=""
+PROJECT_ROOT=""
+TOP_N=8
+MIN_SCORE=2
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --top)        shift; TOP_N="${1:-8}" ;;
+    --min-score)  shift; MIN_SCORE="${1:-2}" ;;
+    --help|-h)
+      echo "Usage: spec-backfill-candidates.sh <spec-id> <R-id> [--top N] [--min-score N] [project-root]" >&2
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: unknown flag '$1'" >&2
+      exit 1
+      ;;
+    *)
+      if   [[ -z "$SPEC_ID" ]]; then SPEC_ID="$1"
+      elif [[ -z "$R_ID" ]];    then R_ID="$1"
+      elif [[ -z "$PROJECT_ROOT" ]]; then PROJECT_ROOT="$1"
+      else echo "ERROR: extra positional argument '$1'" >&2; exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+[[ -z "$SPEC_ID" || -z "$R_ID" ]] && {
+  echo "Usage: spec-backfill-candidates.sh <spec-id> <R-id> [--top N] [project-root]" >&2
+  exit 1
+}
+
+# ── Locate project root ──────────────────────────────────────────────────────
+if [[ -z "$PROJECT_ROOT" ]]; then
+  dir="$PWD"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -d "$dir/.spec" ]] || [[ -d "$dir/.git" ]]; then
+      PROJECT_ROOT="$dir"
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+  [[ -z "$PROJECT_ROOT" ]] && {
+    echo "ERROR: Could not find project root (no .spec/ or .git/ found)." >&2
+    exit 1
+  }
+fi
+
+MANIFEST="$PROJECT_ROOT/.spec/registry/manifest.json"
+[[ ! -f "$MANIFEST" ]] && {
+  echo "ERROR: spec manifest not found at $MANIFEST" >&2
+  exit 1
+}
+
+SPEC_FILE=$(spec_file_for_id "$MANIFEST" "$SPEC_ID")
+[[ -z "$SPEC_FILE" || ! -f "$SPEC_FILE" ]] && {
+  echo "ERROR: Could not resolve spec file for '$SPEC_ID'" >&2
+  exit 1
+}
+
+# ── Extract requirement text ─────────────────────────────────────────────────
+# R-ids may span multiple lines. Read from the matching `^R<id>.` line up to
+# the next `^R[0-9]` or the end of the `## Requirements` section.
+R_TEXT=$(awk -v rid="$R_ID" '
+  /^## Requirements *$/ { in_req = 1; next }
+  /^## / && in_req     { in_req = 0 }
+  in_req {
+    # Match the line that opens our R-id (e.g., `R3.` or `R51a.`).
+    if ($0 ~ ("^" rid "\\.")) { capture = 1 }
+    else if (capture && $0 ~ /^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\./) { capture = 0 }
+    if (capture) print
+  }
+' "$SPEC_FILE")
+
+[[ -z "$R_TEXT" ]] && {
+  echo "ERROR: Requirement '$R_ID' not found in $SPEC_FILE" >&2
+  exit 1
+}
+
+echo "[backfill] $SPEC_ID.$R_ID text: $(echo "$R_TEXT" | head -1)" >&2
+
+# ── Extract subject tokens ───────────────────────────────────────────────────
+# Same heuristic as spec-resolve.sh Step 7c: CamelCase or snake_case
+# identifiers, length >=4, deduplicated, common stopwords skipped.
+# Lowercase plural tokens get a singular variant added (charges → charge,
+# entries → entry) so prose plurals match singular code identifiers.
+TOKENS=$(echo "$R_TEXT" | awk '
+  BEGIN {
+    # Common English / spec-prose stopwords that survive the length filter.
+    # Mirrors the prune list in spec-resolve.sh tokens_from_line.
+    split("must shall will should when then this that with from into upon they them their there these those have been being which what whose where because every", sw)
+    for (i in sw) skip[sw[i]] = 1
+  }
+  function emit(tok) {
+    if (length(tok) < 4) return
+    if (tolower(tok) in skip) return
+    if (tok in dedup) return
+    dedup[tok] = 1
+    print tok
+  }
+  {
+    s = $0
+    while (match(s, /[A-Z][a-zA-Z0-9]+|[a-z_][a-z_0-9]+/)) {
+      tok = substr(s, RSTART, RLENGTH)
+      s   = substr(s, RSTART + RLENGTH)
+      emit(tok)
+      # For lowercase tokens, also emit a simple singular form so prose
+      # plurals match singular code identifiers (charges → charge,
+      # entries → entry, classes → class).
+      if (tok ~ /^[a-z]/) {
+        if (tok ~ /ies$/)         emit(substr(tok, 1, length(tok)-3) "y")
+        else if (tok ~ /sses$/)   emit(substr(tok, 1, length(tok)-2))
+        else if (tok ~ /[^s]es$/) emit(substr(tok, 1, length(tok)-2))
+        else if (tok ~ /[^s]s$/)  emit(substr(tok, 1, length(tok)-1))
+      }
+    }
+  }
+')
+
+if [[ -z "$TOKENS" ]]; then
+  echo "[backfill] no subject tokens extracted from requirement text" >&2
+  exit 0
+fi
+
+token_list=$(echo "$TOKENS" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+echo "[backfill] $SPEC_ID.$R_ID tokens: $token_list" >&2
+
+# ── Determine scan directories ───────────────────────────────────────────────
+SCAN_DIRS=()
+if [[ -n "${SPEC_TRACE_DIRS:-}" ]]; then
+  IFS=',' read -ra USER_DIRS <<< "$SPEC_TRACE_DIRS"
+  for d in "${USER_DIRS[@]}"; do
+    d=$(echo "$d" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [[ -d "$PROJECT_ROOT/$d" ]] && SCAN_DIRS+=("$PROJECT_ROOT/$d")
+  done
+else
+  for candidate in src lib app main test tests spec modules examples benchmarks; do
+    [[ -d "$PROJECT_ROOT/$candidate" ]] && SCAN_DIRS+=("$PROJECT_ROOT/$candidate")
+  done
+fi
+
+if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
+  echo "[backfill] no source directories to scan in $PROJECT_ROOT" >&2
+  exit 0
+fi
+
+# ── Grep each token, accumulate hits, then score ────────────────────────────
+# A line's score = number of distinct requirement tokens appearing on it OR
+# within ±2 lines of it (a small window so a method declaration scores
+# alongside its body). We greatly simplify: per-line single-token hits with
+# a final aggregation by file+line.
+
+HITS_FILE=$(mktemp)
+trap 'rm -f "$HITS_FILE"' EXIT
+
+while IFS= read -r tok; do
+  [[ -z "$tok" ]] && continue
+  # Case-insensitive substring (fixed-string, not regex). Word boundaries
+  # would miss tokens fragmented inside CamelCase identifiers (e.g., the
+  # prose token `Expiry` would not word-boundary-match `validateExpiry` in
+  # code). Substring + min-score filtering trades precision for recall:
+  # noise gets pruned by requiring at least MIN_SCORE distinct token hits
+  # at the same line.
+  grep -rniIF -- "$tok" "${SCAN_DIRS[@]}" \
+    --include='*.java' --include='*.py' --include='*.js' --include='*.ts' \
+    --include='*.go' --include='*.rs' --include='*.kt' --include='*.scala' \
+    --include='*.c' --include='*.cpp' --include='*.h' --include='*.hpp' \
+    --include='*.cs' --include='*.rb' --include='*.swift' --include='*.m' \
+    --include='*.sh' \
+    2>/dev/null | while IFS= read -r ghit; do
+      # ghit format: file:line:content
+      printf '%s\t%s\n' "$tok" "$ghit"
+    done >> "$HITS_FILE" || true
+done <<< "$TOKENS"
+
+if [[ ! -s "$HITS_FILE" ]]; then
+  echo "[backfill] 0 candidate(s) above threshold" >&2
+  exit 0
+fi
+
+# ── Aggregate score per (file, line) — distinct tokens per location ────────
+# For each unique (file:line), count distinct tokens that hit. Filter test
+# files OUT of impl candidates? No — annotation in tests is also valid.
+# Output: score \t file:line \t context (truncated)
+
+CANDIDATES=$(awk -F'\t' -v root="$PROJECT_ROOT/" '
+  {
+    tok = $1
+    # $2 is "file:line:content" — split.
+    n = index($2, ":")
+    file = substr($2, 1, n - 1)
+    rest = substr($2, n + 1)
+    n2 = index(rest, ":")
+    lineno = substr(rest, 1, n2 - 1)
+    content = substr(rest, n2 + 1)
+
+    # Make path relative to project root for display
+    rel = file
+    sub(root, "", rel)
+
+    key = rel ":" lineno
+    if (!(key SUBSEP tok in seen)) {
+      seen[key SUBSEP tok] = 1
+      score[key]++
+      # First-seen content wins for the snippet
+      if (!(key in ctx)) {
+        # Trim leading/trailing whitespace; truncate to 80 chars
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", content)
+        if (length(content) > 80) content = substr(content, 1, 77) "..."
+        ctx[key] = content
+      }
+    }
+  }
+  END {
+    for (k in score) {
+      printf "%d\t%s\t%s\n", score[k], k, ctx[k]
+    }
+  }
+' "$HITS_FILE" | awk -F'\t' -v min="$MIN_SCORE" '$1 >= min' | sort -t$'\t' -k1,1nr -k2,2)
+
+if [[ -z "$CANDIDATES" ]]; then
+  echo "[backfill] 0 candidate(s) above threshold (min-score=$MIN_SCORE)" >&2
+  exit 0
+fi
+
+# Emit top N
+total=$(echo "$CANDIDATES" | wc -l | tr -d ' ')
+echo "[backfill] $total candidate(s) above threshold (min-score=$MIN_SCORE), showing top $TOP_N" >&2
+echo "$CANDIDATES" | head -"$TOP_N"

--- a/scripts/spec-backfill-log.sh
+++ b/scripts/spec-backfill-log.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# spec-backfill-log.sh — append-only progress log for /spec-backfill
+#
+# Stores per-(spec, R-id) backfill outcomes so re-running /spec-backfill on
+# the same corpus skips already-decided requirements (annotated, waived, or
+# explicitly skipped). The log is append-only — callers MUST NOT rewrite
+# rows; later rows for the same key supersede earlier ones for the
+# `latest-status` query semantics.
+#
+# Default location: .spec/backfill-log.md (corpus-wide). Per-spec scoping is
+# achieved by the row's `spec` column, not by separate files.
+#
+# Subcommands:
+#   init <log-md>
+#       Create <log-md> with a header table if it does not exist. Idempotent.
+#
+#   append <log-md> <date> <spec-id> <r-id> <status> [<file:line>] [<notes>]
+#       Append a row. Status values:
+#         annotated — `@spec` annotation applied at <file:line>.
+#         skipped   — user chose to skip this R-id (will resurface on rerun).
+#         waived    — user marked the requirement intentionally uncovered.
+#       Idempotent within a (date, spec, r-id, status, location, notes) tuple.
+#
+#   has-decision <log-md> <spec-id> <r-id>
+#       Exit 0 if the latest row for (spec, r-id) is `annotated` or `waived`
+#       (a terminal decision); exit 1 otherwise. Used by /spec-backfill to
+#       skip already-decided R-ids on resume. `skipped` is NOT terminal —
+#       skipped R-ids resurface on rerun by design.
+#
+#   list-decisions <log-md> <spec-id>
+#       Emit `<r-id>|<latest-status>|<location>|<date>` for every R-id of
+#       the given spec that has at least one log row. Most-recent row wins.
+#
+#   report <log-md>
+#       Three-line summary: total rows / annotated / skipped+waived.
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,/^set -e/p' "$0" | sed 's/^# *//;s/^#$//' | head -n -1
+  exit 2
+}
+
+cmd_init() {
+  local log="${1:-}"
+  [[ -z "$log" ]] && { echo "ERROR: init requires <log-md>" >&2; exit 2; }
+  if [[ -f "$log" ]]; then
+    echo "[backfill-log] init: $log already exists — no-op" >&2
+    return 0
+  fi
+  cat > "$log" <<'HEADER'
+# Spec Backfill Log
+
+> **Append-only. Managed by `scripts/spec-backfill-log.sh`.**
+> Records per-requirement backfill outcomes for `/spec-backfill`. Later
+> rows for the same `(spec, R-id)` supersede earlier ones — never edit
+> or delete prior rows.
+
+| Date | Spec | R-id | Status | Location | Notes |
+|------|------|------|--------|----------|-------|
+HEADER
+  echo "[backfill-log] init: created $log" >&2
+}
+
+cmd_append() {
+  local log="${1:-}" date="${2:-}" spec="${3:-}" rid="${4:-}" status="${5:-}"
+  local location="${6:-}" notes="${7:-}"
+  [[ -z "$log" || -z "$date" || -z "$spec" || -z "$rid" || -z "$status" ]] && {
+    echo "ERROR: append requires <log-md> <date> <spec-id> <r-id> <status> [location] [notes]" >&2
+    exit 2
+  }
+  case "$status" in
+    annotated|skipped|waived) ;;
+    *) echo "ERROR: status must be one of: annotated, skipped, waived (got '$status')" >&2; exit 2 ;;
+  esac
+  [[ -f "$log" ]] || cmd_init "$log"
+
+  # Sanitize pipes in user-supplied fields (notes especially).
+  local s_loc s_notes
+  s_loc=$(echo "$location" | tr '|' '/' )
+  s_notes=$(echo "$notes" | tr '|' '/' )
+
+  local new_row
+  new_row="| $date | $spec | $rid | $status | $s_loc | $s_notes |"
+
+  # Idempotence: skip if the exact row already exists (rare in practice).
+  if grep -Fxq "$new_row" "$log" 2>/dev/null; then
+    echo "[backfill-log] append: row already present — no-op" >&2
+    return 0
+  fi
+  echo "$new_row" >> "$log"
+  echo "[backfill-log] append: $spec.$rid → $status" >&2
+}
+
+# Emit the latest status for (spec, rid) on stdout. Empty if no rows.
+_latest_status() {
+  local log="$1" spec="$2" rid="$3"
+  awk -F'|' -v s="$spec" -v r="$rid" '
+    {
+      gsub(/^ +| +$/, "", $3); gsub(/^ +| +$/, "", $4); gsub(/^ +| +$/, "", $5)
+      if ($3 == s && $4 == r) last = $5
+    }
+    END { print last }
+  ' "$log"
+}
+
+cmd_has_decision() {
+  local log="${1:-}" spec="${2:-}" rid="${3:-}"
+  [[ -z "$log" || -z "$spec" || -z "$rid" ]] && {
+    echo "ERROR: has-decision requires <log-md> <spec-id> <r-id>" >&2
+    exit 2
+  }
+  [[ ! -f "$log" ]] && exit 1
+  local status
+  status=$(_latest_status "$log" "$spec" "$rid")
+  case "$status" in
+    annotated|waived) exit 0 ;;
+    *) exit 1 ;;
+  esac
+}
+
+cmd_list_decisions() {
+  local log="${1:-}" spec="${2:-}"
+  [[ -z "$log" || -z "$spec" ]] && {
+    echo "ERROR: list-decisions requires <log-md> <spec-id>" >&2
+    exit 2
+  }
+  [[ ! -f "$log" ]] && return 0
+  awk -F'|' -v s="$spec" '
+    {
+      gsub(/^ +| +$/, "", $2); gsub(/^ +| +$/, "", $3); gsub(/^ +| +$/, "", $4)
+      gsub(/^ +| +$/, "", $5); gsub(/^ +| +$/, "", $6)
+      if ($3 == s && $4 ~ /^R[0-9]/) {
+        # Last write wins per (spec, rid)
+        rid_status[$4] = $5
+        rid_loc[$4]    = $6
+        rid_date[$4]   = $2
+      }
+    }
+    END {
+      for (r in rid_status) {
+        print r "|" rid_status[r] "|" rid_loc[r] "|" rid_date[r]
+      }
+    }
+  ' "$log" | sort
+}
+
+cmd_report() {
+  local log="${1:-}"
+  [[ -z "$log" ]] && { echo "ERROR: report requires <log-md>" >&2; exit 2; }
+  [[ ! -f "$log" ]] && {
+    echo "no log file at $log"
+    return 0
+  }
+  local total ann skp wav
+  total=$(grep -cE '^\| [0-9]{4}-[0-9]{2}-[0-9]{2} \|' "$log" 2>/dev/null || echo 0)
+  ann=$(awk -F'|' '$5 ~ /annotated/ {n++} END {print n+0}' "$log")
+  skp=$(awk -F'|' '$5 ~ /skipped/   {n++} END {print n+0}' "$log")
+  wav=$(awk -F'|' '$5 ~ /waived/    {n++} END {print n+0}' "$log")
+  echo "rows: $total  annotated: $ann  skipped: $skp  waived: $wav"
+}
+
+CMD="${1:-}"
+shift || true
+case "$CMD" in
+  init)            cmd_init "$@" ;;
+  append)          cmd_append "$@" ;;
+  has-decision)    cmd_has_decision "$@" ;;
+  list-decisions)  cmd_list_decisions "$@" ;;
+  report)          cmd_report "$@" ;;
+  ""|-h|--help)    usage ;;
+  *) echo "ERROR: unknown subcommand '$CMD'" >&2; usage ;;
+esac

--- a/scripts/spec-trace.sh
+++ b/scripts/spec-trace.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # spec-trace.sh — find @spec annotations for a spec across the codebase
-# Usage: spec-trace.sh <spec-id> [project-root]
+# Usage: spec-trace.sh [--uncovered] <spec-id> [project-root]
 #   spec-id: legacy FXX (e.g., F13) OR domain.slug (e.g., schema.field-access)
+#   --uncovered: emit a parseable list of R-ids defined in the spec but absent
+#                from any @spec annotation in code. Output is one R-id per line
+#                on stdout (e.g., `auth.token-validation.R3`); a one-line
+#                summary goes to stderr. Used by /spec-backfill and /curate's
+#                annotation-drift analysis to drive backfill.
 # Optional env: SPEC_TRACE_DIRS="src,lib,test" — comma-separated dirs to scan (default: auto-detect)
 # Optional env: SPEC_TRACE_FORMAT="summary|detail|json" — output format (default: summary)
 # Output: grouped annotation report on stdout | diagnostics on stderr
@@ -12,17 +17,60 @@
 
 set -euo pipefail
 
-SPEC_ID="${1:-}"
-# Backwards-compatible alias used internally by older code paths
-PROJECT_ROOT="${2:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# spec-lib.sh is sourced for spec_file_for_id (used by --uncovered to resolve
+# a spec ID to its file via the manifest). Sourcing only defines functions —
+# no runtime cost or new hard dependencies for the default scan path.
+# shellcheck source=spec-lib.sh disable=SC1091
+source "$SCRIPT_DIR/spec-lib.sh"
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+# Accepts --uncovered as a flag in any position; preserves the historical
+# positional arg order (spec-id, then optional project-root).
+UNCOVERED_MODE=false
+SPEC_ID=""
+PROJECT_ROOT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --uncovered) UNCOVERED_MODE=true ;;
+    --help|-h)
+      echo "Usage: spec-trace.sh [--uncovered] <spec-id> [project-root]" >&2
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        if [[ -z "$SPEC_ID" ]]; then SPEC_ID="$1"
+        elif [[ -z "$PROJECT_ROOT" ]]; then PROJECT_ROOT="$1"
+        fi
+        shift
+      done
+      break
+      ;;
+    -*)
+      echo "ERROR: unknown flag '$1'" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "$SPEC_ID" ]]; then SPEC_ID="$1"
+      elif [[ -z "$PROJECT_ROOT" ]]; then PROJECT_ROOT="$1"
+      else
+        echo "ERROR: extra positional argument '$1'" >&2
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
 FORMAT="${SPEC_TRACE_FORMAT:-summary}"
 
 [[ -z "$SPEC_ID" ]] && {
-  echo "Usage: spec-trace.sh <spec-id> [project-root]" >&2
+  echo "Usage: spec-trace.sh [--uncovered] <spec-id> [project-root]" >&2
   echo "  Examples:" >&2
   echo "    spec-trace.sh F13                      # legacy FXX format" >&2
   echo "    spec-trace.sh schema.field-access      # domain.slug format" >&2
   echo "    spec-trace.sh F13 /path/to/project" >&2
+  echo "    spec-trace.sh --uncovered auth.token-validation" >&2
   echo "" >&2
   echo "  Env: SPEC_TRACE_DIRS='src,lib,test'  — dirs to scan" >&2
   echo "  Env: SPEC_TRACE_FORMAT='summary'      — summary|detail|json" >&2
@@ -102,7 +150,7 @@ grep -rnE "$GREP_PATTERN" "${SCAN_DIRS[@]}" \
 
 MATCH_COUNT=$(wc -l < "$MATCHES_FILE" | tr -d ' ')
 
-if [[ "$MATCH_COUNT" -eq 0 ]]; then
+if [[ "$MATCH_COUNT" -eq 0 && "$UNCOVERED_MODE" != "true" ]]; then
   echo "No @spec annotations found for $SPEC_ID" >&2
   echo "## $SPEC_ID — Trace Report"
   echo ""
@@ -191,6 +239,66 @@ IFS=$'\n' SORTED_REQS=($(
   done | sort -V | cut -f2-
 ))
 unset IFS
+
+# ── --uncovered mode: emit R-ids defined in the spec but absent from code ───
+# Reads the spec file, enumerates R-ids under the `## Requirements` section,
+# and emits the set difference against the annotated requirements (ALL_REQS).
+# Output: one R-id per line on stdout; one-line summary on stderr.
+# Used by /spec-backfill and /curate annotation-drift analysis to drive
+# backfill of uncovered requirements in mature corpora.
+if [[ "$UNCOVERED_MODE" == "true" ]]; then
+  manifest="$PROJECT_ROOT/.spec/registry/manifest.json"
+  spec_file=""
+  if [[ -f "$manifest" ]]; then
+    spec_file=$(spec_file_for_id "$manifest" "$SPEC_ID")
+  fi
+  if [[ -z "$spec_file" || ! -f "$spec_file" ]]; then
+    echo "ERROR: Could not resolve spec file for '$SPEC_ID'" >&2
+    echo "  Expected manifest at: $manifest" >&2
+    exit 1
+  fi
+
+  # Enumerate R-ids under the `## Requirements` section. Pattern matches
+  # plain (R1.), letter-suffixed (R51a.), and sub-numbered (R5-1., R5-1a.)
+  # forms. Sub-headings (### ...) inside the section do NOT exit the scope —
+  # only the next `## ` does.
+  defined_rids=$(awk '
+    /^## Requirements *$/ { in_req = 1; next }
+    /^## / && in_req     { in_req = 0 }
+    in_req && /^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\./ {
+      rid = $0; sub(/\..*$/, "", rid); print rid
+    }
+  ' "$spec_file" | sort -u)
+
+  total_defined=0
+  if [[ -n "$defined_rids" ]]; then
+    total_defined=$(echo "$defined_rids" | wc -l | tr -d ' ')
+  fi
+
+  # Build the set of annotated R-ids (just the trailing RN portion).
+  annotated_set=$(mktemp)
+  trap 'rm -f "$MATCHES_FILE" "$annotated_set"' EXIT
+  for r in "${ALL_REQS[@]}"; do
+    echo "${r##*.}" >> "$annotated_set"
+  done
+  sort -u -o "$annotated_set" "$annotated_set"
+
+  # Emit uncovered: defined - annotated. Re-attach the spec ID prefix so
+  # the output is fully qualified and directly consumable by /spec-backfill.
+  uncovered_count=0
+  if [[ -n "$defined_rids" ]]; then
+    while IFS= read -r rid; do
+      if ! grep -qxF "$rid" "$annotated_set" 2>/dev/null; then
+        echo "${SPEC_ID}.${rid}"
+        ((uncovered_count++)) || true
+      fi
+    done <<< "$defined_rids"
+  fi
+
+  annotated_count=$(( total_defined - uncovered_count ))
+  echo "[trace] $SPEC_ID: $total_defined requirement(s) defined, $annotated_count annotated, $uncovered_count uncovered" >&2
+  exit 0
+fi
 
 # ── Output ──────────────────────────────────────────────────────────────────────
 

--- a/scripts/work-lib.sh
+++ b/scripts/work-lib.sh
@@ -271,6 +271,29 @@ work_list_groups() {
     ! -name '_archive' ! -name '_refs' | sort
 }
 
+# ── WD lifecycle state rank ──────────────────────────────────────────────────
+# Maps a WD state to a numeric rank for monotonic comparison. Higher rank =
+# further along the lifecycle:
+#   DRAFT (0) → SPECIFYING (1) → SPECIFIED (2) → IMPLEMENTING (3) → COMPLETE (4)
+# IN_PROGRESS is a legacy alias for IMPLEMENTING. Returns -1 for unknown or
+# derived runtime states (e.g. BLOCKED, READY) so they fail any required-state
+# comparison rather than silently satisfying it.
+#
+# Used by work-resolve.sh to satisfy a wd:dep at required_state X when the
+# predecessor has reached any state at-or-past X (e.g. COMPLETE satisfies a
+# need-SPECIFIED dep). Strict equality silently blocked dependents whose
+# predecessors had advanced past the required state.
+work_wd_state_rank() {
+  case "$1" in
+    DRAFT)                    echo 0 ;;
+    SPECIFYING)               echo 1 ;;
+    SPECIFIED)                echo 2 ;;
+    IMPLEMENTING|IN_PROGRESS) echo 3 ;;
+    COMPLETE)                 echo 4 ;;
+    *)                        echo -1 ;;
+  esac
+}
+
 # ── Check if a spec artifact exists and is in required state ─────────────────
 # Accepts either a spec ID (e.g., "auth.jwt-contract", period form) or a
 # slash-path (e.g., "auth/jwt-contract"). The two forms are equivalent —

--- a/scripts/work-resolve.sh
+++ b/scripts/work-resolve.sh
@@ -119,7 +119,12 @@ while IFS= read -r wd_file; do
   fi
 
   if [[ "$wd_status" == "SPECIFIED" ]]; then
-    # Check wd-type deps — SPECIFIED WDs may be blocked by predecessor WDs
+    # Check wd-type deps — SPECIFIED WDs may be blocked by predecessor WDs.
+    # State match is monotonic on the WD lifecycle (DRAFT < SPECIFYING <
+    # SPECIFIED < IMPLEMENTING < COMPLETE) so a predecessor at any rank
+    # at-or-past the required state satisfies the dep. Strict equality
+    # previously blocked dependents whose predecessors had advanced past
+    # the required state (e.g. COMPLETE failed a need-SPECIFIED dep).
     spec_blockers=""
     spec_dep_count=0
     while IFS='|' read -r dep_type dep_ref dep_req_state dep_kind; do
@@ -127,8 +132,14 @@ while IFS= read -r wd_file; do
       ((spec_dep_count++)) || true
       if [[ "$dep_type" == "wd" ]]; then
         ref_status="${WD_STATUS[$dep_ref]:-}"
-        if [[ -z "$ref_status" || "$ref_status" != "$dep_req_state" ]]; then
-          spec_blockers+="wd:$dep_ref — need $dep_req_state, currently ${ref_status:-not found}"$'\n'
+        if [[ -z "$ref_status" ]]; then
+          spec_blockers+="wd:$dep_ref — need $dep_req_state, currently not found"$'\n'
+        else
+          ref_rank=$(work_wd_state_rank "$ref_status")
+          req_rank=$(work_wd_state_rank "$dep_req_state")
+          if (( ref_rank < 0 || req_rank < 0 || ref_rank < req_rank )); then
+            spec_blockers+="wd:$dep_ref — need $dep_req_state, currently $ref_status"$'\n'
+          fi
         fi
       fi
     done < <(work_fm_artifact_deps "$wd_file")
@@ -167,8 +178,16 @@ while IFS= read -r wd_file; do
         ;;
       wd)
         ref_wd_status="${WD_STATUS[$dep_ref]:-}"
-        if [[ -z "$ref_wd_status" || "$ref_wd_status" != "$dep_req_state" ]]; then
-          reason="WD $dep_ref is ${ref_wd_status:-not found} (need $dep_req_state)"
+        if [[ -z "$ref_wd_status" ]]; then
+          reason="WD $dep_ref is not found (need $dep_req_state)"
+        else
+          # Monotonic rank match — see work_wd_state_rank in work-lib.sh.
+          # COMPLETE satisfies SPECIFIED, etc.
+          ref_rank=$(work_wd_state_rank "$ref_wd_status")
+          req_rank=$(work_wd_state_rank "$dep_req_state")
+          if (( ref_rank < 0 || req_rank < 0 || ref_rank < req_rank )); then
+            reason="WD $dep_ref is $ref_wd_status (need $dep_req_state)"
+          fi
         fi
         ;;
       *)

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -458,13 +458,45 @@ From "Spec Annotation Coverage Gaps" in the scan summary:
    spec's traceability is missing.
 
 For each finding, use AskUserQuestion with options:
-- **"Verify via /spec-verify"** → runs `/spec-verify` on the spec to verify
-  requirements, classify gaps (code bug / stale spec / needs decision /
-  test gap), and repair them inline per the spec-verify protocol
+- **"Backfill via /spec-backfill"** → routes to `/spec-backfill <spec-id>`
+  to walk uncovered requirements and apply annotations to existing code.
+  This is the right tool for the "no annotations at all" case and for
+  single-requirement gaps where the implementation already exists.
+- **"Verify via /spec-verify"** → use when the gap may indicate spec→code
+  drift (the spec describes behavior that may no longer be in the code, or
+  vice versa). `/spec-verify` classifies and repairs spec violations; it is
+  heavier than `/spec-backfill` and not the default for pure annotation
+  backfill.
 - **"Accept gap with justification"** → the gap is intentional (e.g. the
   requirement is pure documentation; no runtime behavior to annotate). Record
   in the curation state review log with a short justification.
 - **"Skip for now"** — defer to next /curate pass
+
+### 2m-drift — Annotation drift (partial coverage below 50%)
+
+**Guard:** Only run this step if the "Annotation drift — APPROVED specs
+below 50% coverage" subsection exists under "Spec Annotation Coverage Gaps"
+in the scan summary. If absent, skip entirely.
+
+This subsection lists APPROVED specs whose annotation coverage has slipped
+below 50% — they have *some* annotations (so they are not in the
+unannotated bucket above) but are drifting. Rows are ordered by uncovered-
+percentage descending, then by spec-file age descending.
+
+If there are 4+ drifted specs, ask the user once whether to handle them
+individually or run a corpus walk. Use AskUserQuestion with options:
+- **"Run /spec-backfill --all"** → the corpus walk catches drift across
+  every spec in one pass; progress persists in `.spec/backfill-log.md`
+  so the user can break out and resume.
+- **"Walk specs one at a time"** → fall through to per-spec routing below.
+
+For each drifted spec (or each one when walking individually), use
+AskUserQuestion with options:
+- **"Backfill via /spec-backfill <spec-id>"** → routes to per-spec walk.
+- **"Skip for now"** — defer to next /curate pass.
+- **"Dismiss as intentional"** — record in the review log so this spec
+  no longer appears in drift findings (e.g. an aspirational spec where
+  partial coverage is by design).
 
 ### 2n — Aging open obligations
 

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: "Backfill @spec annotations on existing code for an APPROVED spec"
-argument-hint: "<spec-id>"
+description: "Backfill @spec annotations on existing code for an APPROVED spec (or --all specs)"
+argument-hint: "<spec-id> | --all"
 ---
 
 # /spec-backfill
@@ -10,8 +10,15 @@ in code, present likely enforcement sites for each, and apply annotations
 the user chooses. The catch-up tool for mature corpora authored before
 `@spec` annotation enforcement (`v0.16.5` / PR #67) was added.
 
-**When to use:** APPROVED spec whose requirements pre-date annotation
-enforcement and which has many uncovered R-ids. `/curate` annotation-drift
+**Two modes:**
+- `/spec-backfill <spec-id>` — walk one spec.
+- `/spec-backfill --all` — iterate every APPROVED spec in the manifest,
+  running the per-spec walk against each. The catch-up tool for whole
+  corpora (e.g. jlsm: 75 specs / 12 domains, mostly authored before
+  enforcement existed).
+
+**When to use:** APPROVED spec(s) whose requirements pre-date annotation
+enforcement and which have uncovered R-ids. `/curate` annotation-drift
 analysis routes here when a spec falls below 50% coverage.
 
 **Not for:** active features mid-pipeline. The `/feature-test` and
@@ -32,10 +39,14 @@ existing pre-enforcement code that no live feature touches.
 2. Verify `.spec/registry/manifest.json` exists. If not, tell the user to
    run `/spec-init` and stop.
 
-3. Resolve the spec ID from `$ARGUMENTS`. If empty, ask the user which spec
-   to backfill via AskUserQuestion. Build the option list from
-   `spec_manifest_ids` (limit to 4 + Other; if more candidates exist, hint
-   that `/spec-backfill --all` covers the corpus).
+3. Determine mode from `$ARGUMENTS`:
+   - `--all` (or `-a`) → corpus mode (jump to "Corpus mode" section below
+     after pre-flight).
+   - empty → ask the user which spec to backfill via AskUserQuestion.
+     Build the option list from APPROVED specs in the manifest (limit to
+     4 + Other; if more candidates exist, hint that `/spec-backfill --all`
+     covers the corpus).
+   - non-empty, not `--all` → treat as a literal spec-id and use it.
 
 4. Read `rules/spec-annotation-protocol.md` (already in your context as a
    project rule) — you must follow its comment-syntax-per-language and
@@ -193,6 +204,89 @@ If `skipped` count > 0, tell the user how to resume:
 ```
 <K> requirement(s) were skipped and will resurface on rerun. Run
 /spec-backfill <spec-id> again when you're ready to revisit them.
+```
+
+---
+
+## Corpus mode (`--all`)
+
+When invoked with `--all`, iterate every APPROVED spec in the manifest
+and run the per-spec walk against each. Pre-flight runs once; the
+backfill log is the same `.spec/backfill-log.md` so progress and prior
+decisions persist across the whole corpus.
+
+### C1. Discover the candidate set
+
+Enumerate APPROVED specs by reading the manifest:
+
+```bash
+jq -r '
+  if .specs then
+    .specs[] | select(.state == "APPROVED") | .id
+  else
+    (.features // {}) | to_entries[] | select(.value.state == "APPROVED") | .key
+  end
+' .spec/registry/manifest.json
+```
+
+Both v1 (`features` object keyed by ID) and v2 (`specs` array of objects)
+manifest schemas are handled by the `if .specs then` switch — the same
+dual-schema pattern `spec-lib.sh` uses.
+
+For each ID, run `bash .claude/scripts/spec-trace.sh --uncovered <id>`
+and capture only the count of uncovered R-ids. Skip specs that return
+zero uncovered (already fully annotated).
+
+Tell the user the corpus picture in one paragraph:
+
+```
+Corpus has <N> APPROVED specs. <K> already fully annotated — skipping.
+<M> have at least one uncovered requirement, totalling <U> uncovered
+R-ids across the corpus. Walking specs in manifest order; you can
+break out at any time and rerun /spec-backfill --all to resume.
+```
+
+### C2. Per-spec walk
+
+For each spec with uncovered R-ids, run **Phase 1 → Phase 2 → Phase 3**
+verbatim from the per-spec mode above. Between specs, surface a brief
+transition line so the user knows where they are:
+
+```
+─────────────────────────────────────────
+Spec 4 of 12 — auth.token-validation
+6 uncovered, 2 already decided in log
+─────────────────────────────────────────
+```
+
+### C3. Corpus summary
+
+After the last spec, emit a final aggregate report:
+
+- Total specs walked / skipped (already covered) / partially covered after run
+- Total annotations applied this session
+- Total R-ids skipped (will resurface) / waived
+- Pointer to `.spec/backfill-log.md` for the canonical record
+
+If any spec still has skipped or undecided R-ids, tell the user how to
+resume:
+
+```
+<X> requirement(s) across <Y> spec(s) were skipped this run. Rerun
+/spec-backfill --all to resume — already-decided R-ids will be skipped
+automatically.
+```
+
+### C4. Cost awareness
+
+Whole-corpus runs can be long. Surface a one-line cost note before
+starting if the corpus has > 50 uncovered R-ids in total:
+
+```
+Heads up: <U> uncovered R-ids across the corpus. Each requires at
+least one decision (annotate / skip / waive). Plan to break this
+into multiple sessions if needed — progress persists in
+.spec/backfill-log.md.
 ```
 
 ---

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -1,0 +1,212 @@
+---
+description: "Backfill @spec annotations on existing code for an APPROVED spec"
+argument-hint: "<spec-id>"
+---
+
+# /spec-backfill
+
+Walk every requirement of an APPROVED spec that has zero `@spec` annotations
+in code, present likely enforcement sites for each, and apply annotations
+the user chooses. The catch-up tool for mature corpora authored before
+`@spec` annotation enforcement (`v0.16.5` / PR #67) was added.
+
+**When to use:** APPROVED spec whose requirements pre-date annotation
+enforcement and which has many uncovered R-ids. `/curate` annotation-drift
+analysis routes here when a spec falls below 50% coverage.
+
+**Not for:** active features mid-pipeline. The `/feature-test` and
+`/feature-implement` substages already gate on annotation coverage; the
+forward-enforcement gate is the right tool there. `/spec-backfill` is for
+existing pre-enforcement code that no live feature touches.
+
+---
+
+## Pre-flight
+
+1. Verify `jq` is installed:
+   ```bash
+   command -v jq >/dev/null 2>&1
+   ```
+   If missing, tell the user and stop.
+
+2. Verify `.spec/registry/manifest.json` exists. If not, tell the user to
+   run `/spec-init` and stop.
+
+3. Resolve the spec ID from `$ARGUMENTS`. If empty, ask the user which spec
+   to backfill via AskUserQuestion. Build the option list from
+   `spec_manifest_ids` (limit to 4 + Other; if more candidates exist, hint
+   that `/spec-backfill --all` covers the corpus).
+
+4. Read `rules/spec-annotation-protocol.md` (already in your context as a
+   project rule) — you must follow its comment-syntax-per-language and
+   placement guidance when applying annotations below.
+
+---
+
+## Phase 1 — Discover uncovered requirements
+
+Run the trace primitive in `--uncovered` mode:
+
+```bash
+bash .claude/scripts/spec-trace.sh --uncovered <spec-id>
+```
+
+Output is a parseable list, one R-id per line on stdout (e.g.
+`auth.token-validation.R3`); a count summary is on stderr.
+
+If output is empty: tell the user "spec is fully annotated — nothing to
+backfill" and stop.
+
+If non-empty: capture the list and the count. Read `.spec/backfill-log.md`
+(initialize with `bash .claude/scripts/spec-backfill-log.sh init
+.spec/backfill-log.md` if it does not exist) and filter the list down to
+R-ids that do NOT yet have a terminal decision (`annotated` or `waived`).
+`skipped` rows from prior runs are NOT terminal — those resurface by
+design.
+
+Tell the user the plan in one or two sentences:
+
+```
+spec <id> has <N> uncovered requirement(s). <K> were skipped on prior
+runs and will resurface; <M> are already annotated or waived in the log
+and will be skipped. Walking <N - already-decided> now.
+```
+
+---
+
+## Phase 2 — Walk uncovered requirements
+
+For each R-id remaining (in spec order):
+
+### 2a. Surface the requirement text
+
+Read the spec file (path resolved via `spec_file_for_id`). Locate the
+matching `^R<n>[a-z]*(-…)?\.` line under `## Requirements` and extract the
+requirement text (may span multiple lines until the next R-id).
+
+### 2b. Find candidate sites
+
+Run the candidate finder:
+
+```bash
+bash .claude/scripts/spec-backfill-candidates.sh <spec-id> <r-id>
+```
+
+Output is one row per candidate, ranked by token-overlap score:
+
+```
+<score>\t<rel-path>:<line>\t<truncated-context>
+```
+
+Stderr surfaces the requirement text and the extracted subject tokens for
+display. Read both. The candidate finder may return zero rows for very
+short or token-poor requirements — that is expected.
+
+### 2c. Present and decide
+
+Present the requirement text and top candidates to the user.
+
+Build the AskUserQuestion options dynamically from the candidate rows.
+Show up to 4 candidates as labeled options; always include "Other (specify
+file:line)" and "Skip this R-id". Add "Waive (intentionally uncovered)"
+when the user signals at top of session that they want this option, or
+when a candidate set is empty.
+
+```
+R3 — The system must enforce token expiry by rejecting tokens whose
+exp claim is in the past at validation time.
+
+Subject tokens: TokenValidator, expiry, validate
+
+Likely sites:
+  (a) src/auth/TokenValidator.java:78  (overlap: 3)
+        if (claims.getExpiry().isBefore(now)) {
+  (b) src/auth/TokenValidator.java:45  (overlap: 2)
+        public boolean validateExpiry(Claims claims) {
+  (c) test/auth/TokenValidatorTest.java:120  (overlap: 2)
+        @Test void expiredTokensRejected() {
+```
+
+Use AskUserQuestion with the constructed options. Do NOT prompt with prose
+("Type a / b / c") — that does not stop generation; AskUserQuestion does.
+
+### 2d. Apply the user's decision
+
+Based on the choice:
+
+- **Candidate selected** — read the file, locate the chosen line, and
+  insert a `@spec <spec-id>.<R-id>` annotation in a comment ABOVE the line
+  (not on the same line) using the comment syntax for that language. Per
+  `rules/spec-annotation-protocol.md`: `// @spec <ref>` for C-family,
+  `# @spec <ref>` for Python/Ruby/Bash, `-- @spec <ref>` for Lua/SQL,
+  `<!-- @spec <ref> -->` for HTML/XML. If a sibling annotation already
+  exists at that location, append the new ref to the existing comment
+  rather than adding a separate line. Use Edit to apply.
+
+  Then append to the log:
+  ```bash
+  bash .claude/scripts/spec-backfill-log.sh append \
+    .spec/backfill-log.md "$(date +%F)" <spec-id> <r-id> annotated \
+    "<rel-path>:<line>"
+  ```
+
+- **Other** — ask the user via AskUserQuestion follow-up for the file:line.
+  Validate the path exists. Apply annotation as above. Log as `annotated`
+  with the user-supplied location.
+
+- **Skip** — append `skipped` to the log with no location. Move on. The
+  R-id will resurface on the next run.
+
+- **Waive** — ask follow-up via AskUserQuestion for a one-line reason.
+  Append `waived` with the reason in the notes column. Waived R-ids do
+  NOT resurface; the user has declared the requirement intentionally
+  uncovered (e.g., aspirational, deprecated, enforced externally).
+
+### 2e. Re-trace after each annotation (cheap correctness check)
+
+After applying an `annotated` decision, the next loop iteration starts
+with a stale picture of what is already covered. That is acceptable for
+performance — the candidate finder still scores correctly because tokens
+do not change. The end-of-session re-trace below catches any drift.
+
+---
+
+## Phase 3 — Confirm coverage moved
+
+After all R-ids are processed (decided or skipped), re-run:
+
+```bash
+bash .claude/scripts/spec-trace.sh --uncovered <spec-id>
+```
+
+Compute and report:
+- How many R-ids were uncovered at start.
+- How many are uncovered now.
+- Of the difference: how many were `annotated`, how many `skipped` (will
+  resurface), how many `waived`.
+
+Surface the report inline. Do NOT write a separate report file — the
+`.spec/backfill-log.md` is the authoritative record.
+
+If `skipped` count > 0, tell the user how to resume:
+
+```
+<K> requirement(s) were skipped and will resurface on rerun. Run
+/spec-backfill <spec-id> again when you're ready to revisit them.
+```
+
+---
+
+## Failure modes and recovery
+
+- **Manifest does not resolve the spec ID.** Tell the user the spec ID is
+  unknown; suggest `/spec` to list available specs. Stop.
+- **Candidate finder returns zero rows for every R-id.** Likely indicates
+  the requirement text is too prose-y for token extraction. Fall through
+  to "Other" / "Skip" — do not silently advance.
+- **Edit collides with an existing annotation that already covers this
+  R-id.** That should not happen if Phase 1 filtered correctly, but if
+  it does: log as `annotated` (idempotent on the log) and continue.
+- **User aborts mid-walk.** The log preserves every decision applied so
+  far; rerunning resumes from where the user left off. Do not revert
+  applied annotations.

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -1343,6 +1343,170 @@ fi
 rm -rf "$BARE_DIR" 2>/dev/null || true
 cd "$REPO_ROOT"
 
+# ── Test 32: Annotation drift — partial coverage below 50% surfaces ────────
+# An APPROVED spec with > 50% of requirements uncovered (but at least one
+# annotation) should appear in the new "Annotation drift" subsection of
+# the scan summary, distinct from UNANNOTATED. Sorted by uncovered-pct.
+
+echo ""
+echo "── Test 32: Annotation drift — partial coverage below 50% surfaces"
+
+DRIFT_DIR="/tmp/vallorcine/scenario-annotation-drift"
+rm -rf "$DRIFT_DIR" 2>/dev/null || true
+mkdir -p "$DRIFT_DIR/.spec/domains/auth" "$DRIFT_DIR/.spec/registry" \
+         "$DRIFT_DIR/.curate" "$DRIFT_DIR/.claude/scripts" "$DRIFT_DIR/src/auth"
+cp "$REPO_ROOT/scripts/curate-scan.sh" "$DRIFT_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$DRIFT_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-trace.sh" "$DRIFT_DIR/.claude/scripts/"
+
+cd "$DRIFT_DIR"
+git init -q .
+git config user.email t@t.com && git config user.name t
+
+# Spec with 5 R-ids; only R1 will be annotated → 4/5 uncovered = 80% drift.
+cat > .spec/domains/auth/token.md << 'SPECEOF'
+---
+{
+  "id": "auth.token",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"],
+  "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []
+}
+---
+
+# auth.token
+
+## Requirements
+
+R1. Validate token signatures.
+R2. Reject expired tokens.
+R3. Support multi-tenant claims.
+R4. Handle malformed tokens with parse errors.
+R5. Issue tokens with configurable TTL.
+SPECEOF
+
+cat > src/auth/Token.java << 'JEOF'
+// @spec auth.token.R1 — signature validation
+public class Token {
+    public boolean validate() { return true; }
+}
+JEOF
+
+cat > .spec/registry/manifest.json << 'MFEOF'
+{"schema_version": 2, "spec_count": 1,
+ "specs": [
+   {"id":"auth.token","path":".spec/domains/auth/token.md","state":"APPROVED","version":1,"domains":["auth"],"requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]}
+ ]}
+MFEOF
+
+git add -A && git commit -q -m "init"
+
+if command -v jq >/dev/null 2>&1; then
+    bash .claude/scripts/curate-scan.sh --init >/tmp/curate-drift.out 2>&1 || true
+
+    # auth.token should appear in the drift subsection (4/5 uncovered = 80%)
+    if grep -B 2 -A 15 'Annotation drift' .curate/scan-summary.md 2>/dev/null \
+       | grep -qE '^\| auth\.token \| 4 \| 5 \| 80% \|'; then
+        pass "auth.token surfaces in annotation-drift with 4/5 uncovered"
+    else
+        fail "auth.token should appear with 4 uncov, 5 total, 80%" \
+             "$(grep -B 2 -A 15 'Annotation drift' .curate/scan-summary.md 2>/dev/null | head -25)"
+    fi
+
+    # auth.token should NOT appear in UNANNOTATED (it has at least one annotation)
+    if grep -A 10 "no @spec annotations of any kind" .curate/scan-summary.md 2>/dev/null \
+       | grep -q "auth.token"; then
+        fail "auth.token leaked into UNANNOTATED (it has @spec auth.token.R1)"
+    else
+        pass "drifted spec stays out of UNANNOTATED bucket"
+    fi
+
+    # Drift subsection routes to /spec-backfill
+    if grep -A 5 'Annotation drift' .curate/scan-summary.md 2>/dev/null \
+       | grep -q '/spec-backfill'; then
+        pass "drift subsection routes to /spec-backfill"
+    else
+        fail "drift subsection should mention /spec-backfill"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+rm -rf "$DRIFT_DIR" 2>/dev/null || true
+cd "$REPO_ROOT"
+
+# ── Test 33: Annotation drift — fully-covered spec does NOT surface ────────
+# Spec with all R-ids annotated must NOT appear in the drift subsection.
+
+echo ""
+echo "── Test 33: Annotation drift — fully covered spec does not surface"
+
+COV_DIR="/tmp/vallorcine/scenario-fully-covered"
+rm -rf "$COV_DIR" 2>/dev/null || true
+mkdir -p "$COV_DIR/.spec/domains/auth" "$COV_DIR/.spec/registry" \
+         "$COV_DIR/.curate" "$COV_DIR/.claude/scripts" "$COV_DIR/src/auth"
+cp "$REPO_ROOT/scripts/curate-scan.sh" "$COV_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$COV_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-trace.sh" "$COV_DIR/.claude/scripts/"
+
+cd "$COV_DIR"
+git init -q .
+git config user.email t@t.com && git config user.name t
+
+cat > .spec/domains/auth/cov.md << 'SPECEOF'
+---
+{
+  "id": "auth.cov",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"],
+  "requires": [], "invalidates": [], "decision_refs": [], "kb_refs": []
+}
+---
+
+# auth.cov
+
+## Requirements
+
+R1. First.
+R2. Second.
+SPECEOF
+
+cat > src/auth/Cov.java << 'JEOF'
+// @spec auth.cov.R1
+public class CovOne {}
+// @spec auth.cov.R2
+public class CovTwo {}
+JEOF
+
+cat > .spec/registry/manifest.json << 'MFEOF'
+{"schema_version": 2, "spec_count": 1,
+ "specs": [
+   {"id":"auth.cov","path":".spec/domains/auth/cov.md","state":"APPROVED","version":1,"domains":["auth"],"requires":[],"invalidates":[],"decision_refs":[],"kb_refs":[]}
+ ]}
+MFEOF
+
+git add -A && git commit -q -m "init"
+
+if command -v jq >/dev/null 2>&1; then
+    bash .claude/scripts/curate-scan.sh --init >/tmp/curate-cov.out 2>&1 || true
+
+    if grep -A 15 'Annotation drift' .curate/scan-summary.md 2>/dev/null \
+       | grep -q "auth.cov"; then
+        fail "fully-covered auth.cov leaked into drift subsection"
+    else
+        pass "fully-covered spec does not appear in annotation-drift"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+rm -rf "$COV_DIR" 2>/dev/null || true
+cd "$REPO_ROOT"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/scenario-spec-backfill.sh
+++ b/tests/scenario-spec-backfill.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# Scenario: /spec-backfill primitives — candidate finder + append-only log
+#
+# Tests:
+# - spec-backfill-candidates.sh ranks code locations by token overlap
+# - candidate finder filters below min-score
+# - candidate finder respects --top
+# - spec-backfill-log.sh init + append + has-decision + list-decisions + report
+# - has-decision distinguishes terminal (annotated/waived) from skipped
+# - log is append-only and idempotent on identical rows
+# - report counts each status correctly
+#
+# Run from repo root: bash tests/scenario-spec-backfill.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-spec-backfill"
+CAND="$REPO_ROOT/scripts/spec-backfill-candidates.sh"
+LOG="$REPO_ROOT/scripts/spec-backfill-log.sh"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+cleanup() { rm -rf "$TEST_BASE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: spec-backfill primitives"
+echo "────────────────────────────────────────────────"
+
+cleanup
+mkdir -p "$TEST_BASE/project/.git"
+mkdir -p "$TEST_BASE/project/.spec/registry"
+mkdir -p "$TEST_BASE/project/.spec/domains/auth"
+mkdir -p "$TEST_BASE/project/src/auth"
+mkdir -p "$TEST_BASE/project/test/auth"
+
+# ── Spec fixture ────────────────────────────────────────────────────────────
+cat > "$TEST_BASE/project/.spec/domains/auth/F01-token-validation.md" << 'EOF'
+---
+{
+  "id": "F01",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"]
+}
+---
+
+# F01 — Token Validation
+
+## Requirements
+
+R1. The TokenValidator must reject expired tokens by checking the expiry claim.
+R2. The system must support multi-tenant claims with TenantContext propagation.
+R3. The TokenValidator must handle malformed tokens by raising a parse error.
+
+## Design Narrative
+Notes.
+EOF
+
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "F01", "path": ".spec/domains/auth/F01-token-validation.md", "state": "APPROVED", "domains": ["auth"] }
+  ]
+}
+EOF
+
+# ── Code fixture: realistic enforcement points ──────────────────────────────
+
+cat > "$TEST_BASE/project/src/auth/TokenValidator.java" << 'EOF'
+package com.example.auth;
+
+public class TokenValidator {
+
+    public boolean validateExpiry(Claims claims) {
+        if (claims.getExpiry().isBefore(now())) {
+            return false;
+        }
+        return true;
+    }
+
+    public TenantContext extractTenant(Claims claims) {
+        return new TenantContext(claims.getTenantId());
+    }
+
+    public Claims parseToken(String raw) throws ParseException {
+        // parsing logic
+        return Claims.parse(raw);
+    }
+}
+EOF
+
+cat > "$TEST_BASE/project/test/auth/TokenValidatorTest.java" << 'EOF'
+package com.example.auth;
+
+@Test
+void expiredTokensRejected() {
+    TokenValidator v = new TokenValidator();
+    assertFalse(v.validateExpiry(expiredClaims));
+}
+EOF
+
+# Decoy: file mentioning Token but not the requirement subjects.
+cat > "$TEST_BASE/project/src/auth/TokenLogger.java" << 'EOF'
+package com.example.auth;
+public class TokenLogger {
+    public void log(String message) {
+        System.out.println(message);
+    }
+}
+EOF
+
+# ── Test 1: candidate finder produces candidates with overlap scores ────────
+
+echo ""
+echo "── Test 1: candidate finder produces candidates ranked by score"
+
+output=$(cd "$TEST_BASE/project" && bash "$CAND" F01 R1 2>/dev/null)
+# Top candidate should reference TokenValidator (impl or test file are both
+# valid annotation targets per spec-annotation-protocol). Score column must
+# be present and numeric.
+if [[ -n "$output" ]] && echo "$output" | head -1 | grep -qE '^[0-9]+\s+(src|test)/auth/TokenValidator(Test)?\.java:[0-9]+'; then
+    pass "top candidate for R1 references TokenValidator (impl or test)"
+else
+    fail "expected TokenValidator file in top candidate" "got: $output"
+fi
+
+# ── Test 2: top candidate has higher score than tail ────────────────────────
+
+echo ""
+echo "── Test 2: candidates are sorted by score descending"
+
+output=$(cd "$TEST_BASE/project" && bash "$CAND" F01 R1 --top 10 2>/dev/null)
+first_score=$(echo "$output" | head -1 | cut -f1)
+last_score=$(echo "$output" | tail -1 | cut -f1)
+if [[ -n "$first_score" && -n "$last_score" && "$first_score" -ge "$last_score" ]]; then
+    pass "candidate scores are non-increasing (top=$first_score, last=$last_score)"
+else
+    fail "expected non-increasing scores" "first=$first_score last=$last_score; got: $output"
+fi
+
+# ── Test 3: --top N caps the output length ──────────────────────────────────
+
+echo ""
+echo "── Test 3: --top caps the output length"
+
+output_top1=$(cd "$TEST_BASE/project" && bash "$CAND" F01 R1 --top 1 2>/dev/null)
+line_count=$(echo "$output_top1" | wc -l | tr -d ' ')
+if [[ "$line_count" -eq 1 ]]; then
+    pass "--top 1 emits exactly one row"
+else
+    fail "--top 1 should emit one row" "got $line_count rows: $output_top1"
+fi
+
+# ── Test 4: --min-score filters low-overlap noise ───────────────────────────
+
+echo ""
+echo "── Test 4: --min-score filters low-overlap candidates"
+
+# TokenLogger has only "Token" overlap (1 token, below default min-score=2)
+output=$(cd "$TEST_BASE/project" && bash "$CAND" F01 R1 --top 99 2>/dev/null)
+if ! echo "$output" | grep -q "TokenLogger"; then
+    pass "TokenLogger filtered out below min-score=2"
+else
+    fail "TokenLogger should be below min-score" "got: $output"
+fi
+
+# Lower the bar — at min-score=1, decoys may surface (informational; not asserted).
+
+# ── Test 5: candidate finder resolves domain.slug ID via fallback ───────────
+
+echo ""
+echo "── Test 5: candidate finder resolves domain.slug ID"
+
+# Add a domain.slug-styled spec at the path-derived location
+mkdir -p "$TEST_BASE/project/.spec/domains/billing"
+cat > "$TEST_BASE/project/.spec/domains/billing/charge.md" << 'EOF'
+---
+{
+  "id": "billing.charge",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["billing"]
+}
+---
+
+# billing.charge
+
+## Requirements
+
+R1. The ChargeProcessor must finalize charges via the SettlementGateway.
+EOF
+
+# Update manifest to include billing.charge
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "F01", "path": ".spec/domains/auth/F01-token-validation.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "billing.charge", "path": ".spec/domains/billing/charge.md", "state": "APPROVED", "domains": ["billing"] }
+  ]
+}
+EOF
+
+mkdir -p "$TEST_BASE/project/src/billing"
+cat > "$TEST_BASE/project/src/billing/ChargeProcessor.java" << 'EOF'
+package com.example.billing;
+public class ChargeProcessor {
+    private SettlementGateway gateway;
+    public void finalize(Charge c) {
+        gateway.settle(c);
+    }
+}
+EOF
+
+output=$(cd "$TEST_BASE/project" && bash "$CAND" billing.charge R1 2>/dev/null)
+if echo "$output" | grep -q "src/billing/ChargeProcessor.java"; then
+    pass "candidate finder resolves domain.slug spec ID"
+else
+    fail "should find ChargeProcessor.java for billing.charge.R1" "got: $output"
+fi
+
+# ── Test 6: missing requirement → error ─────────────────────────────────────
+
+echo ""
+echo "── Test 6: candidate finder errors clearly on missing R-id"
+
+output=$(cd "$TEST_BASE/project" && bash "$CAND" F01 R99 2>&1 || true)
+if echo "$output" | grep -q "Requirement 'R99' not found"; then
+    pass "missing R-id produces clear error"
+else
+    fail "should error on missing R-id" "got: $output"
+fi
+
+# ── Test 7: log init creates header table ───────────────────────────────────
+
+echo ""
+echo "── Test 7: log init creates a header table"
+
+bash "$LOG" init "$TEST_BASE/log.md" >/dev/null 2>&1
+if grep -q "^| Date | Spec | R-id | Status |" "$TEST_BASE/log.md"; then
+    pass "log init writes header table"
+else
+    fail "log init should write header" "got: $(cat "$TEST_BASE/log.md")"
+fi
+
+# ── Test 8: log init is idempotent ──────────────────────────────────────────
+
+echo ""
+echo "── Test 8: log init is idempotent"
+
+cp "$TEST_BASE/log.md" "$TEST_BASE/log.md.bak"
+bash "$LOG" init "$TEST_BASE/log.md" >/dev/null 2>&1
+if cmp -s "$TEST_BASE/log.md" "$TEST_BASE/log.md.bak"; then
+    pass "log init does not overwrite existing log"
+else
+    fail "log init clobbered existing content"
+fi
+
+# ── Test 9: append annotated row ────────────────────────────────────────────
+
+echo ""
+echo "── Test 9: append annotated row records location"
+
+bash "$LOG" append "$TEST_BASE/log.md" 2026-05-06 F01 R1 annotated "src/auth/TokenValidator.java:5" >/dev/null 2>&1
+if grep -qE '^\| 2026-05-06 \| F01 \| R1 \| annotated \| src/auth/TokenValidator\.java:5 \|' "$TEST_BASE/log.md"; then
+    pass "append wrote annotated row with location"
+else
+    fail "annotated row not written" "got: $(grep R1 "$TEST_BASE/log.md")"
+fi
+
+# ── Test 10: has-decision returns 0 for annotated ───────────────────────────
+
+echo ""
+echo "── Test 10: has-decision distinguishes terminal vs non-terminal"
+
+# `set -e` in the harness would short-circuit on the rc=1 paths below;
+# pause errexit while we capture exit codes, then restore.
+set +e
+bash "$LOG" has-decision "$TEST_BASE/log.md" F01 R1
+ann_rc=$?
+bash "$LOG" append "$TEST_BASE/log.md" 2026-05-06 F01 R2 skipped "" >/dev/null 2>&1
+bash "$LOG" has-decision "$TEST_BASE/log.md" F01 R2
+skp_rc=$?
+bash "$LOG" has-decision "$TEST_BASE/log.md" F01 R99
+unknown_rc=$?
+set -e
+if [[ "$ann_rc" -eq 0 && "$skp_rc" -eq 1 && "$unknown_rc" -eq 1 ]]; then
+    pass "has-decision: annotated=0, skipped=1, unknown=1"
+else
+    fail "has-decision exit codes wrong" "ann=$ann_rc skp=$skp_rc unk=$unknown_rc"
+fi
+
+# ── Test 11: append is idempotent on identical rows ─────────────────────────
+
+echo ""
+echo "── Test 11: append is idempotent on identical rows"
+
+before=$(wc -l < "$TEST_BASE/log.md")
+bash "$LOG" append "$TEST_BASE/log.md" 2026-05-06 F01 R1 annotated "src/auth/TokenValidator.java:5" >/dev/null 2>&1
+after=$(wc -l < "$TEST_BASE/log.md")
+if [[ "$before" -eq "$after" ]]; then
+    pass "duplicate append does not add a new row"
+else
+    fail "duplicate append wrote a new row" "before=$before after=$after"
+fi
+
+# ── Test 12: later row supersedes earlier (most-recent wins) ────────────────
+
+echo ""
+echo "── Test 12: later row supersedes earlier (most-recent wins)"
+
+# R2 was skipped above. Annotate it later — has-decision should now return 0.
+bash "$LOG" append "$TEST_BASE/log.md" 2026-05-07 F01 R2 annotated "src/auth/TokenValidator.java:11" >/dev/null 2>&1
+set +e
+bash "$LOG" has-decision "$TEST_BASE/log.md" F01 R2
+later_rc=$?
+set -e
+if [[ "$later_rc" -eq 0 ]]; then
+    pass "later annotated row supersedes earlier skipped"
+else
+    fail "later row should supersede" "rc=$later_rc"
+fi
+
+# ── Test 13: list-decisions emits per-R-id rows for the spec ────────────────
+
+echo ""
+echo "── Test 13: list-decisions emits one row per R-id for the spec"
+
+bash "$LOG" append "$TEST_BASE/log.md" 2026-05-06 F01 R3 waived "" "aspirational" >/dev/null 2>&1
+output=$(bash "$LOG" list-decisions "$TEST_BASE/log.md" F01 2>/dev/null)
+expected=$'R1|annotated|src/auth/TokenValidator.java:5|2026-05-06\nR2|annotated|src/auth/TokenValidator.java:11|2026-05-07\nR3|waived||2026-05-06'
+if [[ "$output" == "$expected" ]]; then
+    pass "list-decisions emits R1/R2/R3 with latest status each"
+else
+    fail "list-decisions output mismatch" "got: $output"
+fi
+
+# ── Test 14: report counts each status ──────────────────────────────────────
+
+echo ""
+echo "── Test 14: report counts each status correctly"
+
+# Log has: R1 annotated, R2 skipped+annotated, R3 waived → 4 rows total
+output=$(bash "$LOG" report "$TEST_BASE/log.md" 2>/dev/null)
+if echo "$output" | grep -qE 'rows: 4 +annotated: 2 +skipped: 1 +waived: 1'; then
+    pass "report counts rows=4 / annotated=2 / skipped=1 / waived=1"
+else
+    fail "report counts mismatch" "got: $output"
+fi
+
+# ── Test 15: invalid status rejected ────────────────────────────────────────
+
+echo ""
+echo "── Test 15: append rejects invalid status"
+
+output=$(bash "$LOG" append "$TEST_BASE/log.md" 2026-05-06 F01 R4 broken "" 2>&1 || true)
+if echo "$output" | grep -q "status must be one of"; then
+    pass "invalid status produces clear error"
+else
+    fail "should reject invalid status" "got: $output"
+fi
+
+# ── Test 16: pipe-bearing notes are sanitized ───────────────────────────────
+
+echo ""
+echo "── Test 16: pipe characters in notes are sanitized"
+
+bash "$LOG" append "$TEST_BASE/log.md" 2026-05-06 F01 R5 waived "" "complex|pipe|value" >/dev/null 2>&1
+if grep -q "complex/pipe/value" "$TEST_BASE/log.md" && \
+   ! grep -qE '\| F01 \| R5 \| waived \| \| complex\|' "$TEST_BASE/log.md"; then
+    pass "pipes in notes replaced with slashes (preserves table integrity)"
+else
+    fail "pipes not sanitized" "got: $(grep R5 "$TEST_BASE/log.md")"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+
+exit $failed

--- a/tests/scenario-spec-backfill.sh
+++ b/tests/scenario-spec-backfill.sh
@@ -380,6 +380,85 @@ else
     fail "pipes not sanitized" "got: $(grep R5 "$TEST_BASE/log.md")"
 fi
 
+# ── Test 17: --all corpus enumeration on v2 manifest ────────────────────────
+
+echo ""
+echo "── Test 17: --all corpus enumeration emits APPROVED spec IDs (v2)"
+
+# v2 manifest already in place (with F01 + billing.charge from earlier tests).
+# Add a DRAFT spec that should NOT be enumerated.
+cat > "$TEST_BASE/project/.spec/domains/auth/F09-draft.md" << 'EOF'
+---
+{
+  "id": "F09",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "DRAFT",
+  "domains": ["auth"]
+}
+---
+
+# F09 — Draft only
+
+## Requirements
+R1. Draft.
+EOF
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "F01", "path": ".spec/domains/auth/F01-token-validation.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "billing.charge", "path": ".spec/domains/billing/charge.md", "state": "APPROVED", "domains": ["billing"] },
+    { "id": "F09", "path": ".spec/domains/auth/F09-draft.md", "state": "DRAFT", "domains": ["auth"] }
+  ]
+}
+EOF
+
+# Mirror the SKILL's enumeration — must work without bespoke tooling.
+output=$(jq -r '
+  if .specs then
+    .specs[] | select(.state == "APPROVED") | .id
+  else
+    (.features // {}) | to_entries[] | select(.value.state == "APPROVED") | .key
+  end
+' "$TEST_BASE/project/.spec/registry/manifest.json" | sort)
+expected=$'F01\nbilling.charge'
+if [[ "$output" == "$expected" ]]; then
+    pass "--all enumeration filters APPROVED only (v2 schema)"
+else
+    fail "should emit F01 and billing.charge, exclude F09 (DRAFT)" "got: '$output'"
+fi
+
+# ── Test 18: --all corpus enumeration on v1 manifest ────────────────────────
+
+echo ""
+echo "── Test 18: --all corpus enumeration handles v1 manifest schema"
+
+cat > "$TEST_BASE/v1-manifest.json" << 'EOF'
+{
+  "domains": { "auth": {} },
+  "features": {
+    "F01": { "latest_file": "domains/auth/F01.md", "state": "APPROVED" },
+    "F02": { "latest_file": "domains/auth/F02.md", "state": "DRAFT" },
+    "F03": { "latest_file": "domains/auth/F03.md", "state": "APPROVED" }
+  }
+}
+EOF
+
+output=$(jq -r '
+  if .specs then
+    .specs[] | select(.state == "APPROVED") | .id
+  else
+    (.features // {}) | to_entries[] | select(.value.state == "APPROVED") | .key
+  end
+' "$TEST_BASE/v1-manifest.json" | sort)
+expected=$'F01\nF03'
+if [[ "$output" == "$expected" ]]; then
+    pass "--all enumeration handles v1 manifest schema"
+else
+    fail "should emit F01 and F03 from v1 manifest" "got: '$output'"
+fi
+
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────────────"

--- a/tests/scenario-spec-coverage.sh
+++ b/tests/scenario-spec-coverage.sh
@@ -50,6 +50,7 @@ mkdir -p "$TEST_BASE/project/.spec/registry/" \
 
 cp "$REPO_ROOT/scripts/spec-coverage.sh" "$TEST_BASE/project/.claude/scripts/"
 cp "$REPO_ROOT/scripts/spec-trace.sh"    "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh"      "$TEST_BASE/project/.claude/scripts/"
 
 # Synthetic spec-resolve bundle (the input to `init`).
 cat > "$TEST_BASE/project/.feature/sample/spec-bundle.md" <<'BUNDLE'

--- a/tests/scenario-spec-trace.sh
+++ b/tests/scenario-spec-trace.sh
@@ -11,6 +11,7 @@
 # - No-match case exits cleanly
 # - Summary, detail, and JSON output formats
 # - SPEC_TRACE_DIRS override
+# - --uncovered mode: emits R-ids defined in spec but absent from annotations
 #
 # Run from repo root: bash tests/scenario-spec-trace.sh
 
@@ -265,6 +266,244 @@ if [[ "$req_count" -eq 4 ]]; then
     pass "description text after — separator does not create false requirement matches"
 else
     fail "should have exactly 4 requirements (R1, R3, R7, R12)" "got: $req_count"
+fi
+
+# ── --uncovered mode setup ───────────────────────────────────────────────────
+# Add a .spec/ directory with a manifest and two spec files. F01 defines R1,
+# R3, R5, R7, R12 — only R5 has no annotation in the fixture above. F02
+# defines R1, R4, R8 — only R8 has no annotation.
+
+mkdir -p "$TEST_BASE/project/.spec/registry"
+mkdir -p "$TEST_BASE/project/.spec/domains/auth"
+mkdir -p "$TEST_BASE/project/.spec/domains/data"
+
+cat > "$TEST_BASE/project/.spec/domains/auth/F01-jwt-token.md" << 'EOF'
+---
+{
+  "id": "F01",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"]
+}
+---
+
+# F01 — JWT Token Contract
+
+## Requirements
+
+R1. The system must reject null keys.
+R3. The system must validate token signatures.
+R5. The system must enforce token expiry. (uncovered — no @spec annotation)
+R7. The system must support multi-tenant claims.
+R12. The system must produce a helper constraint.
+
+## Design Narrative
+Notes here.
+EOF
+
+cat > "$TEST_BASE/project/.spec/domains/data/F02-serializer.md" << 'EOF'
+---
+{
+  "id": "F02",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["data"]
+}
+---
+
+# F02 — Serializer Contract
+
+## Requirements
+
+R1. The system must serialize records.
+R4. The system must enforce shared serialization constraint.
+R8. The system must compress records over 4KB. (uncovered)
+EOF
+
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "F01", "path": ".spec/domains/auth/F01-jwt-token.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "F02", "path": ".spec/domains/data/F02-serializer.md", "state": "APPROVED", "domains": ["data"] }
+  ]
+}
+EOF
+
+# ── Test 14: --uncovered emits only R-ids absent from annotations ───────────
+
+output_uncov=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" --uncovered F01 2>/dev/null)
+if [[ "$output_uncov" == "F01.R5" ]]; then
+    pass "--uncovered F01 emits exactly the unannotated R-id (F01.R5)"
+else
+    fail "--uncovered should emit only F01.R5" "got: '$output_uncov'"
+fi
+
+# ── Test 15: --uncovered emits stderr summary with counts ───────────────────
+
+stderr_uncov=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" --uncovered F01 2>&1 >/dev/null)
+if echo "$stderr_uncov" | grep -qE 'F01:.*5 requirement.*defined.*4 annotated.*1 uncovered'; then
+    pass "--uncovered stderr summary reports defined/annotated/uncovered counts"
+else
+    fail "stderr summary should report 5 defined / 4 annotated / 1 uncovered" "got: $stderr_uncov"
+fi
+
+# ── Test 16: --uncovered handles a spec with multiple uncovered R-ids ───────
+
+# Annotate only F02.R1 and F02.R4 in the fixture (R8 left uncovered) and verify.
+output_uncov_f02=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" --uncovered F02 2>/dev/null)
+if [[ "$output_uncov_f02" == "F02.R8" ]]; then
+    pass "--uncovered F02 emits only F02.R8 (R1 and R4 are annotated)"
+else
+    fail "--uncovered F02 should emit F02.R8" "got: '$output_uncov_f02'"
+fi
+
+# ── Test 17: --uncovered with no annotations emits all defined R-ids ────────
+
+# Add a spec with NO annotations anywhere.
+cat > "$TEST_BASE/project/.spec/domains/auth/F03-orphan.md" << 'EOF'
+---
+{
+  "id": "F03",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"]
+}
+---
+
+# F03 — Orphan spec
+
+## Requirements
+
+R1. First.
+R2. Second.
+R3. Third.
+EOF
+
+# Update manifest
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "F01", "path": ".spec/domains/auth/F01-jwt-token.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "F02", "path": ".spec/domains/data/F02-serializer.md", "state": "APPROVED", "domains": ["data"] },
+    { "id": "F03", "path": ".spec/domains/auth/F03-orphan.md", "state": "APPROVED", "domains": ["auth"] }
+  ]
+}
+EOF
+
+output_orphan=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" --uncovered F03 2>/dev/null | sort)
+expected_orphan=$'F03.R1\nF03.R2\nF03.R3'
+if [[ "$output_orphan" == "$expected_orphan" ]]; then
+    pass "--uncovered emits all R-ids when none are annotated"
+else
+    fail "--uncovered F03 should emit all three R-ids" "got: '$output_orphan'"
+fi
+
+# ── Test 18: --uncovered for domain.slug spec resolves via manifest ─────────
+
+mkdir -p "$TEST_BASE/project/.spec/domains/auth/token"
+cat > "$TEST_BASE/project/.spec/domains/auth/token/validation.md" << 'EOF'
+---
+{
+  "id": "auth.token.validation",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"]
+}
+---
+
+# auth.token.validation
+
+## Requirements
+
+R1. Validate signature.
+R2. Reject expired tokens.
+EOF
+
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "F01", "path": ".spec/domains/auth/F01-jwt-token.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "F02", "path": ".spec/domains/data/F02-serializer.md", "state": "APPROVED", "domains": ["data"] },
+    { "id": "F03", "path": ".spec/domains/auth/F03-orphan.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "auth.token.validation", "path": ".spec/domains/auth/token/validation.md", "state": "APPROVED", "domains": ["auth"] }
+  ]
+}
+EOF
+
+output_dom=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" --uncovered auth.token.validation 2>/dev/null | sort)
+expected_dom=$'auth.token.validation.R1\nauth.token.validation.R2'
+if [[ "$output_dom" == "$expected_dom" ]]; then
+    pass "--uncovered resolves domain.slug spec via manifest"
+else
+    fail "--uncovered auth.token.validation should emit R1 and R2" "got: '$output_dom'"
+fi
+
+# ── Test 19: --uncovered with letter-suffixed and sub-numbered R-ids ────────
+
+cat > "$TEST_BASE/project/.spec/domains/auth/F04-suffixed.md" << 'EOF'
+---
+{
+  "id": "F04",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["auth"]
+}
+---
+
+# F04 — Suffixed requirements
+
+## Requirements
+
+R1. Plain.
+R2a. Letter-suffixed.
+R2b. Letter-suffixed.
+R5-1. Sub-numbered.
+R5-1a. Sub-numbered with letter.
+EOF
+
+cat > "$TEST_BASE/project/.spec/registry/manifest.json" << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "F01", "path": ".spec/domains/auth/F01-jwt-token.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "F02", "path": ".spec/domains/data/F02-serializer.md", "state": "APPROVED", "domains": ["data"] },
+    { "id": "F03", "path": ".spec/domains/auth/F03-orphan.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "auth.token.validation", "path": ".spec/domains/auth/token/validation.md", "state": "APPROVED", "domains": ["auth"] },
+    { "id": "F04", "path": ".spec/domains/auth/F04-suffixed.md", "state": "APPROVED", "domains": ["auth"] }
+  ]
+}
+EOF
+
+output_sfx=$(cd "$TEST_BASE/project" && bash "$TRACE_SCRIPT" --uncovered F04 2>/dev/null | sort)
+expected_sfx=$'F04.R1\nF04.R2a\nF04.R2b\nF04.R5-1\nF04.R5-1a'
+if [[ "$output_sfx" == "$expected_sfx" ]]; then
+    pass "--uncovered handles letter-suffixed and sub-numbered R-ids"
+else
+    fail "--uncovered should emit all suffixed R-ids" "got: '$output_sfx'"
+fi
+
+# ── Test 20: --uncovered with no manifest fails cleanly ─────────────────────
+
+# Need a src/ dir so spec-trace passes the auto-detect dir check before
+# reaching the manifest resolution step we're testing here.
+mkdir -p "$TEST_BASE/no-manifest/.git"
+mkdir -p "$TEST_BASE/no-manifest/src"
+echo '// noop' > "$TEST_BASE/no-manifest/src/dummy.java"
+cd "$TEST_BASE/no-manifest"
+output_nm=$(bash "$TRACE_SCRIPT" --uncovered F01 2>&1 || true)
+cd "$TEST_BASE/project"
+if echo "$output_nm" | grep -q "Could not resolve spec file"; then
+    pass "--uncovered without manifest fails with clear error"
+else
+    fail "--uncovered should error when manifest is missing" "got: $output_nm"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/tests/scenario-work-resolve.sh
+++ b/tests/scenario-work-resolve.sh
@@ -12,6 +12,8 @@
 # 8. Scope signal shown for high-dep-count WDs
 # 9. Dependency graph shows which WDs unblock others
 # 10. Curate mode emits extra data tables
+# 11-16. wd-type deps (basic + chained)
+# 17-21. monotonic state-rank match for wd deps (regression for strict-equality bug)
 #
 # Run from repo root: bash tests/scenario-work-resolve.sh
 
@@ -517,6 +519,153 @@ fi
 
 # ── Cleanup wd-dep-test group ───────────────────────────────────────────────
 rm -rf .work/wd-dep-test
+
+# ── Tests 17-21: monotonic state-rank match for wd deps ─────────────────────
+#
+# Regression for strict-equality bug surfaced from jlsm: a dep declared as
+# `required_state: SPECIFIED` was reported BLOCKED when the predecessor had
+# advanced to COMPLETE (a higher-ranked state on the lifecycle). The dep
+# should be satisfied by any state at-or-past the required rank.
+#
+# Lifecycle: DRAFT (0) → SPECIFYING (1) → SPECIFIED (2) → IMPLEMENTING (3)
+# → COMPLETE (4). IN_PROGRESS is a legacy alias for IMPLEMENTING.
+
+mkdir -p "$TEST_BASE/project/.work/state-rank-test"
+
+# Predecessor we'll mutate across tests
+cat > .work/state-rank-test/WD-01.md << 'EOF'
+---
+id: WD-01
+title: Predecessor
+group: state-rank-test
+status: COMPLETE
+domains: [auth]
+artifact_deps: []
+produces: []
+---
+
+## Summary
+Predecessor whose state will vary across the test cases below.
+
+## Acceptance Criteria
+Test.
+EOF
+
+# Dependent declares need-SPECIFIED — the bug case
+cat > .work/state-rank-test/WD-02.md << 'EOF'
+---
+id: WD-02
+title: Needs WD-01 SPECIFIED
+group: state-rank-test
+status: SPECIFIED
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: SPECIFIED }
+produces: []
+---
+
+## Summary
+This WD only needs WD-01 to have reached SPECIFIED — any state past
+SPECIFIED (IMPLEMENTING, COMPLETE) should also satisfy.
+
+## Acceptance Criteria
+Test.
+EOF
+
+# ── Test 17: COMPLETE predecessor satisfies need-SPECIFIED (SPECIFIED branch)
+
+echo ""
+echo "── Test 17: COMPLETE predecessor satisfies need-SPECIFIED dep (SPECIFIED branch)"
+
+output="$(bash .claude/scripts/work-resolve.sh state-rank-test 2>&1)"
+if echo "$output" | grep "WD-02" | grep -q "SPECIFIED" && \
+   ! echo "$output" | grep "WD-02" | grep -q "BLOCKED"; then
+    pass "COMPLETE predecessor satisfies need-SPECIFIED on a SPECIFIED dependent"
+else
+    fail "WD-02 should be SPECIFIED (WD-01 COMPLETE >= SPECIFIED)" "got: $output"
+fi
+
+# ── Test 18: IMPLEMENTING predecessor satisfies need-SPECIFIED ──────────────
+
+echo ""
+echo "── Test 18: IMPLEMENTING predecessor satisfies need-SPECIFIED dep"
+
+sed -i 's/^status: COMPLETE$/status: IMPLEMENTING/' .work/state-rank-test/WD-01.md
+
+output="$(bash .claude/scripts/work-resolve.sh state-rank-test 2>&1)"
+if echo "$output" | grep "WD-02" | grep -q "SPECIFIED" && \
+   ! echo "$output" | grep "WD-02" | grep -q "BLOCKED"; then
+    pass "IMPLEMENTING predecessor satisfies need-SPECIFIED"
+else
+    fail "WD-02 should be SPECIFIED (WD-01 IMPLEMENTING >= SPECIFIED)" "got: $output"
+fi
+
+# ── Test 19: SPECIFYING predecessor does NOT satisfy need-SPECIFIED ─────────
+
+echo ""
+echo "── Test 19: SPECIFYING predecessor does NOT satisfy need-SPECIFIED dep"
+
+sed -i 's/^status: IMPLEMENTING$/status: SPECIFYING/' .work/state-rank-test/WD-01.md
+
+output="$(bash .claude/scripts/work-resolve.sh state-rank-test 2>&1)"
+if echo "$output" | grep "WD-02" | grep -q "BLOCKED"; then
+    pass "SPECIFYING predecessor does not satisfy need-SPECIFIED (below required rank)"
+else
+    fail "WD-02 should be BLOCKED (WD-01 SPECIFYING < SPECIFIED)" "got: $output"
+fi
+
+# ── Test 20: COMPLETE predecessor satisfies need-SPECIFIED (DRAFT branch) ───
+
+echo ""
+echo "── Test 20: COMPLETE predecessor satisfies need-SPECIFIED dep (DRAFT branch)"
+
+sed -i 's/^status: SPECIFYING$/status: COMPLETE/' .work/state-rank-test/WD-01.md
+
+# DRAFT dependent that needs WD-01 SPECIFIED
+cat > .work/state-rank-test/WD-03.md << 'EOF'
+---
+id: WD-03
+title: Draft needs WD-01 SPECIFIED
+group: state-rank-test
+status: DRAFT
+domains: [auth]
+artifact_deps:
+  - { type: wd, ref: "WD-01", required_state: SPECIFIED }
+produces: []
+---
+
+## Summary
+DRAFT WD that wants WD-01 SPECIFIED to plan against.
+
+## Acceptance Criteria
+Test.
+EOF
+
+output="$(bash .claude/scripts/work-resolve.sh state-rank-test 2>&1)"
+if echo "$output" | grep "WD-03" | grep -q "READY" && \
+   ! echo "$output" | grep "WD-03" | grep -q "BLOCKED"; then
+    pass "DRAFT WD with COMPLETE predecessor is READY (need-SPECIFIED satisfied)"
+else
+    fail "WD-03 should be READY (WD-01 COMPLETE >= SPECIFIED)" "got: $output"
+fi
+
+# ── Test 21: IN_PROGRESS legacy alias satisfies need-SPECIFIED ──────────────
+
+echo ""
+echo "── Test 21: IN_PROGRESS legacy alias satisfies need-SPECIFIED"
+
+sed -i 's/^status: COMPLETE$/status: IN_PROGRESS/' .work/state-rank-test/WD-01.md
+
+output="$(bash .claude/scripts/work-resolve.sh state-rank-test 2>&1)"
+if echo "$output" | grep "WD-02" | grep -q "SPECIFIED" && \
+   ! echo "$output" | grep "WD-02" | grep -q "BLOCKED"; then
+    pass "IN_PROGRESS (legacy IMPLEMENTING alias) satisfies need-SPECIFIED"
+else
+    fail "WD-02 should be SPECIFIED (WD-01 IN_PROGRESS == IMPLEMENTING >= SPECIFIED)" "got: $output"
+fi
+
+# ── Cleanup state-rank-test group ───────────────────────────────────────────
+rm -rf .work/state-rank-test
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **`/spec-backfill <spec-id> | --all`** — new skill that walks every requirement of an APPROVED spec lacking `@spec` annotations in code, presents likely enforcement sites ranked by subject-token overlap, and applies user-chosen annotations. The catch-up tool for mature corpora authored before v0.16.5 forward-enforcement existed (e.g. jlsm: 75 specs / 12 domains).
- **`spec-trace.sh --uncovered`** — emits a parseable list of R-ids defined in a spec but absent from `@spec` annotations in code. Backing primitive for `/spec-backfill` and `/curate` annotation-drift.
- **`/curate` annotation-drift subsection** — surfaces APPROVED specs whose coverage has slipped below 50% (with at least one annotation, so distinct from the unannotated bucket). Routes to `/spec-backfill <id>` per-spec or `/spec-backfill --all` when 4+ specs have drifted.
- **`work-resolve.sh` WD dep state match — monotonic, not strict equality** — `wd:` deps now satisfy at-or-past on the lifecycle (DRAFT < SPECIFYING < SPECIFIED < IMPLEMENTING < COMPLETE), so a `required_state: SPECIFIED` dep is satisfied when the predecessor has reached COMPLETE. Fixes a jlsm-surfaced `/work-plan` block where COMPLETE/SPECIFIED predecessors flagged dependents as blocked despite being functionally satisfied.

## Test plan

- [x] `tests/scenario-work-resolve.sh` — 21/21 pass; 5 new regression cases (17-21) cover monotonic match on both SPECIFIED and DRAFT branches, IN_PROGRESS legacy alias, and SPECIFYING (below required) negative case.
- [x] `tests/scenario-spec-trace.sh` — 22/22 pass; 7 new cases for `--uncovered` (single uncovered, fully uncovered, domain.slug resolution, suffixed/sub-numbered R-ids, stderr summary, missing-manifest error).
- [x] `tests/scenario-spec-backfill.sh` — 18/18 pass; covers candidate ranking + score sort + min-score filter + log lifecycle (init/append/has-decision/list-decisions/report) + idempotence + supersede semantics + status validation + pipe sanitization + dual-schema (v1/v2) APPROVED enumeration.
- [x] `tests/scenario-curate-scan.sh` — 65/65 pass; 4 new cases for annotation-drift (4/5 uncov surfaces, drift-vs-UNANNOTATED separation, /spec-backfill routing, fully-covered exclusion).
- [x] `tests/scenario-spec-coverage.sh` — 14/14 pass after fixture fix (added `cp spec-lib.sh` alongside `spec-trace.sh`, matching every other scenario-spec-* test).
- [x] `tests/test-install.sh` — 64/64 pass; full install regression suite green.
- [x] Full sweep `tests/scenario-*.sh` — 50/51 scenarios pass. The single fail (`scenario-pipefail-sigpipe.sh` Check 11) is a pre-existing baseline failure on `main` and is not introduced by this PR (verified by running the same test on `main` HEAD).
- [x] Pre-PR MANIFEST↔source bidirectional check — clean (0 missing, 0 extra). Fresh `bash install.sh` to a tmp dir installs all three new files (`skills/spec-backfill/SKILL.md`, `scripts/spec-backfill-candidates.sh`, `scripts/spec-backfill-log.sh`).

## Notes

- Spec/ADR dep checks intentionally keep exact-match: specs have INVALIDATED and ADRs have superseded/deprecated as terminal-replaced states that must NOT silently satisfy a need-APPROVED/accepted dep. The state-rank fix is wd-only.
- `/curate` step 2m's "no annotations at all" routing was retargeted from `/spec-verify` to `/spec-backfill`. `/spec-verify` is preserved as the alternative when the gap may indicate true spec→code divergence rather than pure backfill.
- The candidate-finder uses case-insensitive substring matching (with simple plural→singular normalization) rather than word-boundary regex. Word boundaries miss prose tokens fragmented inside CamelCase identifiers (e.g. `Expiry` cannot word-boundary-match `validateExpiry`); MIN_SCORE filtering prunes the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)