### PR TITLE
fix(feature-resume): reconcile Spec Authoring substage against manifest

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -136,6 +136,7 @@
 .claude/scripts/work-context.sh
 .claude/scripts/work-finalize.sh
 .claude/scripts/work-index.sh
+.claude/scripts/feature-state-reconcile.sh
 .claude/scripts/narrative-wrapper.sh
 .claude/scripts/narrative/model.py
 .claude/scripts/narrative/tokenizer.py

--- a/install.sh
+++ b/install.sh
@@ -310,6 +310,7 @@ install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/wor
 install_file "$SCRIPT_DIR/scripts/work-context.sh" "$TARGET/.claude/scripts/work-context.sh"
 install_file "$SCRIPT_DIR/scripts/work-finalize.sh" "$TARGET/.claude/scripts/work-finalize.sh"
 install_file "$SCRIPT_DIR/scripts/work-index.sh" "$TARGET/.claude/scripts/work-index.sh"
+install_file "$SCRIPT_DIR/scripts/feature-state-reconcile.sh" "$TARGET/.claude/scripts/feature-state-reconcile.sh"
 install_file "$SCRIPT_DIR/scripts/narrative-wrapper.sh" "$TARGET/.claude/scripts/narrative-wrapper.sh"
 chmod +x "$TARGET/.claude/scripts/narrative-wrapper.sh" 2>/dev/null || true
 mkdir -p "$TARGET/.claude/scripts/narrative"
@@ -342,6 +343,7 @@ chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-finalize.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-index.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/feature-state-reconcile.sh" 2>/dev/null || true
 
 # ── Merge driver for index files ──────────────────────────────────────────────
 
@@ -429,7 +431,8 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
-      "Bash(bash .claude/scripts/work-index.sh:*)"
+      "Bash(bash .claude/scripts/work-index.sh:*)",
+      "Bash(bash .claude/scripts/feature-state-reconcile.sh:*)"
     ]
   },
   "hooks": {
@@ -545,7 +548,8 @@ HOOKJSON
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
-      "Bash(bash .claude/scripts/work-index.sh:*)"
+      "Bash(bash .claude/scripts/work-index.sh:*)",
+      "Bash(bash .claude/scripts/feature-state-reconcile.sh:*)"
         ] | unique)' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
         echo -e "  ${GREEN}merge${NC} Script permissions added to settings.json"
     elif [[ -f "$SETTINGS_FILE" ]]; then

--- a/scripts/feature-state-reconcile.sh
+++ b/scripts/feature-state-reconcile.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# feature-state-reconcile.sh — reconcile a feature's status.md against
+# durable artifacts (specs in manifest, etc.) and surface stage drift
+# that local cache missed.
+#
+# Usage:
+#   feature-state-reconcile.sh <feature-slug> [--read-only]
+#
+# Why this exists:
+#   .feature/<slug>/ is gitignored. When a sibling WD authors a spec
+#   that this WD's `produces:` declares, the spec lands in the manifest
+#   (durable, committed) but this feature's status.md still says
+#   "Spec Authoring pending" — the local cache never observed the
+#   change, since it lives only on whoever ran the spec-authoring
+#   session. Re-entering this feature on a fresh machine or session
+#   then misreads the state and tries to redo work that's already done.
+#
+#   Reconciliation: read the WD's `produces:` list, look up each
+#   produced spec's state in the manifest, and if all are APPROVED,
+#   advance the Spec Authoring row in status.md to `complete`.
+#
+# Scope:
+#   - Spec Authoring substage only. Planning/Testing/Implementation
+#     produce code + tests in git, which is the canonical state — and
+#     status.md drift on those is rarer because they advance within a
+#     single session.
+#   - Only work-group features. Plain features without `work_group`
+#     have no cross-session artifact production to reconcile against.
+#
+# Output (stdout): one human-readable summary line per check.
+# Exit code: 0 always (drift is informational, not an error).
+
+set -euo pipefail
+
+_FSR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=spec-lib.sh disable=SC1091
+source "$_FSR_SCRIPT_DIR/spec-lib.sh"
+# shellcheck source=work-lib.sh disable=SC1091
+source "$_FSR_SCRIPT_DIR/work-lib.sh"
+
+SLUG="${1:-}"
+READ_ONLY=false
+shift || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --read-only) READ_ONLY=true ;;
+    *) echo "ERROR: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+[[ -z "$SLUG" ]] && {
+  echo "Usage: feature-state-reconcile.sh <feature-slug> [--read-only]" >&2
+  exit 2
+}
+
+# ── Locate feature dir ──────────────────────────────────────────────────────
+FEATURE_DIR=""
+if   [[ -d ".feature/$SLUG" ]];          then FEATURE_DIR=".feature/$SLUG"
+elif [[ -d ".feature/_archive/$SLUG" ]]; then FEATURE_DIR=".feature/_archive/$SLUG"
+fi
+
+[[ -z "$FEATURE_DIR" ]] && {
+  echo "no feature directory for '$SLUG' — nothing to reconcile" >&2
+  exit 0
+}
+
+STATUS_FILE="$FEATURE_DIR/status.md"
+[[ ! -f "$STATUS_FILE" ]] && {
+  echo "no status.md for '$SLUG' — nothing to reconcile" >&2
+  exit 0
+}
+
+# ── Detect work group + WD (mirrors work-finalize.sh) ──────────────────────
+WORK_GROUP="$(grep -m1 '^work_group:' "$STATUS_FILE" 2>/dev/null \
+              | sed 's/^work_group:[[:space:]]*//' || true)"
+WORK_DEF="$(grep -m1 '^work_definition:' "$STATUS_FILE" 2>/dev/null \
+            | sed 's/^work_definition:[[:space:]]*//' || true)"
+
+if [[ -z "$WORK_GROUP" && "$SLUG" == *"--"* ]]; then
+  WORK_GROUP="${SLUG%%--*}"
+  wd_suffix="${SLUG##*--}"
+  WORK_DEF="$(echo "$wd_suffix" | tr '[:lower:]' '[:upper:]' | sed 's/-/\-/g')"
+fi
+
+if [[ -z "$WORK_GROUP" ]]; then
+  echo "'$SLUG' is not work-group-sourced — no cross-session reconciliation needed"
+  exit 0
+fi
+
+WD_FILE=""
+WORK_DIR=".work/$WORK_GROUP"
+if [[ -d "$WORK_DIR" ]]; then
+  for f in "$WORK_DIR"/WD-*.md; do
+    [[ ! -f "$f" ]] && continue
+    wd_id="$(work_fm "$f" "id")"
+    if [[ "$wd_id" == "$WORK_DEF" ]]; then
+      WD_FILE="$f"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$WD_FILE" ]]; then
+  echo "WD file not found for $WORK_GROUP/$WORK_DEF — nothing to reconcile"
+  exit 0
+fi
+
+# ── Read produces specs and check their manifest state ─────────────────────
+MANIFEST=".spec/registry/manifest.json"
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "no spec manifest — nothing to reconcile"
+  exit 0
+fi
+
+PRODUCED_SPECS=()
+while IFS='|' read -r prod_type prod_path _ _; do
+  [[ -z "$prod_type" ]] && continue
+  [[ "$prod_type" != "spec" ]] && continue
+  # Normalize slash → dot so domain-shaped paths match manifest IDs.
+  normalized="${prod_path//\//.}"
+  PRODUCED_SPECS+=("$normalized")
+done < <(work_fm_produces "$WD_FILE")
+
+if [[ ${#PRODUCED_SPECS[@]} -eq 0 ]]; then
+  echo "$SLUG: WD produces no specs — spec authoring substage has no durable check"
+  exit 0
+fi
+
+approved=0
+total=${#PRODUCED_SPECS[@]}
+not_approved=()
+for sid in "${PRODUCED_SPECS[@]}"; do
+  state="$(spec_manifest_state "$MANIFEST" "$sid")"
+  if [[ "$state" == "APPROVED" ]]; then
+    approved=$((approved + 1))
+  else
+    not_approved+=("$sid${state:+ ($state)}")
+  fi
+done
+
+# ── Read current Spec Authoring substage from status.md ────────────────────
+# The Stage Completion table row we care about:
+#   "| Spec Authoring | <status> | ... |"
+current_row="$(grep -E '^\| Spec Authoring \|' "$STATUS_FILE" 2>/dev/null | head -1)"
+if [[ -z "$current_row" ]]; then
+  echo "$SLUG: no Spec Authoring row in status.md — pipeline_mode may exclude it"
+  exit 0
+fi
+
+current_status="$(echo "$current_row" | awk -F'|' '{gsub(/^ +| +$/, "", $3); print $3}')"
+
+# ── Decide ──────────────────────────────────────────────────────────────────
+if [[ "$approved" -eq "$total" ]]; then
+  if [[ "$current_status" == "complete" ]]; then
+    echo "$SLUG: Spec Authoring already complete in status.md; $approved/$total produced specs APPROVED in manifest — current"
+    exit 0
+  fi
+
+  echo "$SLUG: drift — Spec Authoring '$current_status' in status.md but $approved/$total produced specs APPROVED in manifest"
+  if [[ "$READ_ONLY" == "true" ]]; then
+    echo "  (read-only mode — not rewriting status.md)"
+    exit 0
+  fi
+
+  # Apply: flip the row's status column to "complete" and stamp the
+  # Completed column to today. Awk index() avoids regex hazards with `|`.
+  today="$(date +%F)"
+  prefix='| Spec Authoring |'
+  tmp="$(mktemp)"
+  awk -v prefix="$prefix" -v today="$today" '
+    index($0, prefix) == 1 {
+      # Reformat the row, preserving the trailing columns past Completed.
+      n = split($0, cols, "|")
+      # cols[2] = " Spec Authoring "
+      # cols[3] = " <status> "
+      # cols[4] = " <completed> "
+      # cols[5] = " <est tokens> "
+      # cols[6] = " <actual tokens> "
+      # cols[7] = " <notes> "
+      cols[3] = " complete "
+      if (cols[4] ~ /^[ ]*—[ ]*$/ || cols[4] ~ /^[ ]*$/) {
+        cols[4] = " " today " "
+      }
+      cols[7] = " reconciled — produced specs APPROVED in manifest "
+      out = ""
+      for (i = 2; i <= n - 1; i++) out = out "|" cols[i]
+      print out "|"
+      next
+    }
+    { print }
+  ' "$STATUS_FILE" > "$tmp"
+  mv "$tmp" "$STATUS_FILE"
+  echo "  reconciled status.md: Spec Authoring → complete (Completed=$today)"
+  exit 0
+fi
+
+# Some produced specs not yet APPROVED — surface the gap so the caller
+# can decide. No write either way: status.md "in-progress" or
+# "not-started" is consistent with reality.
+echo "$SLUG: Spec Authoring '$current_status' in status.md; $approved/$total produced specs APPROVED in manifest"
+if [[ ${#not_approved[@]} -gt 0 ]]; then
+  echo "  not yet APPROVED:"
+  for s in "${not_approved[@]}"; do
+    echo "    - $s"
+  done
+fi

--- a/skills/feature-resume/SKILL.md
+++ b/skills/feature-resume/SKILL.md
@@ -99,6 +99,36 @@ Options:
 ```
 Stop.
 
+### Reconcile against durable artifacts
+
+`.feature/<slug>/` is gitignored. When a sibling WD authors a spec
+that this WD's `produces:` declares, the manifest learns about it but
+this feature's status.md does not — the local cache lives only on
+whoever ran the spec-authoring session. Re-entering on a fresh
+machine then misreads "Spec Authoring pending" even though the spec
+is APPROVED and committed.
+
+Run the reconciler before reading status.md so it reflects durable
+truth:
+
+```bash
+bash .claude/scripts/feature-state-reconcile.sh "<slug>"
+```
+
+The script:
+- Detects work-group features (status.md `work_group:` field or
+  `<group>--<wd>` slug pattern). No-op for plain features.
+- Reads the WD's `produces:` list and looks up each spec's state in
+  the manifest.
+- If every produced spec is APPROVED: flips the Spec Authoring row
+  in status.md to `complete` with today's date, leaving the
+  Estimated/Actual token columns alone.
+- Idempotent — a re-run on already-reconciled state writes nothing
+  and prints "current".
+
+If the script reported drift, surface that one-line summary above the
+"CURRENT POSITION" header so the user sees what was reconciled.
+
 ---
 
 ## Step 1b — Mode dispatch

--- a/tests/scenario-feature-state-reconcile.sh
+++ b/tests/scenario-feature-state-reconcile.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Scenario: feature-state-reconcile.sh detects + repairs Spec Authoring
+# substage drift caused by sibling-WD spec authoring landing in a
+# different feature's PR.
+#
+# Tests:
+# 1. Drift detected when produced spec is APPROVED but status.md says in-progress
+# 2. Apply mode rewrites the Stage Completion row to `complete` with today's date
+# 3. --read-only mode reports drift but does not write
+# 4. Re-running on already-reconciled state is a no-op (prints "current")
+# 5. Plain (non-work-group) feature reports "no cross-session reconciliation needed"
+# 6. WD with no produced specs reports "no durable check"
+# 7. Partial — 1/2 produced specs APPROVED leaves status.md unchanged
+# 8. Slash-form path normalizes to dot-form for manifest lookup
+# 9. Archived feature directory is reconciled too
+# 10. Missing manifest exits cleanly without writing
+#
+# Run from repo root: bash tests/scenario-feature-state-reconcile.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-feature-state-reconcile"
+RECONCILE="$REPO_ROOT/scripts/feature-state-reconcile.sh"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+cleanup() { rm -rf "$TEST_BASE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: feature-state-reconcile spec-authoring drift detection"
+echo "──────────────────────────────────────────────────────────────────"
+
+cleanup
+
+# ── Common fixture builder ──────────────────────────────────────────────────
+
+setup_fixture() {
+  local name="$1"
+  local proj="$TEST_BASE/$name/project"
+  local wd_status="${2:-SPECIFIED}"
+  local spec_state="${3:-APPROVED}"
+  local feature_substage="${4:-in-progress}"
+
+  rm -rf "$TEST_BASE/$name"
+  mkdir -p "$proj/.feature/add-compaction--wd-05" \
+           "$proj/.work/add-compaction" \
+           "$proj/.spec/registry" \
+           "$proj/.spec/domains/engine" \
+           "$proj/.claude/scripts"
+  cp "$REPO_ROOT/scripts/feature-state-reconcile.sh" "$proj/.claude/scripts/"
+  cp "$REPO_ROOT/scripts/spec-lib.sh"                "$proj/.claude/scripts/"
+  cp "$REPO_ROOT/scripts/work-lib.sh"                "$proj/.claude/scripts/"
+
+  cat > "$proj/.work/add-compaction/WD-05.md" << EOF
+---
+id: WD-05
+title: Compaction orchestration
+group: add-compaction
+status: $wd_status
+domains: [engine]
+artifact_deps: []
+produces:
+  - { type: spec, path: "engine.compaction-orchestration" }
+---
+
+## Summary
+Author the orchestration spec.
+EOF
+
+  cat > "$proj/.spec/registry/manifest.json" << EOF
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "engine.compaction-orchestration", "path": ".spec/domains/engine/compaction-orchestration.md", "state": "$spec_state", "version": 4, "domains": ["engine"] }
+  ]
+}
+EOF
+  echo '# engine.compaction-orchestration' > "$proj/.spec/domains/engine/compaction-orchestration.md"
+
+  cat > "$proj/.feature/add-compaction--wd-05/status.md" << EOF
+# Status — add-compaction--wd-05
+
+## Current Position
+**Stage:** spec-authoring
+**Substage:** drafting
+
+## Work Group
+work_group: add-compaction
+work_definition: WD-05
+
+## Stage Completion
+
+| Stage | Status | Completed | Est. Tokens | Actual Tokens | Notes |
+|-------|--------|-----------|-------------|---------------|-------|
+| Scoping | complete | 2026-04-30 | ~5K | 4.2K in / 3K out | |
+| Domains | complete | 2026-05-01 | ~6K | 8.1K in / 2K out | |
+| Spec Authoring | $feature_substage | — | — | — | drafting |
+| Planning | not-started | — | — | — | |
+EOF
+  echo "$proj"
+}
+
+# ── Test 1: Drift detected ──────────────────────────────────────────────────
+
+echo ""
+echo "── Test 1: Drift detected when spec is APPROVED but status.md says in-progress"
+
+proj=$(setup_fixture t1)
+cd "$proj"
+output=$(bash "$RECONCILE" add-compaction--wd-05 --read-only 2>&1)
+if echo "$output" | grep -q "drift — Spec Authoring 'in-progress'.*1/1 produced specs APPROVED"; then
+    pass "drift detected with correct counts"
+else
+    fail "drift detection wrong" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Test 2: Apply mode rewrites the row ─────────────────────────────────────
+
+echo ""
+echo "── Test 2: Apply mode rewrites Spec Authoring row to complete"
+
+proj=$(setup_fixture t2)
+cd "$proj"
+bash "$RECONCILE" add-compaction--wd-05 >/dev/null 2>&1
+today=$(date +%F)
+if grep -qE "^\| Spec Authoring \| complete \| $today \|" .feature/add-compaction--wd-05/status.md; then
+    pass "Spec Authoring row → complete with today's date"
+else
+    fail "row not rewritten correctly" "got: $(grep '^| Spec Authoring' .feature/add-compaction--wd-05/status.md)"
+fi
+cd - >/dev/null
+
+# ── Test 3: --read-only does not write ──────────────────────────────────────
+
+echo ""
+echo "── Test 3: --read-only reports drift but does not write"
+
+proj=$(setup_fixture t3)
+cd "$proj"
+cp .feature/add-compaction--wd-05/status.md /tmp/before-readonly.md
+bash "$RECONCILE" add-compaction--wd-05 --read-only >/dev/null 2>&1
+if cmp -s .feature/add-compaction--wd-05/status.md /tmp/before-readonly.md; then
+    pass "--read-only left status.md byte-identical"
+else
+    fail "--read-only wrote to status.md"
+fi
+cd - >/dev/null
+
+# ── Test 4: Re-run is no-op on already-reconciled state ─────────────────────
+
+echo ""
+echo "── Test 4: Re-run on already-reconciled state is a no-op"
+
+proj=$(setup_fixture t4)
+cd "$proj"
+bash "$RECONCILE" add-compaction--wd-05 >/dev/null 2>&1
+cp .feature/add-compaction--wd-05/status.md /tmp/before-rerun.md
+output=$(bash "$RECONCILE" add-compaction--wd-05 2>&1)
+if echo "$output" | grep -q "already complete in status.md.*current" && \
+   cmp -s .feature/add-compaction--wd-05/status.md /tmp/before-rerun.md; then
+    pass "re-run reports current and writes nothing"
+else
+    fail "re-run mutated status.md or wrong message" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Test 5: Plain (non-work-group) feature ──────────────────────────────────
+
+echo ""
+echo "── Test 5: Plain feature reports no cross-session reconciliation needed"
+
+proj=$(setup_fixture t5)
+cd "$proj"
+# Strip work_group + work_definition from status.md and rename feature dir
+mv .feature/add-compaction--wd-05 .feature/plain-feature
+sed -i '/^work_group:/d; /^work_definition:/d' .feature/plain-feature/status.md
+output=$(bash "$RECONCILE" plain-feature 2>&1)
+if echo "$output" | grep -q "not work-group-sourced"; then
+    pass "plain feature short-circuits cleanly"
+else
+    fail "plain feature should report not work-group-sourced" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Test 6: WD with no produced specs ───────────────────────────────────────
+
+echo ""
+echo "── Test 6: WD with empty produces reports no durable check"
+
+proj=$(setup_fixture t6)
+cd "$proj"
+# Drop the produces section
+sed -i '/^produces:$/,/^---$/{ /^---$/!d }' .work/add-compaction/WD-05.md
+output=$(bash "$RECONCILE" add-compaction--wd-05 2>&1)
+if echo "$output" | grep -q "produces no specs"; then
+    pass "WD without produced specs short-circuits"
+else
+    fail "should report produces no specs" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Test 7: Partial coverage (some specs not yet APPROVED) ──────────────────
+
+echo ""
+echo "── Test 7: Partial — only 1/2 produced specs APPROVED leaves status.md unchanged"
+
+proj=$(setup_fixture t7)
+cd "$proj"
+# Add a second produces entry pointing at a DRAFT spec
+cat > .work/add-compaction/WD-05.md << 'EOF'
+---
+id: WD-05
+title: Compaction orchestration
+group: add-compaction
+status: SPECIFIED
+domains: [engine]
+artifact_deps: []
+produces:
+  - { type: spec, path: "engine.compaction-orchestration" }
+  - { type: spec, path: "engine.compaction-budget" }
+---
+EOF
+# Add the budget spec to manifest as DRAFT
+cat > .spec/registry/manifest.json << 'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "engine.compaction-orchestration", "path": ".spec/domains/engine/compaction-orchestration.md", "state": "APPROVED", "version": 4, "domains": ["engine"] },
+    { "id": "engine.compaction-budget", "path": ".spec/domains/engine/compaction-budget.md", "state": "DRAFT", "version": 1, "domains": ["engine"] }
+  ]
+}
+EOF
+cp .feature/add-compaction--wd-05/status.md /tmp/before-partial.md
+output=$(bash "$RECONCILE" add-compaction--wd-05 2>&1)
+if echo "$output" | grep -q "1/2 produced specs APPROVED" && \
+   echo "$output" | grep -q "engine.compaction-budget" && \
+   cmp -s .feature/add-compaction--wd-05/status.md /tmp/before-partial.md; then
+    pass "partial coverage reports gap and leaves status.md unchanged"
+else
+    fail "partial reconciliation incorrect" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Test 8: Slash-form path normalizes to dot-form ──────────────────────────
+
+echo ""
+echo "── Test 8: Slash-form path in produces resolves to dot-form ID"
+
+proj=$(setup_fixture t8)
+cd "$proj"
+sed -i 's|engine.compaction-orchestration|engine/compaction-orchestration|' .work/add-compaction/WD-05.md
+output=$(bash "$RECONCILE" add-compaction--wd-05 --read-only 2>&1)
+if echo "$output" | grep -q "1/1 produced specs APPROVED"; then
+    pass "slash-form path normalized to dot-form for manifest lookup"
+else
+    fail "slash-form not normalized" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Test 9: Archived feature directory ──────────────────────────────────────
+
+echo ""
+echo "── Test 9: Archived feature directory is reconciled too"
+
+proj=$(setup_fixture t9)
+cd "$proj"
+mkdir -p .feature/_archive
+mv .feature/add-compaction--wd-05 .feature/_archive/
+output=$(bash "$RECONCILE" add-compaction--wd-05 2>&1)
+if echo "$output" | grep -q "1/1 produced specs APPROVED"; then
+    pass "archived feature is found + reconciled"
+else
+    fail "archived feature not reconciled" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Test 10: Missing manifest exits cleanly ─────────────────────────────────
+
+echo ""
+echo "── Test 10: Missing manifest exits cleanly without writing"
+
+proj=$(setup_fixture t10)
+cd "$proj"
+rm -f .spec/registry/manifest.json
+cp .feature/add-compaction--wd-05/status.md /tmp/before-no-manifest.md
+output=$(bash "$RECONCILE" add-compaction--wd-05 2>&1)
+if echo "$output" | grep -q "no spec manifest" && \
+   cmp -s .feature/add-compaction--wd-05/status.md /tmp/before-no-manifest.md; then
+    pass "missing manifest reports + leaves status.md untouched"
+else
+    fail "missing manifest path wrong" "got: $output"
+fi
+cd - >/dev/null
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+exit $failed


### PR DESCRIPTION
## Summary

`.feature/<slug>/` is gitignored, so `status.md` is a local cache that drifts when a sibling WD authors specs in a different session/PR. Re-entering the feature on a fresh machine then misreads the state and reports "Spec Authoring pending" even though the spec is APPROVED and committed.

Real example: WD-05 of the compaction-scheduling work group showed Spec Authoring pending while the spec was already APPROVED v4 in a prior PR that bundled the spec authoring together.

## What changed

- **New: `scripts/feature-state-reconcile.sh <slug> [--read-only]`** — reads the WD's `produces:` list, looks up each spec's state in `.spec/registry/manifest.json`, and if every produced spec is APPROVED, flips the Stage Completion `Spec Authoring` row to `complete`. Idempotent. Slash/dot path normalization. Plain (non-work-group) features short-circuit.
- **`/feature-resume` Step 1** — now calls the reconciler before reading status.md so the displayed state reflects durable truth and the local cache is healed in the same step.
- **MANIFEST + install.sh** — register the new script, chmod +x, allowlist the bash entry.

## Test plan

- [x] `tests/scenario-feature-state-reconcile.sh` — 10/10 (drift detection, apply, --read-only, no-op re-run, plain features, empty produces, partial coverage, slash/dot normalization, archived features, missing manifest)
- [x] Full scenario sweep — 53/53 (52 prior + new scenario-feature-state-reconcile)
- [x] `tests/test-install.sh` — 64/64

## Notes

- Scope is intentionally limited to the Spec Authoring substage. Planning/Testing/Implementation produce code + tests in git (canonical state) and rarely drift across sessions.
- Script does not touch token columns or other rows; only the Spec Authoring status, completion date, and notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)