### PR TITLE
feat(spec-coverage): scope gate to primary specs by default

### DIFF
--- a/scripts/spec-coverage.sh
+++ b/scripts/spec-coverage.sh
@@ -117,6 +117,18 @@ HEADER
     return 0
   fi
 
+  # Read the bundle's "Primary specs:" preamble line. spec-resolve emits
+  # this so coverage can scope the gate: rows from primary (direct-match)
+  # specs are gate-enforced; rows from context (transitively pulled —
+  # parent chain, requires:, sibling expansion) are visible in the table
+  # but not required to be annotated by this feature. Bundles without
+  # the line treat every spec as primary (legacy behavior).
+  local primary_line primary_set=""
+  primary_line=$(grep -m1 '^Primary specs:' "$bundle" 2>/dev/null || true)
+  if [[ -n "$primary_line" ]]; then
+    primary_set=$(echo "$primary_line" | sed 's/^Primary specs:[[:space:]]*//; s/,[[:space:]]*/|/g; s/[[:space:]]*$//')
+  fi
+
   {
     cat <<HEADER
 # Spec Coverage
@@ -124,12 +136,26 @@ HEADER
 > **Managed by vallorcine pipeline. Do not hand-edit.**
 > Updated by /feature-plan, /feature-test, /feature-implement, /feature-pr.
 > Cell values: \`pending\`, \`<file>:<line>\` (multiple comma-separated), \`waived: <reason>\`.
+> Notes column: \`context\` marks rows from transitively-pulled specs that
+> the gate skips by default (visible for annotation if the WD genuinely
+> satisfies them; not required obligations).
 
 | Spec | Req | Test | Impl | Notes |
 |------|-----|------|------|-------|
 HEADER
     while IFS=$'\t' read -r spec rid; do
       [[ -z "$spec" || -z "$rid" ]] && continue
+      # Decide scope from the Primary specs preamble. Empty preamble →
+      # treat as primary (legacy bundles).
+      local scope="primary"
+      if [[ -n "$primary_set" ]]; then
+        # Exact ID match against the alternation. The set was built from
+        # `Primary specs:` so the comparison is a literal whole-word
+        # match against pipe-separated IDs.
+        if ! grep -qxE "$primary_set" <<<"$spec" 2>/dev/null; then
+          scope="context"
+        fi
+      fi
       # Restore prior cell values for this row if present
       local prior
       prior=$(echo "$existing_rows" | awk -F'\t' -v s="$spec" -v r="$rid" '$1==s && $2==r {print $3 "\t" $4 "\t" $5; exit}')
@@ -139,13 +165,34 @@ HEADER
         [[ -z "$test_cell" ]] && test_cell="pending"
         [[ -z "$impl_cell" ]] && impl_cell="pending"
       fi
+      # Only stamp `context` when the row is not already carrying an
+      # explicit waiver/annotation note from a prior run. This keeps
+      # init idempotent: re-running on a populated table preserves
+      # any context tag without overwriting waiver notes.
+      if [[ "$scope" == "context" && ( -z "$notes_cell" || "$notes_cell" == "context" ) ]]; then
+        notes_cell="context"
+      fi
       printf '| %s | %s | %s | %s | %s |\n' "$spec" "$rid" "$test_cell" "$impl_cell" "$notes_cell"
     done <<<"$pairs"
   } > "$cov"
 
-  local total
+  local total context_total
   total=$(echo "$pairs" | wc -l | tr -d ' ')
-  echo "[coverage] init: wrote $total requirement rows to $cov" >&2
+  # Count context-tagged rows via awk so the result is always a single
+  # integer (grep -c on no matches exits 1; with `|| echo 0` you get
+  # "0\n0" which breaks arithmetic). Awk emits exactly one number.
+  context_total=$(awk -F'|' '
+    /^\| *[a-zA-Z0-9.-]+ *\| *R[0-9]+/ {
+      gsub(/^ +| +$/, "", $6)
+      if ($6 == "context") n++
+    }
+    END { print n+0 }
+  ' "$cov")
+  if (( context_total > 0 )); then
+    echo "[coverage] init: wrote $total requirement rows to $cov ($((total - context_total)) primary, $context_total context)" >&2
+  else
+    echo "[coverage] init: wrote $total requirement rows to $cov" >&2
+  fi
 }
 
 # ── Subcommand: update ───────────────────────────────────────────────────────
@@ -292,7 +339,22 @@ cmd_update() {
 # Exits 0 if every row has at least one annotation (Test or Impl) OR is waived.
 # Exits 1 (with a list of pending rows on stdout) otherwise.
 cmd_gate() {
-  local cov="${1:-}"
+  local cov="" include_context=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --include-context) include_context=true ;;
+      -h|--help)
+        echo "Usage: spec-coverage.sh gate <coverage-md> [--include-context]" >&2
+        return 2
+        ;;
+      *)
+        if [[ -z "$cov" ]]; then cov="$1"
+        else echo "ERROR: extra positional argument '$1'" >&2; exit 2
+        fi
+        ;;
+    esac
+    shift
+  done
   [[ -z "$cov" ]] && { echo "ERROR: gate requires <coverage-md>" >&2; exit 2; }
   [[ ! -f "$cov" ]] && { echo "ERROR: coverage file not found: $cov" >&2; exit 1; }
 
@@ -301,12 +363,19 @@ cmd_gate() {
     return 0
   fi
 
+  # Default: skip rows whose Notes column starts with `context` — those
+  # are transitively-pulled specs the WD has no obligation to annotate
+  # (visible in the table for awareness; gate-enforcement would force
+  # waiver-spam on every feature pulled into a bundle for planning).
+  # `--include-context` flips to strict mode for whole-bundle audits.
   local pending
-  pending=$(awk -F'|' '
+  pending=$(awk -F'|' -v skip_context="$([[ "$include_context" == "true" ]] && echo 0 || echo 1)" '
     /^\| *[a-zA-Z0-9.-]+ *\| *R[0-9]+/ {
-      spec = $2; rid = $3; t = $4; i = $5
+      spec = $2; rid = $3; t = $4; i = $5; notes = $6
       gsub(/^ +| +$/, "", spec); gsub(/^ +| +$/, "", rid)
       gsub(/^ +| +$/, "", t); gsub(/^ +| +$/, "", i)
+      gsub(/^ +| +$/, "", notes)
+      if (skip_context && index(notes, "context") == 1) next
       # Pending iff BOTH Test and Impl are pending and neither is waived.
       if (t == "pending" && i == "pending") {
         printf("%s.%s\n", spec, rid)
@@ -314,7 +383,11 @@ cmd_gate() {
     }' "$cov")
 
   if [[ -z "$pending" ]]; then
-    echo "[coverage] gate: PASS — every loaded requirement has at least one @spec annotation or waiver" >&2
+    if [[ "$include_context" == "true" ]]; then
+      echo "[coverage] gate: PASS (--include-context) — every row has annotation or waiver" >&2
+    else
+      echo "[coverage] gate: PASS — every primary requirement has an @spec annotation or waiver" >&2
+    fi
     return 0
   fi
 
@@ -330,6 +403,10 @@ cmd_gate() {
   echo ""
   echo "Waive a row:"
   echo "  bash .claude/scripts/spec-coverage.sh waive <coverage-md> <spec-id>.R<n> \"<reason>\""
+  if [[ "$include_context" != "true" ]]; then
+    echo ""
+    echo "(Context rows skipped. Re-run with --include-context to gate the whole bundle.)"
+  fi
   return 1
 }
 
@@ -388,16 +465,25 @@ cmd_report() {
   awk -F'|' '
     /^\| *[a-zA-Z0-9.-]+ *\| *R[0-9]+/ {
       total++
-      t = $4; i = $5
-      gsub(/^ +| +$/, "", t); gsub(/^ +| +$/, "", i)
+      t = $4; i = $5; notes = $6
+      gsub(/^ +| +$/, "", t); gsub(/^ +| +$/, "", i); gsub(/^ +| +$/, "", notes)
+      is_context = (index(notes, "context") == 1)
+      if (is_context) context++
       if (t ~ /^waived:/ || i ~ /^waived:/) waived++
       else if (t != "pending" || i != "pending") covered++
+      else if (is_context) context_pending++
       else pending++
     }
     END {
       total = total + 0
-      printf("Spec coverage: %d loaded · %d annotated · %d waived · %d pending\n",
-             total, covered+0, waived+0, pending+0)
+      base = sprintf("Spec coverage: %d loaded · %d annotated · %d waived · %d pending",
+                     total, covered+0, waived+0, pending+0)
+      if (context+0 > 0) {
+        printf("%s (+ %d context not gate-enforced; %d of those still pending)\n",
+               base, context+0, context_pending+0)
+      } else {
+        printf("%s\n", base)
+      }
     }
   ' "$cov"
 }

--- a/scripts/spec-resolve.sh
+++ b/scripts/spec-resolve.sh
@@ -290,6 +290,8 @@ done
 BUNDLE_PARTS=()
 OMITTED=()
 FORCED=()
+PRIMARY_IDS=()
+CONTEXT_IDS=()
 RUNNING_TOKENS=0
 HEADER_RESERVE=300
 
@@ -324,6 +326,16 @@ for f in "${ALL_FILES[@]+"${ALL_FILES[@]}"}"; do
 
   BUNDLE_PARTS+=("$section")
   RUNNING_TOKENS=$(( RUNNING_TOKENS + section_tokens ))
+  # Track primary (direct-match) vs context (transitively pulled —
+  # parent chain, requires:, sibling expansion). spec-coverage uses
+  # this to scope its gate: only primary-spec R-clauses are
+  # gate-enforced; context rows are visible in the table but not
+  # required to be annotated by this feature.
+  if [[ "${DIRECT_FILES[$f]+x}" == "x" ]]; then
+    PRIMARY_IDS+=("$spec_id")
+  else
+    CONTEXT_IDS+=("$spec_id")
+  fi
   if [[ "$must_force" == "true" ]]; then
     FORCED+=("$spec_id")
     echo "[resolve] WARNING: $spec_id (~$section_tokens tokens) force-included over budget $TOKEN_BUDGET — bump --token-budget to suppress this warning" >&2
@@ -700,6 +712,16 @@ if [[ ${#FORCED[@]} -gt 0 ]]; then
 else
     FORCED_STR="none"
 fi
+if [[ ${#PRIMARY_IDS[@]} -gt 0 ]]; then
+    PRIMARY_STR="$(IFS=', '; echo "${PRIMARY_IDS[*]}")"
+else
+    PRIMARY_STR="none"
+fi
+if [[ ${#CONTEXT_IDS[@]} -gt 0 ]]; then
+    CONTEXT_STR="$(IFS=', '; echo "${CONTEXT_IDS[*]}")"
+else
+    CONTEXT_STR="none"
+fi
 
 cat <<EOF
 # Resolved Context Bundle
@@ -710,6 +732,8 @@ Token budget: $TOKEN_BUDGET | Tokens used: ~$RUNNING_TOKENS
 Omitted (budget): $OMITTED_STR
 Force-included (over budget, kept to avoid empty bundle): $FORCED_STR
 Omitted (DRAFT with unresolved conflicts): $CONFLICT_OMITTED_STR
+Primary specs: $PRIMARY_STR
+Context specs: $CONTEXT_STR
 
 ## Open Obligations (must be addressed in this feature)
 ${OBLIGATIONS:-none}

--- a/skills/feature-pr/SKILL.md
+++ b/skills/feature-pr/SKILL.md
@@ -159,8 +159,11 @@ intent and behaviour, not implementation details.
 
 If `.feature/<slug>/spec-coverage.md` exists, refresh it against the current
 codebase and run the gate. The gate is the structural enforcement that every
-loaded spec requirement has at least one `@spec` annotation in tests or
-implementation:
+**primary** loaded spec requirement has at least one `@spec` annotation in
+tests or implementation. Rows tagged `context` in the Notes column come from
+specs that were transitively pulled into the bundle for planning visibility
+(parent chain, `requires:`, sibling expansion) — those are NOT this feature's
+annotation obligation and the gate skips them by default:
 
 ```bash
 if [[ -f .feature/<slug>/spec-coverage.md ]]; then
@@ -173,8 +176,9 @@ fi
 
 **If the gate fails (exit nonzero):**
 
-The script prints the list of uncovered requirements. Display the output to
-the user and stop the PR draft. Do not proceed to Step 2.
+The script prints the list of uncovered requirements (primary scope only by
+default). Display the output to the user and stop the PR draft. Do not
+proceed to Step 2.
 
 The user has three resolutions:
 
@@ -200,6 +204,18 @@ The override path is intended for rare cases where the user has a valid
 reason the kit cannot detect (e.g., legacy code being touched in a way that
 predates spec authoring). It is recorded in the PR so reviewers can see
 the gap was explicit.
+
+**`--include-context` strict mode** is available for whole-bundle audits
+(reviewing every requirement the bundle pulled in, not just primary scope):
+
+```bash
+bash .claude/scripts/spec-coverage.sh gate \
+  .feature/<slug>/spec-coverage.md --include-context
+```
+
+`/feature-pr` does NOT pass `--include-context` by default. Reach for it only
+when explicitly auditing the whole bundle's coverage — e.g., during a
+spec-backfill or curation pass — not as a routine PR check.
 
 ---
 

--- a/tests/scenario-spec-coverage.sh
+++ b/tests/scenario-spec-coverage.sh
@@ -374,6 +374,195 @@ else
     fail "bare-ID bundle regressed" "got: $(cat "$COV_BARE" | tail -5)"
 fi
 
+# ── Tests 12-19: primary-vs-context scope distinction ──────────────────────
+# Regression: spec-coverage previously gate-enforced every row in the
+# bundle, which forced waiver-spam on transitively-pulled context specs
+# (parent chain, requires:, sibling expansion). spec-resolve now emits
+# `Primary specs:` and `Context specs:` preamble lines; init reads them
+# to tag context rows; gate skips context-tagged rows by default with
+# --include-context for strict mode.
+
+# Bundle with explicit Primary/Context preamble lines.
+mkdir -p .feature/scoped
+cat > .feature/scoped/spec-bundle.md << 'BUNDLE'
+# Resolved Context Bundle
+Generated: 2026-05-07T00:00:00Z
+Feature request: scoped
+Domains matched: auth, billing
+Token budget: 25000 | Tokens used: ~1500
+Omitted (budget): none
+Force-included (over budget, kept to avoid empty bundle): none
+Omitted (DRAFT with unresolved conflicts): none
+Primary specs: auth.token-validation
+Context specs: auth.session-lifecycle, billing.charge-flow
+
+## Open Obligations (must be addressed in this feature)
+none
+
+## Feature Requirements
+
+# auth.token-validation — JWT Token Validation
+
+## Requirements
+R1. The TokenValidator must reject expired tokens.
+R2. The TokenValidator must reject malformed tokens.
+
+---
+
+# auth.session-lifecycle — Session Lifecycle (transitively pulled)
+
+## Requirements
+R1. The SessionStore must invalidate on logout.
+
+---
+
+# billing.charge-flow — Charge Flow (transitively pulled)
+
+## Requirements
+R1. The ChargeProcessor must finalize via SettlementGateway.
+R2. The ChargeProcessor must roll back on settlement failure.
+BUNDLE
+
+COV_SCOPED=".feature/scoped/spec-coverage.md"
+bash .claude/scripts/spec-coverage.sh init "$COV_SCOPED" .feature/scoped/spec-bundle.md 2>/dev/null
+
+# ── Test 12: init tags context-spec rows with `context` in Notes ───────────
+
+echo ""
+echo "── Test 12: init tags context-spec rows with 'context' in Notes column"
+
+if grep -qE '^\| auth\.session-lifecycle \| R1 \| pending \| pending \| context \|' "$COV_SCOPED" \
+   && grep -qE '^\| billing\.charge-flow \| R1 \| pending \| pending \| context \|' "$COV_SCOPED"; then
+    pass "context-spec rows tagged"
+else
+    fail "context-spec rows not tagged" "got: $(grep '^|' $COV_SCOPED)"
+fi
+
+# ── Test 13: init does NOT tag primary-spec rows ───────────────────────────
+
+echo ""
+echo "── Test 13: primary-spec rows have empty Notes column"
+
+if grep -qE '^\| auth\.token-validation \| R1 \| pending \| pending \|  \|' "$COV_SCOPED" \
+   && grep -qE '^\| auth\.token-validation \| R2 \| pending \| pending \|  \|' "$COV_SCOPED"; then
+    pass "primary-spec rows have empty Notes"
+else
+    fail "primary-spec rows incorrectly tagged" "got: $(grep token-validation $COV_SCOPED)"
+fi
+
+# ── Test 14: gate (default) skips context rows ─────────────────────────────
+
+echo ""
+echo "── Test 14: gate (default) fires only on primary-spec pending rows"
+
+if bash .claude/scripts/spec-coverage.sh gate "$COV_SCOPED" >/tmp/vallorcine/gate-scoped.txt 2>/dev/null; then
+    fail "gate returned 0 with primary-spec rows still pending"
+else
+    # Should list the 2 primary requirements, not the 3 context ones.
+    if grep -q "auth.token-validation.R1" /tmp/vallorcine/gate-scoped.txt \
+       && grep -q "auth.token-validation.R2" /tmp/vallorcine/gate-scoped.txt \
+       && ! grep -q "auth.session-lifecycle" /tmp/vallorcine/gate-scoped.txt \
+       && ! grep -q "billing.charge-flow" /tmp/vallorcine/gate-scoped.txt; then
+        pass "gate enumerated 2 primary requirements; context rows excluded"
+    else
+        fail "gate output mis-scoped" "$(cat /tmp/vallorcine/gate-scoped.txt)"
+    fi
+fi
+
+# ── Test 15: gate hint mentions --include-context for strict mode ──────────
+
+echo ""
+echo "── Test 15: gate failure message hints at --include-context"
+
+if grep -q -- "--include-context" /tmp/vallorcine/gate-scoped.txt; then
+    pass "gate failure mentions --include-context for strict mode"
+else
+    fail "gate failure should mention --include-context" "$(cat /tmp/vallorcine/gate-scoped.txt)"
+fi
+
+# ── Test 16: gate --include-context fires on every pending row ─────────────
+
+echo ""
+echo "── Test 16: gate --include-context flips to whole-bundle strict mode"
+
+if bash .claude/scripts/spec-coverage.sh gate "$COV_SCOPED" --include-context >/tmp/vallorcine/gate-strict.txt 2>/dev/null; then
+    fail "strict gate returned 0 with rows still pending"
+else
+    pending_count=$(grep -cE '^- ' /tmp/vallorcine/gate-strict.txt || echo 0)
+    if [[ "$pending_count" -eq 5 ]]; then
+        pass "strict gate enumerated all 5 rows (2 primary + 3 context)"
+    else
+        fail "strict gate count wrong" "got $pending_count: $(cat /tmp/vallorcine/gate-strict.txt)"
+    fi
+fi
+
+# ── Test 17: report breaks down primary vs context counts ──────────────────
+
+echo ""
+echo "── Test 17: report distinguishes primary vs context in counts"
+
+output=$(bash .claude/scripts/spec-coverage.sh report "$COV_SCOPED" 2>/dev/null)
+if echo "$output" | grep -qE '5 loaded · 0 annotated · 0 waived · 2 pending \(\+ 3 context not gate-enforced; 3 of those still pending\)'; then
+    pass "report shows primary + context breakdown"
+else
+    fail "report breakdown wrong" "got: $output"
+fi
+
+# ── Test 18: legacy bundle (no Primary specs preamble) treats all as primary ─
+
+echo ""
+echo "── Test 18: legacy bundle without Primary specs line — all rows primary"
+
+mkdir -p .feature/legacy
+cat > .feature/legacy/spec-bundle.md << 'BUNDLE'
+# Resolved Context Bundle
+Generated: 2026-04-01T00:00:00Z
+
+## Feature Requirements
+
+# auth.legacy-spec — Legacy
+
+## Requirements
+R1. Legacy req.
+BUNDLE
+
+COV_LEGACY=".feature/legacy/spec-coverage.md"
+bash .claude/scripts/spec-coverage.sh init "$COV_LEGACY" .feature/legacy/spec-bundle.md 2>/dev/null
+# No row should carry the `context` tag — legacy bundles default to primary
+if ! grep -qE '\| context \|' "$COV_LEGACY" \
+   && grep -qE '^\| auth\.legacy-spec \| R1 \| pending \| pending \|  \|' "$COV_LEGACY"; then
+    pass "legacy bundle: every row treated as primary (Notes empty)"
+else
+    fail "legacy bundle should not produce context-tagged rows" "got: $(grep '^|' $COV_LEGACY)"
+fi
+# And the gate should fire on it (default mode, not skipped as context)
+if bash .claude/scripts/spec-coverage.sh gate "$COV_LEGACY" >/dev/null 2>&1; then
+    fail "legacy gate should fail on the lone primary row"
+else
+    pass "legacy gate fires on primary row (no scope filter applied)"
+fi
+
+# ── Test 19: re-init preserves context tag idempotently ─────────────────────
+
+echo ""
+echo "── Test 19: re-init preserves context tag without overwriting waiver notes"
+
+# Apply a waiver on a context row; re-init should not clobber the waiver.
+bash .claude/scripts/spec-coverage.sh waive "$COV_SCOPED" auth.session-lifecycle.R1 \
+    "covered by integration suite" 2>/dev/null
+bash .claude/scripts/spec-coverage.sh init "$COV_SCOPED" .feature/scoped/spec-bundle.md 2>/dev/null
+if grep -qE '^\| auth\.session-lifecycle \| R1 \| waived: covered by integration suite' "$COV_SCOPED"; then
+    pass "re-init preserved waiver on context row"
+else
+    fail "re-init clobbered waiver" "got: $(grep session-lifecycle $COV_SCOPED)"
+fi
+# Other context rows should still carry the `context` tag.
+if grep -qE '^\| billing\.charge-flow \| R1 \| pending \| pending \| context \|' "$COV_SCOPED"; then
+    pass "re-init preserved context tag on un-waived context rows"
+else
+    fail "re-init lost context tag" "got: $(grep charge-flow $COV_SCOPED)"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/scenario-spec-resolve.sh
+++ b/tests/scenario-spec-resolve.sh
@@ -602,6 +602,29 @@ else
     fail "OVERRIDE_DOMAINS should load serialization specs" "got: $v2_override"
 fi
 
+# ── Test 17: bundle preamble lists Primary specs and Context specs ─────────
+# spec-resolve tracks direct-match files vs transitively-pulled specs
+# (parent chain, requires:, sibling expansion). The bundle preamble must
+# emit both lists so spec-coverage can scope its gate to primary specs
+# only — without this preamble, every transitively-pulled context spec
+# becomes a gate obligation and the user has to override or waive
+# whole-bundle scope.
+
+echo ""
+echo "── Test 17: bundle preamble lists Primary specs (direct match)"
+
+# Both serialization specs match this query directly — both should be primary,
+# nothing should be context (no requires/parent chain in this minimal fixture).
+preamble="$(OVERRIDE_DOMAINS="serialization" \
+    bash .claude/scripts/spec-resolve.sh "serialization" 8000 2>/dev/null \
+    | head -15)"
+if echo "$preamble" | grep -qE '^Primary specs: .*serialization\.(yaml-support|json-parsing)' \
+   && echo "$preamble" | grep -qE '^Context specs: none$'; then
+    pass "Primary specs line present; both serialization specs listed; Context specs is 'none'"
+else
+    fail "Primary/Context preamble lines missing or malformed" "got: $preamble"
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

The spec-coverage gate previously fired on every requirement in the resolved bundle, forcing waiver-spam on transitively-pulled context specs (parent chain, `requires:`, sibling expansion) that the WD has no obligation to annotate. Surfaced from jlsm#74 (WD-05) where 136 trailing R-clauses across context specs forced an explicit gate override.

This PR routes the direct-vs-transitive distinction (already tracked internally in `spec-resolve.sh` as `DIRECT_FILES`) through the bundle into the gate.

## What changed

1. **`spec-resolve.sh`** — emit two new preamble lines (`Primary specs:` and `Context specs:`). Both default to `none` when empty.
2. **`spec-coverage.sh init`** — read the preamble; tag non-primary rows with `context` in Notes. Preserves prior waivers across re-init. Legacy bundles (no preamble) treat every spec as primary.
3. **`spec-coverage.sh gate`** — skip `context`-tagged rows by default. New `--include-context` flag for strict whole-bundle audits. Failure message hints at the flag.
4. **`spec-coverage.sh report`** — breaks down primary vs context in the count line when context rows exist.
5. **`/feature-pr` Step 1a doc** — clarifies primary-scope as default, `--include-context` as opt-in for audits.

## Test plan

- [x] `tests/scenario-spec-coverage.sh` — 28/28 (8 new cases: context tagging, primary untagged, default gate scope, gate hint, strict mode, report breakdown, legacy bundle compat, re-init preserves waivers + tags)
- [x] `tests/scenario-spec-resolve.sh` — 22/22 (1 new case: Primary/Context preamble emission)
- [x] Full scenario sweep — 53/53
- [x] `tests/test-install.sh` — 64/64

## Adversarial pass (reviewer-of-self)

- Bundle with title-bearing `# id — title` headers AND Primary preamble: works (both fixes compose).
- `Primary specs: none` (sentinel for no primaries): all rows get `context` tag — gate vacuously passes. Correct.
- ID containing dot or hyphen (`engine.compaction-orchestration`): grep `-qxE` against pipe-alternation matches exact IDs. ✓
- Re-init with prior waivers: `notes_cell` cell is preserved; context stamp only applied when notes are empty or already `context`. ✓
- `update` subcommand preserves Notes column verbatim (line 328-329, pre-existing) — context tag survives `update` runs. ✓
- `waive` preserves Notes column (line 435, pre-existing). ✓
- Legacy table format (no Notes column): awk `$6` is empty, `index("", "context") != 1`, gate treats as primary. Backwards-compatible. ✓
- IDs cannot contain `|`, `,`, or `:` per `SPEC_ID_RE`, so the alternation regex and CSV emission are safe.

## Closes

The kit gap surfaced in jlsm#74's "Spec coverage gate overridden" note. After this lands, jlsm's next `/upgrade-vallorcine` pulls the canonical version, and future WDs gate-check only their primary obligations by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)