### PR TITLE
fix(spec-coverage): init parses title-bearing  headers

### DIFF
--- a/scripts/spec-coverage.sh
+++ b/scripts/spec-coverage.sh
@@ -75,17 +75,22 @@ cmd_init() {
 
   # Extract (spec, R) pairs from the bundle. The spec-resolve bundle's
   # `## Feature Requirements` section contains one or more spec sections;
-  # each starts with `# <spec-id>` (matching the SPEC_ID grammar) and
-  # carries `R<n>.` requirement lines.
+  # each starts with `# <spec-id>` and may continue with ` — <title>`
+  # (the spec file's own title-bearing header is rendered into the
+  # bundle verbatim via machine_section). Match either form: the bare
+  # `^# <id>$` from older bundles AND the title-bearing
+  # `^# <id> — Title` shape that spec-resolve emits today. The
+  # substring extraction then truncates at the first whitespace so
+  # cur_spec captures only the ID, not the appended title.
   local pairs
-  pairs=$(awk -v re="^# $SPEC_ID_RE\$" '
+  pairs=$(awk -v re="^# $SPEC_ID_RE( |\$)" '
     BEGIN { in_features = 0; cur_spec = "" }
     /^## Feature Requirements *$/ { in_features = 1; next }
     in_features && /^## / && !/^## Requirements *$/ { in_features = 0 }
     in_features && /^# / {
       if (match($0, re)) {
         cur_spec = substr($0, 3)
-        sub(/[ \t]+$/, "", cur_spec)
+        sub(/[ \t].*$/, "", cur_spec)
       }
     }
     in_features && /^R[0-9]+[a-z]*(-[0-9]+[a-z]*)?\./ {

--- a/tests/scenario-spec-coverage.sh
+++ b/tests/scenario-spec-coverage.sh
@@ -288,6 +288,92 @@ else
     fail "gate failed on vacuous coverage"
 fi
 
+# ── Test 11: init parses title-bearing spec section headers ─────────────────
+# Regression: spec-coverage.sh init's awk regex was anchored as `^# <id>$`,
+# but spec-resolve.sh's machine_section pass-through includes the spec
+# file's own title line `# <id> — Title`. The anchored regex never
+# matched, init emitted a vacuous-coverage file, and populated tables
+# only appeared later when /spec-coverage update re-derived rows from
+# spec-trace output. After this fix init must populate the table from a
+# title-bearing bundle just like it does from the bare-id form.
+
+echo ""
+echo "── Test 11: init parses title-bearing `# <id> — Title` section headers"
+
+mkdir -p .feature/title-bearing
+cat > .feature/title-bearing/spec-bundle.md << 'BUNDLE'
+# Resolved Context Bundle
+Generated: 2026-05-07T00:00:00Z
+
+## Feature Requirements
+
+# auth.token-validation — JWT Token Validation Contract
+
+## Requirements
+R1. The TokenValidator must reject expired tokens.
+R2. The TokenValidator must reject malformed tokens.
+
+---
+
+# auth.session-lifecycle — Session Lifecycle (revision 3)
+
+## Requirements
+R1. The SessionStore must invalidate on logout.
+R2. The SessionStore must auto-expire on inactivity.
+
+## Cross-References
+none
+BUNDLE
+
+COV_TITLE=".feature/title-bearing/spec-coverage.md"
+bash .claude/scripts/spec-coverage.sh init "$COV_TITLE" .feature/title-bearing/spec-bundle.md 2>/dev/null
+
+# Should NOT fall into the vacuous-coverage branch
+if grep -q '^No specs loaded' "$COV_TITLE"; then
+    fail "title-bearing bundle was misclassified as empty (regex still anchored?)"
+else
+    pass "title-bearing bundle did NOT trigger vacuous-coverage path"
+fi
+
+# Should populate one row per (spec, R)
+row_count=$(grep -cE '^\| auth\.[a-z\-]+ \| R[0-9]+' "$COV_TITLE" || true)
+if [[ "$row_count" == "4" ]]; then
+    pass "4 rows written from title-bearing bundle (2 specs × 2 reqs)"
+else
+    fail "expected 4 rows, got $row_count" "head: $(head -10 "$COV_TITLE")"
+fi
+
+# Spec ID column must be the bare ID, NOT the title-bearing form. If the
+# extraction failed to truncate at the first whitespace, the ID column
+# would contain the appended title.
+if grep -q '— JWT' "$COV_TITLE" || grep -q '— Session' "$COV_TITLE"; then
+    fail "spec ID column captured the title — extraction did not truncate at whitespace" \
+         "got: $(grep '^|' "$COV_TITLE" | head -3)"
+else
+    pass "spec ID column is bare (title not leaked into the ID column)"
+fi
+
+# Bare-ID form must still work — backwards compatibility for older bundles.
+mkdir -p .feature/bare-id
+cat > .feature/bare-id/spec-bundle.md << 'BUNDLE'
+# Resolved Context Bundle
+
+## Feature Requirements
+
+# auth.bare-token
+
+## Requirements
+R1. Just one requirement.
+BUNDLE
+
+COV_BARE=".feature/bare-id/spec-coverage.md"
+bash .claude/scripts/spec-coverage.sh init "$COV_BARE" .feature/bare-id/spec-bundle.md 2>/dev/null
+if grep -qE '^\| auth\.bare-token \| R1 \| pending \| pending \|' "$COV_BARE"; then
+    pass "bare-ID bundle (pre-title format) still parses (backwards-compatible)"
+else
+    fail "bare-ID bundle regressed" "got: $(cat "$COV_BARE" | tail -5)"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

`scripts/spec-coverage.sh init` parsed bundle section headers with `^# <id>$` (fully anchored), but spec-resolve.sh emits each spec section with the file's title-bearing top-level header `# <id> — <title>`. The anchored regex never matched, `cur_spec` was never set, the (spec, R) pair set came out empty, and init fell through to the "no specs in bundle" branch — silently emitting a vacuous-coverage file. Tables only became populated when `/spec-coverage update` later re-derived rows from spec-trace output (different code path that bypasses bundle parsing).

Surfaced from jlsm: every feature since spec-resolve started embedding titles has been getting an empty `spec-coverage.md` from init.

## What changed

Two-line awk diff in `spec-coverage.sh`:
- Regex: `^# $SPEC_ID_RE( |$)` — match the ID followed by a literal space (before " — title") OR end-of-line (legacy bare-ID bundles).
- Substring extraction: `sub(/[ \t].*$/, "", cur_spec)` truncates at the first whitespace so cur_spec captures only the ID, not the appended title.

## Adversarial regex check

Tested all spec ID shapes against title-bearing and bare-ID lines:

| Input                                                              | Match | Captured ID                                  |
|--------------------------------------------------------------------|-------|----------------------------------------------|
| `# F01 — Legacy spec`                                              | ✓     | `F01`                                        |
| `# auth.token — Domain spec`                                       | ✓     | `auth.token`                                 |
| `# encryption.primitives-lifecycle.key-rotation — Multi-dot spec`  | ✓     | `encryption.primitives-lifecycle.key-rotation` |
| `# F01` (bare)                                                     | ✓     | `F01`                                        |
| `## Not a spec header (level 2)`                                   | miss  | —                                            |
| `# Not-a-spec-id heading`                                          | miss  | —                                            |
| `# F1` (single digit, invalid per SPEC_ID_RE)                      | miss  | —                                            |

## Test plan

- [x] `tests/scenario-spec-coverage.sh` — 18/18 (4 new regression cases for title-bearing + bare-ID backwards compat)
- [x] Full scenario sweep — 53/53
- [x] `tests/test-install.sh` — 64/64
- [x] Reviewed sibling code paths (spec-validate, spec-trace, spec-split, spec-ambiguity-score) — no other site has the same anchored-regex-on-bundle-header bug class

🤖 Generated with [Claude Code](https://claude.com/claude-code)