### PR TITLE
fix(work): automate .work/CLAUDE.md updates so /feature-complete stops asking for hand-edits

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -135,6 +135,7 @@
 .claude/scripts/work-validate.sh
 .claude/scripts/work-context.sh
 .claude/scripts/work-finalize.sh
+.claude/scripts/work-index.sh
 .claude/scripts/narrative-wrapper.sh
 .claude/scripts/narrative/model.py
 .claude/scripts/narrative/tokenizer.py

--- a/install.sh
+++ b/install.sh
@@ -309,6 +309,7 @@ install_file "$SCRIPT_DIR/scripts/work-resolve.sh" "$TARGET/.claude/scripts/work
 install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/work-validate.sh"
 install_file "$SCRIPT_DIR/scripts/work-context.sh" "$TARGET/.claude/scripts/work-context.sh"
 install_file "$SCRIPT_DIR/scripts/work-finalize.sh" "$TARGET/.claude/scripts/work-finalize.sh"
+install_file "$SCRIPT_DIR/scripts/work-index.sh" "$TARGET/.claude/scripts/work-index.sh"
 install_file "$SCRIPT_DIR/scripts/narrative-wrapper.sh" "$TARGET/.claude/scripts/narrative-wrapper.sh"
 chmod +x "$TARGET/.claude/scripts/narrative-wrapper.sh" 2>/dev/null || true
 mkdir -p "$TARGET/.claude/scripts/narrative"
@@ -340,6 +341,7 @@ chmod +x "$TARGET/.claude/scripts/work-resolve.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-finalize.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/work-index.sh" 2>/dev/null || true
 
 # ── Merge driver for index files ──────────────────────────────────────────────
 
@@ -426,7 +428,8 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
-      "Bash(bash .claude/scripts/work-finalize.sh:*)"
+      "Bash(bash .claude/scripts/work-finalize.sh:*)",
+      "Bash(bash .claude/scripts/work-index.sh:*)"
     ]
   },
   "hooks": {
@@ -541,7 +544,8 @@ HOOKJSON
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
-      "Bash(bash .claude/scripts/work-finalize.sh:*)"
+      "Bash(bash .claude/scripts/work-finalize.sh:*)",
+      "Bash(bash .claude/scripts/work-index.sh:*)"
         ] | unique)' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
         echo -e "  ${GREEN}merge${NC} Script permissions added to settings.json"
     elif [[ -f "$SETTINGS_FILE" ]]; then

--- a/scripts/work-index.sh
+++ b/scripts/work-index.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# work-index.sh — maintain the .work/CLAUDE.md Active Work Groups table.
+#
+# The Active Work Groups table at the corpus root is a per-group rollup
+# of WD counts. Prior to this script, every skill that changed group
+# state (group creation, decomposition, feature completion) hand-edited
+# the row via Edit. That pattern was fragile (any drift in column shape
+# broke the table) and stale (the SKILL doc falsely claimed work-resolve
+# auto-synced it; nothing did). This script is the authoritative writer.
+#
+# Subcommands:
+#   add <group-slug> <goal>
+#       Append a new row for a freshly-created group. Idempotent — if
+#       a row already exists for the slug, fall through to update.
+#       Also adds a "Recently Added" log row.
+#
+#   update <group-slug>
+#       Recompute the row for one group from the actual WD files in
+#       `.work/<slug>/`. Counts:
+#         WDs       = number of WD-*.md files
+#         Ready     = WDs whose status is READY
+#         Complete  = WDs whose status is COMPLETE
+#       Sets Last Updated to today's date.
+#
+#   update-all
+#       Recompute every row in the Active Work Groups table from the
+#       filesystem. Use after a bulk operation or to repair drift.
+#
+#   remove <group-slug>
+#       Drop the row for a group (e.g. fully archived).
+#
+# Output: edits .work/CLAUDE.md in place; emits a one-line diagnostic
+# on stderr per write so callers can confirm the change happened.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=work-lib.sh disable=SC1091
+source "$SCRIPT_DIR/work-lib.sh"
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  work-index.sh add    <group-slug> <goal>
+  work-index.sh update <group-slug>
+  work-index.sh update-all
+  work-index.sh remove <group-slug>
+EOF
+  exit 2
+}
+
+# Locate .work/ root and the index file. Walk up from CWD.
+_find_work_index() {
+  local dir="$PWD"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/.work/CLAUDE.md" ]]; then
+      echo "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  echo "ERROR: .work/CLAUDE.md not found (run /work to bootstrap)" >&2
+  return 1
+}
+
+# Compute Total / Ready / Complete for a group by reading WD files
+# directly. Status is the WD's own declared status; READY for the index
+# is the literal status-rank READY (DRAFT WDs whose deps are met would
+# resolve to READY at runtime via work-resolve.sh, but the index only
+# reflects authored status — work-resolve is the dynamic readiness view).
+_count_group() {
+  local group_dir="$1"
+  local total=0 ready=0 complete=0 wd_status
+  while IFS= read -r wd_file; do
+    [[ -z "$wd_file" ]] && continue
+    total=$((total + 1))
+    wd_status="$(work_fm "$wd_file" "status")"
+    case "$wd_status" in
+      READY)    ready=$((ready + 1)) ;;
+      COMPLETE) complete=$((complete + 1)) ;;
+    esac
+  done < <(work_list_wds "$group_dir")
+  echo "$total|$ready|$complete"
+}
+
+# Atomic in-place edit: write to .tmp then rename. Prevents readers
+# from seeing a half-written table.
+_atomic_replace() {
+  local target="$1" tmp="$2"
+  mv "$tmp" "$target"
+}
+
+# Strip surrounding pipes/whitespace from a Markdown table cell.
+_trim() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  echo "$v"
+}
+
+cmd_update() {
+  local slug="${1:-}"
+  [[ -z "$slug" ]] && { echo "ERROR: update requires <group-slug>" >&2; exit 2; }
+
+  local root index group_dir
+  root="$(_find_work_index)" || exit 1
+  index="$root/.work/CLAUDE.md"
+  group_dir="$root/.work/$slug"
+
+  if [[ ! -d "$group_dir" ]]; then
+    echo "ERROR: group not found: $group_dir" >&2
+    exit 1
+  fi
+
+  local counts total ready complete today
+  counts="$(_count_group "$group_dir")"
+  IFS='|' read -r total ready complete <<<"$counts"
+  today="$(date +%F)"
+
+  # Match rows by literal prefix `| <slug> |`. Pipe is `\|` in grep ERE
+  # but plain `|` is alternation in awk regex, so we use awk's index()
+  # for literal substring match below.
+  local row_prefix="| $slug |"
+  if ! grep -qF "$row_prefix" "$index"; then
+    echo "[work-index] update: no row for '$slug' — use 'add' first" >&2
+    exit 1
+  fi
+
+  # Read the existing row's Path and Goal so update preserves them.
+  local existing
+  existing="$(grep -F "$row_prefix" "$index" | head -1)"
+  IFS='|' read -r _ _ path goal _ _ _ _ <<<"$existing"
+  path="$(_trim "$path")"
+  goal="$(_trim "$goal")"
+
+  local new_row
+  new_row="| $slug | $path | $goal | $total | $ready | $complete | $today |"
+
+  local tmp
+  tmp="$(mktemp)"
+  awk -v prefix="$row_prefix" -v new_row="$new_row" '
+    index($0, prefix) == 1 { print new_row; next }
+    { print }
+  ' "$index" > "$tmp"
+  _atomic_replace "$index" "$tmp"
+  echo "[work-index] update: $slug → $total WDs / $ready ready / $complete complete" >&2
+}
+
+cmd_add() {
+  local slug="${1:-}" goal="${2:-}"
+  [[ -z "$slug" || -z "$goal" ]] && {
+    echo "ERROR: add requires <group-slug> <goal>" >&2; exit 2
+  }
+
+  local root index
+  root="$(_find_work_index)" || exit 1
+  index="$root/.work/CLAUDE.md"
+
+  # Sanitize pipe characters in goal so they cannot split the table column.
+  local safe_goal
+  safe_goal="$(echo "$goal" | tr '|' '/')"
+
+  local row_prefix="| $slug |"
+  if grep -qF "$row_prefix" "$index"; then
+    echo "[work-index] add: row exists for '$slug' — running update instead" >&2
+    cmd_update "$slug"
+    return 0
+  fi
+
+  local today
+  today="$(date +%F)"
+  local new_row="| $slug | .work/$slug/ | $safe_goal | 0 | 0 | 0 | $today |"
+
+  # Insert immediately after the table header separator (`|---|...|`)
+  # so new rows append to the top of the row list. We rely on awk's
+  # match() against a leading `|---` substring rather than a regex
+  # involving `|`, since `|` is alternation in awk regex.
+  local tmp
+  tmp="$(mktemp)"
+  awk -v active_new_row="$new_row" '
+    BEGIN { phase = "" }
+    /^## Active Work Groups *$/ { phase = "active"; print; next }
+    /^## Recently Added/        { phase = "recent"; print; next }
+    phase == "active" && substr($0, 1, 4) == "|---" {
+      print
+      print active_new_row
+      phase = ""
+      next
+    }
+    { print }
+  ' "$index" > "$tmp"
+  _atomic_replace "$index" "$tmp"
+
+  # Append a "Recently Added" log row below the corresponding header.
+  local recent_row="| $today | $slug | — | — | active |"
+  local tmp2
+  tmp2="$(mktemp)"
+  awk -v recent_new_row="$recent_row" '
+    BEGIN { phase = "" }
+    /^## Recently Added/ { phase = "recent"; print; next }
+    /^## /               { phase = ""; print; next }
+    phase == "recent" && substr($0, 1, 4) == "|---" {
+      print
+      print recent_new_row
+      phase = ""
+      next
+    }
+    { print }
+  ' "$index" > "$tmp2"
+  _atomic_replace "$index" "$tmp2"
+  echo "[work-index] add: appended '$slug' to Active Work Groups" >&2
+}
+
+cmd_remove() {
+  local slug="${1:-}"
+  [[ -z "$slug" ]] && { echo "ERROR: remove requires <group-slug>" >&2; exit 2; }
+
+  local root index
+  root="$(_find_work_index)" || exit 1
+  index="$root/.work/CLAUDE.md"
+
+  local row_prefix="| $slug |"
+  if ! grep -qF "$row_prefix" "$index"; then
+    echo "[work-index] remove: no row for '$slug' — no-op" >&2
+    return 0
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  grep -vF "$row_prefix" "$index" > "$tmp"
+  _atomic_replace "$index" "$tmp"
+  echo "[work-index] remove: dropped '$slug'" >&2
+}
+
+cmd_update_all() {
+  local root index
+  root="$(_find_work_index)" || exit 1
+  index="$root/.work/CLAUDE.md"
+
+  # Iterate every group directory under .work/ that has a manifest.md
+  # or any WD file. Skip _archive and other reserved directories.
+  while IFS= read -r group_dir; do
+    [[ -z "$group_dir" ]] && continue
+    local slug
+    slug="$(basename "$group_dir")"
+    cmd_update "$slug" || true
+  done < <(find "$root/.work" -mindepth 1 -maxdepth 1 -type d \
+             ! -name '_archive' ! -name '_refs' 2>/dev/null | sort)
+}
+
+CMD="${1:-}"
+shift || true
+case "$CMD" in
+  add)        cmd_add "$@" ;;
+  update)     cmd_update "$@" ;;
+  update-all) cmd_update_all "$@" ;;
+  remove)     cmd_remove "$@" ;;
+  ""|-h|--help) usage ;;
+  *) echo "ERROR: unknown subcommand '$CMD'" >&2; usage ;;
+esac

--- a/skills/decisions/SKILL.md
+++ b/skills/decisions/SKILL.md
@@ -755,7 +755,15 @@ Write `.work/<group-slug>/manifest.md` using the same format as
 `/work-decompose` Step 6 (populate the Work Definitions table and
 Dependency Graph from the WD files).
 
-Update `.work/CLAUDE.md` — add a row to the Active Work Groups table.
+Add the group to `.work/CLAUDE.md` via the index helper, then refresh
+counts so the row reflects the WDs just created:
+
+```bash
+bash .claude/scripts/work-index.sh add "<group-slug>" "<roadmap goal>"
+bash .claude/scripts/work-index.sh update "<group-slug>"
+```
+
+Do not hand-edit the table.
 
 #### 9e — Present result
 

--- a/skills/feature-complete/SKILL.md
+++ b/skills/feature-complete/SKILL.md
@@ -105,13 +105,19 @@ status.md and does not match the `<group>--<wd>` double-dash convention.**
 
 If this is a work-group-sourced feature:
 
-1. Determine the work group slug (from status.md `work_group` field or slug prefix)
+1. Determine the work group slug (from status.md `work_group` field or slug prefix).
 2. Verify the WD frontmatter has `status: COMPLETE` (should already be set
    by feature-refactor Step 6b). If not COMPLETE, set it now as a fallback.
-3. Update `.work/CLAUDE.md` — increment the Complete count for this group
+3. Refresh `.work/CLAUDE.md` Active Work Groups counts via the index
+   helper — recomputes `WDs / Ready / Complete` and bumps Last Updated:
 
-The manifest table is automatically synced by `work-resolve.sh` — do not
-update it manually.
+   ```bash
+   bash .claude/scripts/work-index.sh update "<group-slug>"
+   ```
+
+   Do not edit `.work/CLAUDE.md` by hand. The script reads each WD's
+   frontmatter `status:` and re-derives the row counts; hand-edits drift
+   from filesystem state and miss the date stamp.
 
 ---
 

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -582,7 +582,14 @@ Write the text dependency graph from Step 3.
 
 ### Update .work/CLAUDE.md
 
-Update the Active Work Groups row for this group: set WDs count to the total.
+Refresh the Active Work Groups row — the index helper recomputes
+`WDs / Ready / Complete` from the filesystem and bumps Last Updated:
+
+```bash
+bash .claude/scripts/work-index.sh update "<group-slug>"
+```
+
+Do not hand-edit the WDs count or any column in `.work/CLAUDE.md`.
 
 ### Run invariant check
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -214,17 +214,18 @@ Write `.work/<group-slug>/manifest.md`:
 
 ### 4c — Update .work/CLAUDE.md index
 
-Add a row to the "Active Work Groups" table:
+Append rows to both the "Active Work Groups" table and the
+"Recently Added" log via the index helper:
 
-```
-| <group-slug> | .work/<group-slug>/ | <goal> | 0 | 0 | 0 | <YYYY-MM-DD> |
+```bash
+bash .claude/scripts/work-index.sh add "<group-slug>" "<goal>"
 ```
 
-Add a row to the "Recently Added" table:
-
-```
-| <YYYY-MM-DD> | <group-slug> | — | — | active |
-```
+The script writes both rows atomically and is idempotent — if a row
+already exists for the slug it falls through to a count refresh
+instead of duplicating. Do not edit `.work/CLAUDE.md` by hand here;
+column-shape drift between hand-edits and other call sites breaks the
+table for `/work-status` and the index helper alike.
 
 ---
 

--- a/tests/scenario-work-index.sh
+++ b/tests/scenario-work-index.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Scenario: work-index.sh maintains .work/CLAUDE.md Active Work Groups
+# table without hand-edits.
+#
+# Tests:
+# 1. add appends a new row to Active Work Groups + Recently Added log
+# 2. add is idempotent — second add for same slug falls through to update
+# 3. update recomputes WDs / Ready / Complete from WD frontmatter
+# 4. update preserves the existing Path and Goal columns
+# 5. update bumps Last Updated to today
+# 6. update-all iterates every group directory under .work/
+# 7. remove drops the row from Active Work Groups
+# 8. update on an unknown slug fails with a clear error
+# 9. add rejects pipe characters in goal so the table cannot be split
+# 10. update reflects status changes (READY → COMPLETE)
+#
+# Run from repo root: bash tests/scenario-work-index.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-work-index"
+INDEX_SCRIPT="$REPO_ROOT/scripts/work-index.sh"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+cleanup() { rm -rf "$TEST_BASE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: work-index Active Work Groups maintenance"
+echo "────────────────────────────────────────────────"
+
+cleanup
+mkdir -p "$TEST_BASE/project/.work/auth-migration" \
+         "$TEST_BASE/project/.work/billing-overhaul" \
+         "$TEST_BASE/project/.claude/scripts"
+
+cp "$REPO_ROOT/scripts/work-index.sh" "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/scripts/work-lib.sh"   "$TEST_BASE/project/.claude/scripts/"
+cp "$REPO_ROOT/work/CLAUDE.md"        "$TEST_BASE/project/.work/CLAUDE.md"
+
+cd "$TEST_BASE/project"
+
+# Two WD fixtures to drive the count math.
+cat > .work/auth-migration/WD-01.md << 'EOF'
+---
+id: WD-01
+title: JWT library
+group: auth-migration
+status: COMPLETE
+domains: [auth]
+---
+EOF
+cat > .work/auth-migration/WD-02.md << 'EOF'
+---
+id: WD-02
+title: Auth middleware
+group: auth-migration
+status: READY
+domains: [auth]
+---
+EOF
+cat > .work/billing-overhaul/WD-01.md << 'EOF'
+---
+id: WD-01
+title: Charge processor
+group: billing-overhaul
+status: DRAFT
+domains: [billing]
+---
+EOF
+
+# ── Test 1: add appends Active Work Groups + Recently Added rows ────────────
+
+echo ""
+echo "── Test 1: add appends Active Work Groups + Recently Added rows"
+
+bash "$INDEX_SCRIPT" add auth-migration "Replace session auth with JWT" >/dev/null 2>&1
+if grep -qF "| auth-migration | .work/auth-migration/ | Replace session auth with JWT |" .work/CLAUDE.md; then
+    pass "Active Work Groups row appended for auth-migration"
+else
+    fail "Active Work Groups row missing" "got: $(grep auth-migration .work/CLAUDE.md)"
+fi
+if grep -qE '^\| 20[0-9]{2}-[0-9]{2}-[0-9]{2} \| auth-migration \| — \| — \| active \|' .work/CLAUDE.md; then
+    pass "Recently Added log row appended"
+else
+    fail "Recently Added log row missing" "got: $(grep -A 5 'Recently Added' .work/CLAUDE.md)"
+fi
+
+# ── Test 2: add is idempotent on same slug ─────────────────────────────────
+
+echo ""
+echo "── Test 2: add is idempotent (second add falls through to update)"
+
+bash "$INDEX_SCRIPT" add auth-migration "different goal" >/dev/null 2>&1
+row_count=$(grep -cF "| auth-migration |" .work/CLAUDE.md)
+if [[ "$row_count" -eq 2 ]]; then
+    # 1 in Active Work Groups + 1 in Recently Added (the latter is a log
+    # — even idempotent add re-falls to update, no extra log row should
+    # appear)
+    pass "second add for same slug does not duplicate Active Work Groups row"
+else
+    fail "expected 2 rows mentioning auth-migration (active + recent), got $row_count" \
+         "$(grep -nF '| auth-migration |' .work/CLAUDE.md)"
+fi
+
+# ── Test 3: update recomputes WDs / Ready / Complete ───────────────────────
+
+echo ""
+echo "── Test 3: update recomputes WDs / Ready / Complete"
+
+bash "$INDEX_SCRIPT" update auth-migration >/dev/null 2>&1
+# auth-migration has 2 WDs: 1 COMPLETE, 1 READY. Expect 2 / 1 / 1.
+if grep -qE '^\| auth-migration \| .work/auth-migration/ \| .* \| 2 \| 1 \| 1 \|' .work/CLAUDE.md; then
+    pass "counts recomputed to 2 WDs / 1 ready / 1 complete"
+else
+    fail "expected counts 2/1/1 for auth-migration" "got: $(grep -F '| auth-migration |' .work/CLAUDE.md | head -1)"
+fi
+
+# ── Test 4: update preserves existing Path and Goal columns ────────────────
+
+echo ""
+echo "── Test 4: update preserves Path and Goal"
+
+if grep -qF "| auth-migration | .work/auth-migration/ | Replace session auth with JWT |" .work/CLAUDE.md; then
+    pass "Path and Goal preserved across update"
+else
+    fail "Path or Goal got rewritten" "got: $(grep -F '| auth-migration |' .work/CLAUDE.md | head -1)"
+fi
+
+# ── Test 5: update bumps Last Updated to today ─────────────────────────────
+
+echo ""
+echo "── Test 5: update bumps Last Updated to today"
+
+today=$(date +%F)
+if grep -qE "^\| auth-migration \|.* \| $today \|" .work/CLAUDE.md; then
+    pass "Last Updated bumped to today ($today)"
+else
+    fail "Last Updated not bumped to $today" "got: $(grep -F '| auth-migration |' .work/CLAUDE.md | head -1)"
+fi
+
+# ── Test 6: update-all iterates every group ────────────────────────────────
+
+echo ""
+echo "── Test 6: update-all iterates every group directory"
+
+# Add billing-overhaul first so update-all has a row to refresh.
+bash "$INDEX_SCRIPT" add billing-overhaul "Modernize charge handling" >/dev/null 2>&1
+bash "$INDEX_SCRIPT" update-all >/dev/null 2>&1
+# billing-overhaul has 1 DRAFT WD: 1 / 0 / 0
+if grep -qE '^\| billing-overhaul \| .work/billing-overhaul/ \| .* \| 1 \| 0 \| 0 \|' .work/CLAUDE.md; then
+    pass "update-all refreshed billing-overhaul to 1/0/0"
+else
+    fail "billing-overhaul not refreshed by update-all" "got: $(grep -F '| billing-overhaul |' .work/CLAUDE.md | head -1)"
+fi
+
+# ── Test 7: remove drops the row ───────────────────────────────────────────
+
+echo ""
+echo "── Test 7: remove drops the Active Work Groups row"
+
+bash "$INDEX_SCRIPT" remove billing-overhaul >/dev/null 2>&1
+if ! grep -qF "| billing-overhaul | .work/billing-overhaul/" .work/CLAUDE.md; then
+    pass "Active Work Groups row dropped for billing-overhaul"
+else
+    fail "row not removed" "got: $(grep -F billing-overhaul .work/CLAUDE.md)"
+fi
+
+# ── Test 8: update on unknown slug fails with clear error ──────────────────
+
+echo ""
+echo "── Test 8: update on unknown slug fails with clear error"
+
+set +e
+out=$(bash "$INDEX_SCRIPT" update never-existed 2>&1)
+rc=$?
+set -e
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q "group not found"; then
+    pass "update on unknown slug returns nonzero with clear error"
+else
+    fail "update on unknown slug should error" "rc=$rc out: $out"
+fi
+
+# ── Test 9: pipe characters in goal sanitized ──────────────────────────────
+
+echo ""
+echo "── Test 9: pipe characters in goal are sanitized"
+
+mkdir -p .work/piped
+cat > .work/piped/WD-01.md << 'EOF'
+---
+id: WD-01
+title: Piped
+group: piped
+status: DRAFT
+---
+EOF
+bash "$INDEX_SCRIPT" add piped "goal|with|pipes" >/dev/null 2>&1
+# Pipes should be replaced with slashes (preserves table column structure)
+if grep -qF "| piped | .work/piped/ | goal/with/pipes |" .work/CLAUDE.md; then
+    pass "pipes replaced with slashes (table integrity preserved)"
+else
+    fail "pipes not sanitized" "got: $(grep -F '| piped |' .work/CLAUDE.md | head -1)"
+fi
+
+# ── Test 10: update reflects status change (READY → COMPLETE) ──────────────
+
+echo ""
+echo "── Test 10: update reflects status changes on existing WDs"
+
+# Flip WD-02 from READY to COMPLETE — auth-migration becomes 2/0/2
+sed -i 's/^status: READY$/status: COMPLETE/' .work/auth-migration/WD-02.md
+bash "$INDEX_SCRIPT" update auth-migration >/dev/null 2>&1
+if grep -qE '^\| auth-migration \|.* \| 2 \| 0 \| 2 \|' .work/CLAUDE.md; then
+    pass "update picked up READY → COMPLETE transition"
+else
+    fail "update didn't reflect status change" "got: $(grep -F '| auth-migration |' .work/CLAUDE.md | head -1)"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+exit $failed


### PR DESCRIPTION
## Summary

`/feature-complete` (and three other skills) was asking Claude to hand-edit `.work/CLAUDE.md` Active Work Groups rows via Edit. The doc even falsely claimed `work-resolve.sh` auto-synced the table — it never did. Hand-edits drift across call sites and miss the Last Updated stamp. This PR adds `scripts/work-index.sh` as the authoritative writer and routes all four call sites through it.

## What changed

- **New: `scripts/work-index.sh`** with `add | update | update-all | remove` subcommands. Counts derived from each WD's frontmatter `status:`. Atomic writes; pipe sanitization in goal text; idempotent add.
- **`/feature-complete` Step 2b** — replaces the hand-edit with `bash .claude/scripts/work-index.sh update "<group-slug>"`. Removes the misleading "automatically synced by work-resolve.sh" line.
- **`/work` Step 4c**, **`/work-decompose` Step 6**, **`/decisions` Step 9d** — all routed through `add` / `update`.
- **MANIFEST + install.sh** — register the new script, chmod +x, allowlist the bash entry in both user and project permission blocks.

## Test plan

- [x] `tests/scenario-work-index.sh` — 11/11 pass (add, idempotent add, update math, Path/Goal preservation, Last Updated bump, update-all, remove, error on unknown slug, pipe sanitization, status transitions)
- [x] Full sweep `tests/scenario-*.sh` — 52/52 (51 prior + new scenario-work-index)
- [x] `tests/test-install.sh` — 64/64
- [x] MANIFEST↔source bidirectional check — clean
- [x] Fresh `bash install.sh` to a tmp dir installs `work-index.sh` and produces valid JSON in `settings.json`

## Implementation note

Row matching uses awk's `index()` for literal substring rather than regex — `|` is alternation in awk regex and `\|` is not the literal escape. An early prototype matched every line and corrupted the table; switched to `index()` after smoke test caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)