### PR TITLE
test(pipefail-sigpipe): match evolved R-id pattern in Check 11

### DIFF
--- a/tests/scenario-pipefail-sigpipe.sh
+++ b/tests/scenario-pipefail-sigpipe.sh
@@ -89,9 +89,9 @@ check_site "$REPO_ROOT/scripts/spec-validate.sh" \
     'echo "$spec_body" | grep -qE '"'"'\[CONFLICT\]'"'"
 
 check_site "$REPO_ROOT/scripts/spec-validate.sh" \
-    "spec-validate Check 11 uses <<< for ^R[0-9]+." \
-    'grep -qE '"'"'^R[0-9]+\.'"'"' <<< "$machine"' \
-    'echo "$machine" | grep -qE '"'"'^R[0-9]+\.'"'"
+    "spec-validate Check 11 uses <<< for ^R[0-9]+ requirements" \
+    'grep -qE '"'"'^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\.'"'"' <<< "$machine"' \
+    'echo "$machine" | grep -qE '"'"'^R[0-9]+'"'"
 
 # kb-search.sh — content_lower (KB index content) is unbounded for big indexes
 check_site "$REPO_ROOT/scripts/kb-search.sh" \


### PR DESCRIPTION
## Summary

- `scenario-pipefail-sigpipe.sh` Check 11 asserts the substring `'^R[0-9]+\.'` but `spec-validate.sh:243` evolved to `'^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\.'` (added letter-suffixed and sub-numbered R-ids for layered specs). The SIGPIPE-safe `<<<` form is already in place — only the test's substring check was stale.
- Fix: update the required substring to match the current grammar and loosen the forbidden substring so the assertion catches future regressions to the pipe form regardless of which R-id pattern lands.

## Why now

Pre-existing baseline failure on main (predates v0.16.7) — surfaced during v0.16.7 pre-PR validation. Fixing per fix-now-not-defer; bugs and failed tests are things to fix immediately.

## Test plan

- [x] `bash tests/scenario-pipefail-sigpipe.sh` — 10/10 pass
- [x] Full scenario sweep — 51/51 pass (was 50/51 with this single failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)