### PR TITLE
fix(work): bundle .work/CLAUDE.md update into feature PR via work-finalize

### DIFF
--- a/scripts/work-finalize.sh
+++ b/scripts/work-finalize.sh
@@ -84,6 +84,19 @@ else
     echo "[finalize] WD file not found for $WORK_DEF in $WORK_DIR" >&2
 fi
 
+# ── 1b. Refresh .work/CLAUDE.md Active Work Groups counts ──────────────────
+# Bundles the index update into the feature commit (and therefore the
+# feature PR), so /feature-complete post-merge has nothing tracked to write.
+# Without this step, /feature-complete's Step 2b would leave a dirty
+# .work/CLAUDE.md after the PR was already merged, requiring a separate
+# follow-up commit + push for derived state.
+if [[ -x "$_WF_SCRIPT_DIR/work-index.sh" ]]; then
+    bash "$_WF_SCRIPT_DIR/work-index.sh" update "$WORK_GROUP" || \
+        echo "[finalize] work-index update failed — counts may be stale" >&2
+else
+    echo "[finalize] work-index.sh not found — counts not refreshed" >&2
+fi
+
 # ── 2. Resolve obligations ────────────────────────────────────────────────
 
 OB_REGISTRY=".spec/registry/_obligations.json"

--- a/scripts/work-index.sh
+++ b/scripts/work-index.sh
@@ -112,10 +112,9 @@ cmd_update() {
     exit 1
   fi
 
-  local counts total ready complete today
+  local counts total ready complete
   counts="$(_count_group "$group_dir")"
   IFS='|' read -r total ready complete <<<"$counts"
-  today="$(date +%F)"
 
   # Match rows by literal prefix `| <slug> |`. Pipe is `\|` in grep ERE
   # but plain `|` is alternation in awk regex, so we use awk's index()
@@ -126,15 +125,39 @@ cmd_update() {
     exit 1
   fi
 
-  # Read the existing row's Path and Goal so update preserves them.
+  # Read the existing row's Path / Goal / counts / date so we can decide
+  # whether anything actually needs to change. Idempotence matters here:
+  # callers (feature-finalize, feature-complete) re-run update routinely,
+  # and bumping Last Updated on a no-op leaves a spurious tracked change
+  # that downstream skills then have to commit + push separately.
   local existing
   existing="$(grep -F "$row_prefix" "$index" | head -1)"
-  IFS='|' read -r _ _ path goal _ _ _ _ <<<"$existing"
-  path="$(_trim "$path")"
-  goal="$(_trim "$goal")"
+  local ex_path ex_goal ex_total ex_ready ex_complete ex_date
+  IFS='|' read -r _ _ ex_path ex_goal ex_total ex_ready ex_complete ex_date _ <<<"$existing"
+  local path goal date_col
+  path="$(_trim "$ex_path")"
+  goal="$(_trim "$ex_goal")"
+  ex_total="$(_trim "$ex_total")"
+  ex_ready="$(_trim "$ex_ready")"
+  ex_complete="$(_trim "$ex_complete")"
+  ex_date="$(_trim "$ex_date")"
+
+  # Keep the existing Last Updated unless the counts actually moved.
+  # That way "Last Updated" reflects the last meaningful change, not the
+  # last time the script was invoked.
+  if [[ "$ex_total" == "$total" && "$ex_ready" == "$ready" && "$ex_complete" == "$complete" ]]; then
+    date_col="$ex_date"
+  else
+    date_col="$(date +%F)"
+  fi
 
   local new_row
-  new_row="| $slug | $path | $goal | $total | $ready | $complete | $today |"
+  new_row="| $slug | $path | $goal | $total | $ready | $complete | $date_col |"
+
+  if [[ "$existing" == "$new_row" ]]; then
+    echo "[work-index] update: $slug already current ($total/$ready/$complete) — no-op" >&2
+    return 0
+  fi
 
   local tmp
   tmp="$(mktemp)"

--- a/skills/feature-complete/SKILL.md
+++ b/skills/feature-complete/SKILL.md
@@ -107,17 +107,23 @@ If this is a work-group-sourced feature:
 
 1. Determine the work group slug (from status.md `work_group` field or slug prefix).
 2. Verify the WD frontmatter has `status: COMPLETE` (should already be set
-   by feature-refactor Step 6b). If not COMPLETE, set it now as a fallback.
-3. Refresh `.work/CLAUDE.md` Active Work Groups counts via the index
-   helper — recomputes `WDs / Ready / Complete` and bumps Last Updated:
+   by feature-refactor Step 6b's `work-finalize.sh` call). If not, set it
+   now as a fallback.
+3. Defensive resync of `.work/CLAUDE.md` via the index helper:
 
    ```bash
    bash .claude/scripts/work-index.sh update "<group-slug>"
    ```
 
-   Do not edit `.work/CLAUDE.md` by hand. The script reads each WD's
-   frontmatter `status:` and re-derives the row counts; hand-edits drift
-   from filesystem state and miss the date stamp.
+   In the normal pipeline this is a **no-op** — `work-finalize.sh`
+   already updated the index inside the feature PR, and the helper
+   preserves Last Updated when counts haven't changed. The call exists
+   for features that bypassed the standard pipeline (hand-completed,
+   resumed from a partial state, or running on an upgraded install
+   where the prior version didn't yet emit the index update).
+
+   Do not edit `.work/CLAUDE.md` by hand under any circumstances —
+   hand-edits drift from filesystem state and break `/work-status`.
 
 ---
 

--- a/skills/feature-refactor/SKILL.md
+++ b/skills/feature-refactor/SKILL.md
@@ -717,6 +717,10 @@ bash .claude/scripts/work-finalize.sh "<slug>"
 
 The script:
 1. Sets the WD status to COMPLETE
+1b. Refreshes `.work/CLAUDE.md` Active Work Groups counts via
+   `work-index.sh update`. Bundling this here means the index update
+   lands inside the feature PR, so post-merge `/feature-complete`
+   has nothing tracked left to write.
 2. Resolves obligations referenced in brief.md (`_obligations.json`)
 3. Removes resolved IDs from spec `open_obligations` frontmatter
 

--- a/tests/scenario-work-index.sh
+++ b/tests/scenario-work-index.sh
@@ -221,6 +221,40 @@ else
     fail "update didn't reflect status change" "got: $(grep -F '| auth-migration |' .work/CLAUDE.md | head -1)"
 fi
 
+# ── Test 11: update is a true no-op when counts haven't changed ────────────
+# Regression: previously `update` rewrote the row on every invocation
+# (bumping Last Updated to today) even when counts were unchanged. That
+# left dirty .work/CLAUDE.md after /feature-complete in the post-merge
+# window — the feature PR had already updated counts, but a same-day
+# /feature-complete still bumped the timestamp. The fix preserves the
+# existing Last Updated when counts haven't moved so re-runs leave the
+# file byte-identical.
+
+echo ""
+echo "── Test 11: update is a true no-op when counts haven't changed"
+
+# Snapshot the file, then run update again with no WD changes.
+cp .work/CLAUDE.md /tmp/work-claude-before.md
+bash "$INDEX_SCRIPT" update auth-migration >/dev/null 2>&1
+if cmp -s .work/CLAUDE.md /tmp/work-claude-before.md; then
+    pass "second update on unchanged counts wrote zero bytes (file byte-identical)"
+else
+    fail "no-op update mutated the file" \
+         "diff: $(diff /tmp/work-claude-before.md .work/CLAUDE.md | head -5)"
+fi
+
+# Even on a different calendar day: if counts are unchanged, Last
+# Updated stays put. Set the row's date column to a known past value,
+# then call update, then assert the past date is preserved (not bumped).
+sed -i -E 's/^(\| auth-migration .* \| 2 \| 0 \| 2 \|) [0-9]{4}-[0-9]{2}-[0-9]{2} \|/\1 2026-01-01 |/' .work/CLAUDE.md
+bash "$INDEX_SCRIPT" update auth-migration >/dev/null 2>&1
+if grep -qE '^\| auth-migration \|.* \| 2 \| 0 \| 2 \| 2026-01-01 \|' .work/CLAUDE.md; then
+    pass "Last Updated preserved (not bumped) when counts unchanged"
+else
+    fail "Last Updated got bumped on a no-op update" \
+         "got: $(grep -F '| auth-migration |' .work/CLAUDE.md | head -1)"
+fi
+
 # ── Summary ─────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────────────"


### PR DESCRIPTION
## Summary

The previous fix routed `.work/CLAUDE.md` edits through `work-index.sh`, but `/feature-complete` still left a tracked change in the working tree because the index update happened *after* the feature PR had merged. End-to-end fix:

1. **`work-finalize.sh` now calls `work-index.sh update` inline.** It already runs at `/feature-refactor` Step 6b — before `/feature-pr` — so the Active Work Groups row bumps in the same commit that flips the WD status. The index update lands inside the feature PR; post-merge `/feature-complete` has nothing tracked to write.
2. **`work-index.sh update` is now a true no-op when counts are unchanged.** Previously each call rewrote the row with today's date, so re-runs bumped Last Updated even though counts hadn't moved. Now: if `(Total, Ready, Complete)` matches the existing row, the file is not rewritten and Last Updated is preserved.

`/feature-complete` Step 2b's call is preserved as a defensive resync for features that bypassed the standard pipeline; in the normal flow it now writes zero bytes.

## Why now

User flagged that even after PR #71 routed all hand-edits through the script, `/feature-complete` still required a follow-up commit. Bugs and unfinished automation are things to fix immediately.

## Test plan

- [x] `tests/scenario-work-index.sh` — 13/13 pass; 2 new cases (byte-identical re-run, Last Updated preserved across no-op)
- [x] Full scenario sweep — 52/52
- [x] `tests/test-install.sh` — 64/64
- [x] End-to-end smoke: ran `work-finalize.sh` against a fixture with a work group; second invocation produced "already current — no-op" with byte-identical `.work/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)