### PR TITLE
feat(work): /work-resume + /work-{plan,start} all + parallel safety

### DIFF
--- a/.claude/rules/kit-development.md
+++ b/.claude/rules/kit-development.md
@@ -58,7 +58,7 @@ and are NOT in the MANIFEST.
   /feature-harden, /feature-implement, /feature-refactor, /audit,
   /feature-pr, /feature-retro, /feature-complete, /feature-cleanup,
   /feature-resume, /feature-coordinate,
-  /work, /work-decompose, /work-plan, /work-start, /work-status,
+  /work, /work-decompose, /work-plan, /work-start, /work-status, /work-resume,
   /spec, /spec-author, /spec-write, /spec-verify, /spec-init, /spec-resolve,
   /kb, /research, /architect, /decisions, /capabilities, /curate,
   /project-context, /vallorcine-help, /setup-vallorcine, /upgrade-vallorcine,

--- a/MANIFEST
+++ b/MANIFEST
@@ -42,6 +42,7 @@
 .claude/skills/work/SKILL.md
 .claude/skills/work-decompose/SKILL.md
 .claude/skills/work-status/SKILL.md
+.claude/skills/work-resume/SKILL.md
 .claude/skills/work-start/SKILL.md
 .claude/skills/work-plan/SKILL.md
 .claude/skills/audit/SKILL.md
@@ -132,6 +133,7 @@
 .claude/scripts/lens-registry.txt
 .claude/scripts/work-lib.sh
 .claude/scripts/work-resolve.sh
+.claude/scripts/work-claim.sh
 .claude/scripts/work-validate.sh
 .claude/scripts/work-context.sh
 .claude/scripts/work-finalize.sh

--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ or work groups stall. The result: your 5th feature is faster than your 1st.
 | `/work-decompose "<slug>"` | Break a work group into work definitions with artifact dependencies and shared interface contracts |
 | `/work-status "<slug>"` | Show readiness: what is READY, BLOCKED, IN_PROGRESS, or COMPLETE |
 | `/work-status --all` | Readiness summary across all active work groups |
-| `/work-plan "<slug>" [WD-nn \| next]` | Specify a work definition — domain analysis and spec authoring only |
-| `/work-start "<slug>" [WD-nn \| next]` | Implement a specified work definition — implementation pipeline only |
+| `/work-resume [<slug>]` | Show where a group is and what to run next — cheap entry point after `/clear` |
+| `/work-plan "<slug>" [WD-nn \| next \| all]` | Specify a work definition — domain analysis and spec authoring only. `all` chains through every READY WD sequentially via subagents |
+| `/work-start "<slug>" [WD-nn \| next \| all]` | Implement a specified work definition — implementation pipeline only. `all` chains through every SPECIFIED WD sequentially via subagents (context-economy alternative to `--parallel`) |
 
 ### Audit — adversarial bug finding
 

--- a/install.sh
+++ b/install.sh
@@ -306,6 +306,7 @@ install_file "$SCRIPT_DIR/scripts/spec-backfill-candidates.sh" "$TARGET/.claude/
 install_file "$SCRIPT_DIR/scripts/spec-backfill-log.sh" "$TARGET/.claude/scripts/spec-backfill-log.sh"
 install_file "$SCRIPT_DIR/scripts/work-lib.sh" "$TARGET/.claude/scripts/work-lib.sh"
 install_file "$SCRIPT_DIR/scripts/work-resolve.sh" "$TARGET/.claude/scripts/work-resolve.sh"
+install_file "$SCRIPT_DIR/scripts/work-claim.sh" "$TARGET/.claude/scripts/work-claim.sh"
 install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/work-validate.sh"
 install_file "$SCRIPT_DIR/scripts/work-context.sh" "$TARGET/.claude/scripts/work-context.sh"
 install_file "$SCRIPT_DIR/scripts/work-finalize.sh" "$TARGET/.claude/scripts/work-finalize.sh"
@@ -339,6 +340,7 @@ chmod +x "$TARGET/.claude/scripts/spec-coverage.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-backfill-candidates.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/spec-backfill-log.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-resolve.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/work-claim.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-finalize.sh" 2>/dev/null || true
@@ -428,6 +430,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/spec-backfill-candidates.sh:*)",
       "Bash(bash .claude/scripts/spec-backfill-log.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
+      "Bash(bash .claude/scripts/work-claim.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
@@ -545,6 +548,7 @@ HOOKJSON
       "Bash(bash .claude/scripts/spec-backfill-candidates.sh:*)",
       "Bash(bash .claude/scripts/spec-backfill-log.sh:*)",
       "Bash(bash .claude/scripts/work-resolve.sh:*)",
+      "Bash(bash .claude/scripts/work-claim.sh:*)",
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
@@ -578,6 +582,9 @@ IGNORE_MARKER="# vallorcine runtime files"
 NEW_GITIGNORE_ENTRIES=(
     ".spec/.split-log/"
     ".spec/.split-plan.json"
+    ".work/*/_readiness.json"
+    ".work/*/_decompose-progress.md"
+    ".work/*/.work-resolve.lock"
 )
 
 if [[ "$DIFF_MODE" != "1" ]]; then
@@ -593,6 +600,9 @@ if [[ "$DIFF_MODE" != "1" ]]; then
 .curate/
 .spec/.split-log/
 .spec/.split-plan.json
+.work/*/_readiness.json
+.work/*/_decompose-progress.md
+.work/*/.work-resolve.lock
 __pycache__/
 GITIGNOREBLOCK
         echo -e "  ${GREEN}write${NC} .gitignore  (runtime file entries)"

--- a/scripts/work-claim.sh
+++ b/scripts/work-claim.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# work-claim.sh — atomically transition a WD's status (compare-and-swap)
+# Usage: work-claim.sh <group-slug> <wd-id> <expected-status> <new-status>
+#
+# Reads the current status, asserts it matches <expected-status>, and
+# updates to <new-status>. The whole sequence runs under flock so two
+# parallel sessions cannot both succeed when racing the same transition
+# (e.g., both running /work-plan WD-01 from DRAFT).
+#
+# Exit codes:
+#   0 — claim succeeded (status was <expected>, now <new>)
+#   1 — claim failed: WD not in expected state (someone got there first,
+#       OR the WD was hand-edited between resolver read and claim)
+#   2 — error (WD file not found, lock acquisition failed, etc.)
+#
+# Stdout: "[claim] <wd-id>: <expected> → <new>" on success, error message
+#         on failure (also written to stderr for piped contexts).
+#
+# Shares the .work-resolve.lock file with work-resolve.sh so the manifest
+# sync inside work-resolve cannot interleave with a status mutation
+# inside work-claim. Both ops mutate the group's effective state and
+# must serialize against each other.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/work-lib.sh"
+
+work_require_deps
+
+if [[ $# -lt 4 ]]; then
+  echo "Usage: work-claim.sh <group-slug> <wd-id> <expected-status> <new-status>" >&2
+  echo "  Example: work-claim.sh auth-rewrite WD-01 DRAFT SPECIFYING" >&2
+  exit 2
+fi
+
+GROUP_SLUG="$1"
+WD_ID="$2"
+EXPECTED="$3"
+NEW="$4"
+
+# Validate the new state is one of the known lifecycle states. Catches
+# typos like "SPECIFFIED" before we sed-flip the WD into a state the
+# resolver doesn't recognize.
+case "$NEW" in
+  DRAFT|SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE) ;;
+  *)
+    echo "ERROR: unknown new-status '$NEW' (valid: DRAFT|SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)" >&2
+    exit 2
+    ;;
+esac
+
+WORK_DIR="$(work_find_root)" || exit 2
+GROUP_DIR="$WORK_DIR/$GROUP_SLUG"
+WD_FILE="$GROUP_DIR/$WD_ID.md"
+
+if [[ ! -d "$GROUP_DIR" ]]; then
+  echo "ERROR: Work group not found: $GROUP_SLUG ($GROUP_DIR)" >&2
+  exit 2
+fi
+
+if [[ ! -f "$WD_FILE" ]]; then
+  echo "ERROR: WD file not found: $WD_FILE" >&2
+  exit 2
+fi
+
+# Acquire the shared work-group write lock so this transition cannot
+# interleave with work-resolve.sh or another work-claim invocation.
+if command -v flock >/dev/null 2>&1; then
+  CLAIM_LOCK="$GROUP_DIR/.work-resolve.lock"
+  exec 9>"$CLAIM_LOCK"
+  if ! flock -w 30 9; then
+    echo "ERROR: lock timeout after 30s on $CLAIM_LOCK" >&2
+    exit 2
+  fi
+fi
+
+# Read current status under the lock — this is the canonical "now" view.
+CURRENT=$(work_fm "$WD_FILE" "status")
+
+if [[ "$CURRENT" != "$EXPECTED" ]]; then
+  echo "[claim] CONFLICT: $WD_ID is '$CURRENT', expected '$EXPECTED'" >&2
+  echo "        Another session likely transitioned this WD first." >&2
+  echo "        Re-run /work-resume \"$GROUP_SLUG\" to see the latest state." >&2
+  exit 1
+fi
+
+# Atomic write: sed -i uses tmp + rename internally on most platforms.
+# We're inside the lock, so even if the underlying I/O races on inode
+# state, no other claim or resolver run can be in flight.
+sed -i "s/^status:.*$/status: $NEW/" "$WD_FILE"
+
+echo "[claim] $WD_ID: $EXPECTED → $NEW"
+exit 0

--- a/scripts/work-resolve.sh
+++ b/scripts/work-resolve.sh
@@ -17,6 +17,40 @@ source "$SCRIPT_DIR/work-lib.sh"
 
 work_require_deps
 
+# Track tmp files written by the script so an EXIT trap can clean them up
+# if printf fails partway through (set -e aborts mid-write, mv never runs,
+# orphan .tmp.$$ accumulates). On success, mv has already moved the file
+# so the trap finds nothing to remove.
+WORK_RESOLVE_TMP_FILES=()
+work_resolve_cleanup() {
+  local f
+  for f in "${WORK_RESOLVE_TMP_FILES[@]:-}"; do
+    [[ -n "$f" && -f "$f" ]] && rm -f "$f"
+  done
+  # Return 0 explicitly. The trap's exit code becomes the script's
+  # exit code; a stale [[ -f ]] check evaluating false would otherwise
+  # propagate a 1 from a successful run.
+  return 0
+}
+trap work_resolve_cleanup EXIT
+
+# JSON string escape for the cached readiness file. Strips ASCII control
+# characters (0x00-0x08, 0x0B-0x0C, 0x0E-0x1F) before escape transforms
+# so the resulting JSON is always valid even if a WD title or blocker
+# message contains a stray control byte. Preserves \t (0x09), \n (0x0A),
+# and \r (0x0D), which the function escapes explicitly. Backslash and
+# double-quote are escaped per JSON spec.
+json_escape() {
+  local s
+  s=$(printf '%s' "${1-}" | tr -d '\000-\010\013\014\016-\037')
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\n'/\\n}"
+  printf '%s' "$s"
+}
+
 GROUP_SLUG="${1:-}"
 CURATE_MODE=false
 for arg in "$@"; do
@@ -37,6 +71,30 @@ GROUP_DIR="$WORK_DIR/$GROUP_SLUG"
   echo "  Expected directory: $GROUP_DIR" >&2
   exit 1
 }
+
+# ── Acquire write lock (parallel-session safety) ────────────────────────────
+# Lock the entire compute+write phase, not just the writes. Locking only
+# the writes lets two parallel runs read state at different times, then
+# serialize their writes — the second writer's snapshot may be older than
+# the first writer's, producing a fresh-mtime cache with stale content.
+# The mtime-based freshness check downstream cannot detect this because
+# the cache mtime is the second-writer's write time.
+#
+# Locking the compute phase too forces the second runner to read state
+# AFTER the first runner's writes have landed, so its computation
+# reflects the latest state and its write is correct.
+#
+# flock is not available on macOS by default (util-linux not in the base
+# install). When missing, fall back to no-lock — parallel writes will
+# race the same way they did before this addition.
+
+if command -v flock >/dev/null 2>&1; then
+  WORK_RESOLVE_LOCK="$GROUP_DIR/.work-resolve.lock"
+  exec 9>"$WORK_RESOLVE_LOCK"
+  if ! flock -w 30 9; then
+    echo "[resolve] Warning: lock timeout after 30s — proceeding without lock" >&2
+  fi
+fi
 
 # ── Cross-group dependencies (external_deps on work.md) ─────────────────────
 # Any unmet external dep becomes a uniform blocker applied to all DRAFT and
@@ -383,4 +441,114 @@ if [[ "$CURATE_MODE" == "true" ]]; then
 fi
 
 echo ""
+
+# ── Emit cached readiness JSON ──────────────────────────────────────────────
+# Side-effect: write `.work/<group>/_readiness.json` so downstream skills
+# (`/work-resume`, `/work-status --all`, future parallel-coordination
+# code) can parse structured state without re-running the resolver.
+#
+# This file is gitignored — it's a per-machine cache regenerated whenever
+# any WD frontmatter changes. The atomic .tmp + rename prevents partial
+# reads from a concurrent skill invocation.
+
+READINESS_JSON="$GROUP_DIR/_readiness.json"
+READINESS_TMP="$READINESS_JSON.tmp.$$"
+WORK_RESOLVE_TMP_FILES+=("$READINESS_TMP")
+
+{
+  printf '{\n'
+  printf '  "schema_version": 1,\n'
+  printf '  "generated_at": "%s",\n' "$TIMESTAMP"
+  printf '  "group": "%s",\n' "$(json_escape "$GROUP_SLUG")"
+  printf '  "summary": {\n'
+  printf '    "total": %d,\n'        "$TOTAL_COUNT"
+  printf '    "ready": %d,\n'        "$READY_COUNT"
+  printf '    "blocked": %d,\n'      "$BLOCKED_COUNT"
+  printf '    "specifying": %d,\n'   "$SPECIFYING_COUNT"
+  printf '    "specified": %d,\n'    "$SPECIFIED_COUNT"
+  printf '    "implementing": %d,\n' "$IMPLEMENTING_COUNT"
+  printf '    "complete": %d\n'      "$COMPLETE_COUNT"
+  printf '  },\n'
+
+  # external_blocker as an array of lines (newline-separated input)
+  printf '  "external_blocker": ['
+  if [[ -n "$EXTERNAL_BLOCKER" ]]; then
+    first_eb=true
+    while IFS= read -r eb_line; do
+      [[ -z "$eb_line" ]] && continue
+      if [[ "$first_eb" == "true" ]]; then
+        printf '\n    "%s"' "$(json_escape "$eb_line")"
+        first_eb=false
+      else
+        printf ',\n    "%s"' "$(json_escape "$eb_line")"
+      fi
+    done <<< "$EXTERNAL_BLOCKER"
+    printf '\n  '
+  fi
+  printf '],\n'
+
+  # wds — sorted by status priority (matches the markdown table order)
+  printf '  "wds": ['
+  first_wd=true
+  for status_phase in READY BLOCKED SPECIFYING SPECIFIED IMPLEMENTING COMPLETE; do
+    for wd_id in $(echo "${!WD_STATUS[@]}" | tr ' ' '\n' | sort); do
+      [[ "${WD_STATUS[$wd_id]}" != "$status_phase" ]] && continue
+      if [[ "$first_wd" == "true" ]]; then
+        printf '\n    {\n'
+        first_wd=false
+      else
+        printf ',\n    {\n'
+      fi
+      printf '      "id": "%s",\n'         "$(json_escape "$wd_id")"
+      printf '      "title": "%s",\n'      "$(json_escape "${WD_TITLE[$wd_id]}")"
+      printf '      "status": "%s",\n'     "${WD_STATUS[$wd_id]}"
+      printf '      "deps_count": %d,\n'   "${WD_DEP_COUNT[$wd_id]}"
+
+      # blockers as array of escaped lines
+      printf '      "blockers": ['
+      blockers_raw="${WD_BLOCKERS[$wd_id]:-}"
+      if [[ -n "$blockers_raw" ]]; then
+        first_b=true
+        while IFS= read -r b_line; do
+          [[ -z "$b_line" ]] && continue
+          if [[ "$first_b" == "true" ]]; then
+            printf '\n        "%s"' "$(json_escape "$b_line")"
+            first_b=false
+          else
+            printf ',\n        "%s"' "$(json_escape "$b_line")"
+          fi
+        done <<< "$blockers_raw"
+        printf '\n      '
+      fi
+      printf '],\n'
+
+      # unblocks as array of WD ids
+      printf '      "unblocks": ['
+      unblocks_raw="${WD_UNBLOCKS[$wd_id]:-}"
+      if [[ -n "$unblocks_raw" ]]; then
+        first_u=true
+        IFS=',' read -ra unblock_arr <<< "$unblocks_raw"
+        for ub in "${unblock_arr[@]}"; do
+          if [[ "$first_u" == "true" ]]; then
+            printf '"%s"' "$(json_escape "$ub")"
+            first_u=false
+          else
+            printf ', "%s"' "$(json_escape "$ub")"
+          fi
+        done
+      fi
+      printf ']\n'
+      printf '    }'
+    done
+  done
+  if [[ "$first_wd" == "false" ]]; then
+    printf '\n  '
+  fi
+  printf ']\n'
+  printf '}\n'
+} > "$READINESS_TMP"
+
+mv -f "$READINESS_TMP" "$READINESS_JSON"
+
+echo "[resolve] Wrote $READINESS_JSON" >&2
 echo "[resolve] Done." >&2

--- a/skills/feature-complete/SKILL.md
+++ b/skills/feature-complete/SKILL.md
@@ -109,18 +109,23 @@ If this is a work-group-sourced feature:
 2. Verify the WD frontmatter has `status: COMPLETE` (should already be set
    by feature-refactor Step 6b's `work-finalize.sh` call). If not, set it
    now as a fallback.
-3. Defensive resync of `.work/CLAUDE.md` via the index helper:
+3. Defensive resync of `.work/CLAUDE.md` via the index helper, then
+   refresh the per-group manifest table and readiness JSON cache:
 
    ```bash
    bash .claude/scripts/work-index.sh update "<group-slug>"
+   bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
    ```
 
-   In the normal pipeline this is a **no-op** — `work-finalize.sh`
+   In the normal pipeline these are **no-ops** — `work-finalize.sh`
    already updated the index inside the feature PR, and the helper
-   preserves Last Updated when counts haven't changed. The call exists
+   preserves Last Updated when counts haven't changed. The calls exist
    for features that bypassed the standard pipeline (hand-completed,
    resumed from a partial state, or running on an upgraded install
-   where the prior version didn't yet emit the index update).
+   where the prior version didn't yet emit the index update). The
+   `work-resolve.sh` call additionally ensures the per-group
+   `_readiness.json` cache reflects this WD's `COMPLETE` state so
+   parallel sessions see the new state immediately.
 
    Do not edit `.work/CLAUDE.md` by hand under any circumstances —
    hand-edits drift from filesystem state and break `/work-status`.

--- a/skills/vallorcine-help/SKILL.md
+++ b/skills/vallorcine-help/SKILL.md
@@ -75,8 +75,9 @@ command to run, then explain what it does and what the user can expect.
 - `/work-decompose "<slug>"` — decompose a work group into work definitions with dependency graph
 - `/work-status "<slug>"` — show readiness: what is ready, blocked, or complete
 - `/work-status --all` — readiness summary across all active work groups
-- `/work-plan "<slug>" [WD-nn | next]` — specify a WD (domain analysis + spec authoring only)
-- `/work-start "<slug>" [WD-nn | next]` — start implementing a specified work definition
+- `/work-resume [<slug>]` — show where a work group is and what to run next; cheap to invoke after `/clear`
+- `/work-plan "<slug>" [WD-nn | next | all]` — specify a WD (domain analysis + spec authoring only); `all` runs every READY WD sequentially via subagents
+- `/work-start "<slug>" [WD-nn | next | all]` — start implementing a specified work definition; `all` runs every SPECIFIED WD sequentially via subagents (use over `--parallel` when context economy matters)
 
 **Codebase quality:**
 - `/audit "<entry-point>"` — run the adversarial audit pipeline against shipped code. Finds bugs, proves them with failing tests, fixes the code. Accepts feature slugs, file paths, spec references, or prior audit reports.

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -34,7 +34,98 @@ Run after `/work "<goal>"` has created the work group.
 2. Read `.work/<group-slug>/work.md` — scope, ordering constraints, shared
    interfaces.
 
-3. Read `.work/<group-slug>/manifest.md` — check if WDs already exist.
+3. **Check for an in-flight Phase A/B checkpoint.** Read
+   `.work/<group-slug>/_decompose-progress.md`. If it exists, the previous
+   `/work-decompose` session was interrupted. Read its frontmatter `phase:`
+   field.
+
+   **Orphan-checkpoint signal.** Before prompting, run the same
+   detection rule `/work-resume` Step 2a uses: if any WD in the group
+   has progressed past DRAFT, OR `phase_a_complete_at` is more than
+   7 days old, the checkpoint is most likely an orphan from a session
+   that wrote the WDs but never cleared the file. Use:
+   ```bash
+   find ".work/<group-slug>" -maxdepth 1 -name 'WD-*.md' \
+        -exec grep -lE '^status: (SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' {} + \
+        2>/dev/null | head -1
+   ```
+
+   Surface accordingly:
+
+   **Genuine in-flight checkpoint** (no WDs past DRAFT, recent):
+   ```
+   ───────────────────────────────────────────────
+   🔧 DECOMPOSE · <group-slug>
+   ───────────────────────────────────────────────
+   Found in-flight checkpoint from <phase_a_complete_at>.
+   Last phase: <A | B>
+   ```
+
+   **Probable orphan** (some WD past DRAFT, OR >7 days old):
+   ```
+   ───────────────────────────────────────────────
+   🔧 DECOMPOSE · <group-slug>
+   ───────────────────────────────────────────────
+   Found checkpoint from <phase_a_complete_at>, but the group already has
+   WDs past DRAFT (or the checkpoint is >7 days old).
+
+   This is most likely an orphan from a prior session that wrote the WDs
+   but never cleared the file. Resuming would re-run Phase B against
+   already-decomposed work — discarding is usually the right answer.
+   ```
+
+   Use AskUserQuestion with options:
+     - "Resume from checkpoint" — load Phase A seam analysis and
+       continue at Step 4 (or wherever phase last was). For genuine
+       in-flight checkpoints, mark this **(Recommended)**.
+     - "Discard and re-decompose from scratch" — delete the checkpoint
+       and restart Phase A. For orphan checkpoints, mark this
+       **(Recommended)**.
+     - "Stop"
+
+   On resume:
+
+   a. Parse the checkpoint's "Phase A — Seam Analysis" section into the
+      equivalent of Step 2c's tentative WDs and coordination surfaces,
+      and "Phase B — Settled" into the list of already-settled surfaces.
+
+   b. **Display the parsed state back to the user before continuing.**
+      Markdown parsing by an LLM is fragile — the user must confirm the
+      interpretation matches what they remember. Show:
+      ```
+      Resumed Phase A state from checkpoint:
+
+      Tentative WDs (<N>):
+        WD-01 — <title>
+        ...
+
+      Coordination surfaces (<settled>/<total> settled):
+        1. <kind> · <subject>           settled: <yes|no>
+        2. ...
+
+      Existing artifacts that apply:
+        - <list>
+
+      Phase B will continue with the <unsettled> remaining surface(s).
+      ```
+
+      Then use AskUserQuestion with options:
+        - "Looks right — continue Phase B" (Recommended)
+        - "Restart Phase A from scratch" — discards checkpoint and re-derives seams
+        - "Stop"
+
+      If "Restart": delete the checkpoint and continue to Phase A as a
+      fresh run. If "Continue": jump to Step 4 (Phase B). When iterating
+      through surfaces in Step 4, **only process surfaces whose `Settled`
+      column is `no` in the loaded checkpoint**. Settled surfaces are
+      already done — re-dispatching `/architect` or `/spec-author` for
+      them would create duplicate ADRs/specs (or fight existing ones,
+      depending on those skills' idempotency).
+
+   On discard: `rm .work/<group-slug>/_decompose-progress.md` and continue
+   to step 4 below.
+
+4. Read `.work/<group-slug>/manifest.md` — check if WDs already exist.
    If WDs exist:
    ```
    ───────────────────────────────────────────────
@@ -46,10 +137,11 @@ Run after `/work "<goal>"` has created the work group.
      - "Add more work definitions"
      - "Replace all and re-decompose"
      - "Stop"
-   If "Replace all": delete existing WD-*.md files and clear the manifest table.
+   If "Replace all": delete existing WD-*.md files and clear the manifest
+   table. Also delete any `_decompose-progress.md` from a prior session.
    If "Add more": proceed to Step 2 with existing WDs as context.
 
-Display opening header:
+Display opening header (if not already shown above):
 ```
 ───────────────────────────────────────────────
 🔧 DECOMPOSE · <group-slug>
@@ -235,6 +327,48 @@ Draft:
   coordination surface to settle here. Record it; Phase C will add the
   frontmatter. See the work.md template in `/work` for shape.
 
+### 2d — Write the Phase A checkpoint
+
+Persist the seam analysis to `.work/<group-slug>/_decompose-progress.md`
+**before** showing it to the user. The checkpoint is what survives
+`/clear`, a crash, or a context switch — without it, an interrupted
+Phase B forces the user to redo seam-finding from scratch.
+
+Write the file with this shape (atomically — write `.tmp` then rename):
+
+```yaml
+---
+group: <group-slug>
+phase: A
+phase_a_complete_at: <ISO-8601 UTC timestamp>
+phase_b_complete_at: null
+---
+
+## Phase A — Seam Analysis
+
+### Tentative WDs
+- WD-01 — <title> — <one-line description>
+- WD-02 — <title> — <one-line description>
+...
+
+### Coordination surfaces
+| # | Kind | Subject | Why cross-WD | Settled |
+|---|------|---------|--------------|---------|
+| 1 | <kind> | <subject> | <reason> | no |
+...
+
+### Existing artifacts that apply
+- <list>
+
+### Research dispatched
+- <list of /research subagent invocations and resulting KB entries>
+
+## Phase B — Settled
+(empty — Phase B has not yet started)
+```
+
+This file is gitignored (per-machine in-flight state). Do not commit it.
+
 ---
 
 ## Step 3 — Present Phase A output
@@ -393,6 +527,17 @@ As each surface settles, record the artifacts produced:
 - Interface-contract paths
 
 These become the `artifact_deps:` WDs will reference in Step 6.
+
+**Update the checkpoint after each surface settles.** Re-write
+`.work/<group-slug>/_decompose-progress.md` with:
+- `phase: B` in the frontmatter
+- A row appended to the "## Phase B — Settled" section recording the
+  surface number, kind, and the artifact produced (ADR slug or spec id)
+- Update the "## Phase A — Seam Analysis" coordination surfaces table to
+  flip the matching row's `Settled` column from `no` to `yes`
+
+Atomic write each time (`.tmp` then rename). This way, a crash mid-Phase-B
+loses at most the in-flight surface, not all prior settlements.
 
 ---
 
@@ -591,6 +736,17 @@ bash .claude/scripts/work-index.sh update "<group-slug>"
 
 Do not hand-edit the WDs count or any column in `.work/CLAUDE.md`.
 
+### Populate the readiness cache
+
+Run the resolver once now so `_readiness.json` reflects the freshly-written
+WDs. This makes `/work-resume` cheap on the first invocation after a
+`/clear` and gives parallel sessions immediate visibility into the new
+WDs:
+
+```bash
+bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
+```
+
 ### Run invariant check
 
 ```bash
@@ -606,6 +762,20 @@ unsettled references and offer options:
 
 Decomposition is not complete until the invariant passes or is
 explicitly waived.
+
+### Clear the Phase A/B checkpoint
+
+Once the manifest is updated and the invariant check passes (or is
+explicitly waived), delete the in-flight checkpoint:
+
+```bash
+rm -f .work/<group-slug>/_decompose-progress.md
+```
+
+The decomposition is now durable — WD frontmatter and the manifest are
+the source of truth. Leaving the checkpoint behind would cause the next
+`/work-decompose` invocation to misread the group as "in-flight" and
+offer to resume an already-finished decomposition.
 
 ---
 

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -1,9 +1,9 @@
 ---
 description: "Specify a work definition — produce specs and ADRs without implementation"
-argument-hint: "<group-slug> [WD-nn | next]"
+argument-hint: "<group-slug> [WD-nn | next | all]"
 ---
 
-# /work-plan "<group-slug>" [WD-nn | next]
+# /work-plan "<group-slug>" [WD-nn | next | all]
 
 Specification-only pipeline for a work definition. Creates a feature directory,
 runs domain analysis and spec authoring, then stops. No implementation stages.
@@ -19,8 +19,23 @@ For implementation after specification is complete, use `/work-start`.
 - `<group-slug>` — the work group to draw from
 - `WD-nn` — specify a particular work definition (e.g., WD-01)
 - `next` — auto-select the highest-value READY work definition
+- `all` — sequentially specify every READY WD (one subagent per WD,
+  waits for each to finish before starting the next). See "Sequential
+  all mode" below. **Use this for context-economy on multi-WD groups —
+  the parent stays small while each subagent gets a fresh context.**
 
 If no WD argument is provided, defaults to `next`.
+
+**A note on `all` and arbitration prompts.** `/spec-author` Pass 2
+surfaces falsification findings that require user decisions
+(arbitration). In `all` mode, those `AskUserQuestion` calls surface to
+you normally — the coordinator pauses while you answer, then continues.
+This is a feature, not a bug: spec quality depends on you weighing in
+on design intent, and the coordinator handles the rest (state, dispatch,
+ordering). If you want fire-and-forget at the cost of accepting auto-
+defaults, that's NOT this mode — it would require a future
+`--autonomous` flag and `/spec-author` learning the same
+`execution_strategy` mode-gate that test/implement/refactor already use.
 
 ---
 
@@ -55,6 +70,12 @@ Display opening header:
 ---
 
 ## Step 3 — Select work definition
+
+### If `all` is the argument:
+
+Skip the single-WD selection logic and go to the **Sequential all
+mode** section below. The rest of Step 3's single-WD paths (WD-nn /
+next) do not apply.
 
 ### If specific WD (e.g., WD-01):
 
@@ -217,14 +238,28 @@ Stage Completion table — specification mode only:
 | Domains | pending |
 | Spec Authoring | pending |
 
-### 4c — Update WD status
+### 4c — Claim the WD (DRAFT → SPECIFYING)
 
-Set the WD status with `sed` so the file does not need to be Read first
-(matches the pattern used in `scripts/work-finalize.sh`):
+Use `work-claim.sh` for the status transition rather than a direct
+`sed`. The script does an atomic compare-and-swap under flock, so two
+parallel sessions racing to plan the same WD cannot both succeed —
+the second one gets a CONFLICT and bails out.
 
 ```bash
-sed -i "s/^status:.*$/status: SPECIFYING/" .work/<group-slug>/WD-<nn>.md
+if ! bash .claude/scripts/work-claim.sh "<group-slug>" "WD-<nn>" DRAFT SPECIFYING; then
+  echo ""
+  echo "Another session is already planning this WD. Run:"
+  echo "  /work-resume \"<group-slug>\""
+  echo "to see the current state."
+  exit 1
+fi
 ```
+
+Why claim instead of raw `sed`: the resolver run at Step 2 is a snapshot
+that's stale by the time we reach Step 4c. Without CAS, two terminals
+that both saw DRAFT at Step 2 will both `sed`-flip to SPECIFYING and
+both proceed to author specs, racing on writes. The claim script
+re-reads status under the lock and refuses if it has changed.
 
 The manifest table is automatically synced by `work-resolve.sh` — do not
 update it manually.
@@ -309,11 +344,23 @@ Run /spec-author "<feature-id>" "<title>" to complete adversarial review.
 ```
 Stop and wait for the user to resolve.
 
-**If all specs are APPROVED:** update the WD with `sed` (no Read required;
-matches the pattern used in `scripts/work-finalize.sh`):
+**If all specs are APPROVED:** transition the WD to SPECIFIED via
+`work-claim.sh` (atomic CAS — see Step 4c for the rationale):
 
 ```bash
-sed -i "s/^status:.*$/status: SPECIFIED/" .work/<group-slug>/WD-<nn>.md
+if ! bash .claude/scripts/work-claim.sh "<group-slug>" "WD-<nn>" SPECIFYING SPECIFIED; then
+  echo "WD-<nn> is no longer in SPECIFYING — refusing to mark SPECIFIED."
+  echo "Run /work-resume \"<group-slug>\" to see the current state."
+  exit 1
+fi
+```
+
+Then refresh the manifest table and the readiness JSON cache so other
+skills (and parallel sessions) see the new state without waiting for the
+next `/work-status` call:
+
+```bash
+bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
 ```
 
 The manifest table is automatically synced by `work-resolve.sh` — do not
@@ -334,6 +381,167 @@ The WD is ready for implementation:
   /work-start "<group-slug>" WD-<nn>
 ───────────────────────────────────────────────
 ```
+
+---
+
+## Sequential all mode
+
+When invoked with `all`, `/work-plan` runs every READY work definition
+in the group **one at a time**, dispatching a separate sub-agent for
+each. The coordinator (this skill, in the user's conversation) only
+carries one-line summaries of completed WDs — the heavy spec-authoring
+work happens in each sub-agent's isolated context.
+
+This is the structural automation of the
+`/clear` + `/work-resume` + `/work-plan WD-N` rhythm: same per-WD
+context economy, same dependency-respecting selection, no `/clear` or
+`/work-resume` typed by the user during the run.
+
+### Arbitration prompts during `all`
+
+`/spec-author` Pass 2 surfaces falsification findings that require the
+user's decision (which findings to apply, which to drop, etc.). In the
+sequential-all flow, each sub-agent's `AskUserQuestion` calls **surface
+to the user normally** — the coordinator pauses while the user
+answers, then continues. This preserves spec quality.
+
+If you need fire-and-forget behaviour at the cost of accepting auto-
+defaults for arbitration, that is NOT this mode. It would require a
+future `--autonomous` flag plus `/spec-author` learning the
+`execution_strategy` mode-gate that test/implement/refactor already
+use. For now: `all` is "automated coordinator, manual arbitration."
+
+### Sequential-all flow
+
+Replace Steps 3–6 with this block when `all` is the argument.
+
+1. **Initial enumeration.** Read `_readiness.json` (refreshed by the
+   resolver call in Step 2) and collect every WD whose status is
+   `READY` (DRAFT with deps met). If zero, report and stop:
+   ```
+   No READY work definitions in '<group-slug>' — every DRAFT WD is
+   either BLOCKED on artifact dependencies or already past DRAFT.
+   Run /work-status "<group-slug>" to see what to unblock.
+   ```
+
+2. **Show the plan.** Sort the READY WDs by unblocking value (most
+   downstream dependents first), tie-breaking by fewer artifact
+   dependencies. Display:
+   ```
+   ── Sequential plan ────────────────────────────
+   Group: <group-slug>
+   READY WDs: <N>
+   Initial order (by unblocking value):
+     1. WD-<nn> — <title>  (unblocks: <list>)
+     2. WD-<nn> — ...
+   Note 1: Pass 2 falsification arbitration during /spec-author will
+   surface here — you'll be prompted for design decisions on each
+   WD's findings.
+   Note 2: a WD's spec authoring may unblock a sibling that's BLOCKED
+   on a spec dep — the loop re-enumerates between iterations, so the
+   run may include WDs not in this initial list.
+   ───────────────────────────────────────────────
+   ```
+   Use AskUserQuestion to confirm:
+     - "Plan sequentially" (Recommended)
+     - "Plan first 3 only" (or another cap)
+     - "Stop"
+
+3. **Iterate until no eligible WD remains.** Loop:
+
+   a. **Re-enumerate.** Run `bash .claude/scripts/work-resolve.sh
+      "<group-slug>" >/dev/null` then re-read `_readiness.json`. Re-
+      enumerating is mandatory — finishing a WD in iteration N may
+      satisfy a spec dep that promotes a sibling from BLOCKED to
+      READY in iteration N+1.
+
+   b. **Pick the next.** From the current READY list, pick the WD with
+      the highest unblocking value. Skip WDs the run has already
+      dispatched (track in a dispatched set). If none remain, exit.
+
+   c. **Honor the cap** if the user set one in Step 2.
+
+   d. **Dispatch ONE sub-agent that recursively invokes the
+      single-WD `/work-plan`.** Do NOT hand-roll the feature creation,
+      claim, and spec-authoring sequence in this coordinator — the
+      single-WD `/work-plan` flow already does it correctly, including
+      the SPECIFYING → SPECIFIED transition at its Step 6. Use this
+      prompt verbatim:
+      ```
+      You are the sequential planner for <group-slug> / <wd-id>.
+
+      Invoke /work-plan "<group-slug>" <wd-id>. The single-WD flow
+      will create the feature directory, claim the WD via
+      work-claim.sh (DRAFT → SPECIFYING), run /feature-domains and
+      spec authoring, and transition to SPECIFIED at Step 6 once
+      every produced spec is APPROVED.
+
+      Do NOT pre-set execution_strategy to balanced or speed for this
+      run. /spec-author Pass 2 must surface its arbitration prompts
+      to the user — that's the whole point of sequential `all` for
+      planning. Spec quality depends on user weighing in on
+      falsification findings.
+
+      Distinguish two failure modes in your final return:
+
+      - If the /work-plan invocation reports a `[claim] CONFLICT:`
+        message from work-claim.sh (another terminal advanced the WD),
+        return:
+          "<group-slug>--<wd-id>: SKIPPED — claim conflict"
+
+      - Any other failure (feature directory creation, status.md
+        write error, /spec-author falsification stuck, manifest write
+        failure, unexpected exception) is an ERROR — return:
+          "<group-slug>--<wd-id>: ERROR — <one-line detail>"
+
+      Successful runs return:
+        "<group-slug>--<wd-id>: <COMPLETE | STOPPED_AT_<stage>> — <detail>"
+
+      Return exactly ONE line and nothing else after.
+      ```
+
+   e. **Wait for the sub-agent to return.**
+
+   f. **Aggregate.** Append the sub-agent's summary to results and
+      display:
+      ```
+      [<n>/<eligible>] <group-slug>--<wd-id>: <STATUS> — <detail>
+      ```
+
+   g. **Stop conditions.** Continue unless:
+      - The sub-agent returned `ERROR` or `STOPPED_AT_<stage>` AND
+        the user opts to halt (AskUserQuestion).
+      - SKIPPED returns are silent — log and continue.
+
+4. **Final aggregate.** When the loop exits:
+   ```
+   ── Sequential plan complete · <group-slug> ────
+   Dispatched: <N>
+   Specified: <n>
+   Stopped mid-pipeline: <list with stage>
+   Errored: <list with detail>
+   Skipped (claim conflict): <list>
+   ───────────────────────────────────────────────
+
+   Next steps:
+     <if any specified:> /work-start "<group-slug>" all — implement them sequentially
+     <if any stopped/errored:> /feature-resume "<group>--<wd-id>" — inspect each
+     <if some still BLOCKED:> /work-status "<group-slug>" — see what's left
+   ```
+
+### Concurrency caveats
+
+Same as `/work-start <group> all`:
+- Another terminal claiming the same WD → CONFLICT exit, sub-agent
+  returns SKIPPED, coordinator continues.
+- Status drift mid-run → re-enumeration at iteration N+1 filters
+  ineligible WDs before dispatch.
+
+Additionally for `/work-plan all`:
+- **`/spec-author` Pass 2 arbitration surfaces to the user.** This is
+  by design (preserves spec quality). The coordinator pauses while the
+  user answers each finding. Account for this when planning long runs
+  — you'll be in the loop for design decisions, not fire-and-forget.
 
 ---
 

--- a/skills/work-resume/SKILL.md
+++ b/skills/work-resume/SKILL.md
@@ -1,0 +1,352 @@
+---
+description: "Show where a work group is and what to run next — entry point after /clear or interruption"
+argument-hint: "[group-slug] [--list]"
+---
+
+# /work-resume "[group-slug]" [--list]
+
+Tells you where a work group is and what to run next.
+Use this after `/clear`, a crash, a context switch, or when picking up a
+group on a different machine.
+
+This skill is the work-layer counterpart to `/feature-resume`. It is
+designed to be cheap — it reads structured state files and a cached
+readiness summary instead of running the full resolver every time, so
+you can call it after `/clear` without re-loading the entire group's
+context into the conversation.
+
+**Modes:**
+- (no arg, or `--list`) — list every active work group with a one-line summary
+- `<group-slug>` — show that group's current state and the next command
+
+`/work-resume` differs from `/work-status`:
+- `/work-status` runs the full resolver and prints the complete readiness
+  table (heavy output suited to "what's the state of everything?")
+- `/work-resume` reads the cached `_readiness.json` and the
+  `_decompose-progress.md` checkpoint to give a thin "where am I and what
+  do I run next" answer (cheap output suited to "I just cleared context")
+
+If the cache is missing or stale, `/work-resume` runs the resolver once
+to refresh it. Subsequent calls in the same session re-read the cache.
+
+---
+
+## Step 0 — List mode (no arg or `--list`)
+
+If no group slug was given, or `--list` was passed:
+
+1. Enumerate directories under `.work/` (excluding `_archive`, `_refs`).
+2. For each group, read `.work/<group>/work.md` for the goal and
+   `.work/<group>/_readiness.json` for the cached summary. Apply the
+   same mtime freshness check as Step 3 — if the cache is missing or
+   any WD-*.md / work.md is newer than the cache, run
+   `bash .claude/scripts/work-resolve.sh <group> >/dev/null` to refresh.
+3. **Track the refresh count.** Before the per-group loop, set
+   `refreshed=0`. Increment it whenever you run the resolver for a
+   group. After the loop, if `refreshed > 0` print this single
+   diagnostic line BELOW the active-groups table (printing it before
+   the table would require buffering output without knowing the count
+   yet — printing it after lets the LLM emit the table first):
+   ```
+   (refreshed N stale readiness cache(s); first /work-resume after
+    state mutations always pays this cost)
+   ```
+   This makes the cost visible — list-mode is "cheap" only when caches
+   are already fresh; otherwise it pays for N resolver runs and the
+   user deserves to know.
+4. Display:
+
+```
+───────────────────────────────────────────────
+📋 ACTIVE WORK GROUPS
+───────────────────────────────────────────────
+  <group-slug>      <ready>R / <blocked>B / <specifying>S / <implementing>I / <complete>C of <total>     <goal one-liner>
+  <group-slug>      <ready>R / <blocked>B / <specifying>S / <implementing>I / <complete>C of <total>     <goal one-liner>
+───────────────────────────────────────────────
+Pick one: /work-resume "<group-slug>"
+```
+
+If no work groups exist:
+```
+No active work groups. Create one with:
+  /work "<goal>"
+```
+
+Stop. Do not continue to other steps.
+
+---
+
+## Step 1 — Validate group
+
+Check `.work/<group-slug>/` exists. If not:
+```
+Work group '<group-slug>' not found.
+
+Available groups:
+```
+List directories under `.work/` (one per line). Stop.
+
+Read `.work/<group-slug>/work.md` for the goal description.
+
+Display opening header:
+```
+───────────────────────────────────────────────
+🔄 WORK RESUME · <group-slug>
+───────────────────────────────────────────────
+Goal: <goal from work.md>
+```
+
+---
+
+## Step 2 — Detect in-flight decompose checkpoint
+
+Check `.work/<group-slug>/_decompose-progress.md`. If it exists, read
+its frontmatter `phase:` field and `phase_a_complete_at:` timestamp.
+
+### Step 2a — Detect orphan checkpoints
+
+A "checkpoint exists" signal isn't always meaningful. Three cases need
+distinct handling:
+
+1. **Genuinely in-flight** — the decomposition needs resuming.
+
+2. **Orphan (deletion at end of Phase C didn't run)** — kit bug, manual
+   ctrl-C between manifest write and checkpoint clear, or external
+   interruption. The decomposition is complete on disk but the
+   checkpoint was never cleared.
+
+3. **Stale-by-age** — a checkpoint that's been sitting for over a week.
+   Even if the group hasn't moved past DRAFT, the user has clearly
+   abandoned this attempt; offer recovery.
+
+**Detection rule**: classify the checkpoint as an orphan if EITHER:
+
+- (a) **At least one WD has progressed past DRAFT.** Use `find ... -exec`
+  rather than piping to `xargs` — `xargs` without `-r` hangs on macOS
+  when the input is empty:
+  ```bash
+  find ".work/<group-slug>" -maxdepth 1 -name 'WD-*.md' \
+       -exec grep -lE '^status: (SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' {} + \
+       2>/dev/null | head -1
+  ```
+  If the command prints any path, treat as orphan. Phase C must have run
+  (it's what writes WD-NN.md files) for any WD to exist past DRAFT; the
+  checkpoint is therefore an orphan that survived a missed cleanup.
+- (b) `phase_a_complete_at` from the checkpoint frontmatter is more than
+  7 days old — stale-by-age.
+
+WD-count matching (the original heuristic) was fragile because users can
+add or remove WDs by hand, and Phase A's "tentative" list isn't a
+reliable count baseline. "Any WD past DRAFT" is a much stronger signal
+because no manual workflow takes a WD past DRAFT without `/work-plan` or
+`/work-start` having run, both of which presuppose that decomposition
+is complete.
+
+For an **orphan**:
+```
+⚠ /work-decompose checkpoint found, but the group looks fully decomposed
+  (<N> WDs in manifest, checkpoint last updated <date>).
+
+  This is most likely an orphan from a prior session that ended
+  between writing the WDs and clearing the checkpoint.
+```
+Use AskUserQuestion with options:
+  - "Delete the orphan and continue" (Recommended)
+  - "Treat as in-flight and resume /work-decompose"
+  - "Stop"
+
+If "Delete and continue": `rm .work/<group-slug>/_decompose-progress.md`
+and continue to Step 3 readiness routing.
+If "Treat as in-flight": fall through to the in-flight surface below.
+If "Stop": exit.
+
+For a genuinely **in-flight** checkpoint:
+
+```
+⚠ /work-decompose was interrupted in Phase <A|B>.
+  Checkpoint:    .work/<group-slug>/_decompose-progress.md
+  Last updated:  <timestamp from frontmatter>
+
+To resume:
+  /work-decompose "<group-slug>"
+  → the skill will detect the checkpoint, summarize Phase A's seam
+    analysis, and continue from where it left off.
+```
+
+Stop. Do not continue to readiness routing — finishing decomposition is
+the prerequisite, and showing READY/BLOCKED tables before WDs are
+finalized is misleading.
+
+---
+
+## Step 3 — Refresh readiness cache (if needed)
+
+Decide whether the cache is fresh with this single check (mtime-based,
+no JSON parsing needed):
+
+```bash
+CACHE=".work/<group-slug>/_readiness.json"
+if [[ ! -f "$CACHE" ]] || \
+   find ".work/<group-slug>" -maxdepth 1 \
+        \( -name 'WD-*.md' -o -name 'work.md' \) \
+        -newer "$CACHE" -print -quit | grep -q .; then
+  bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
+fi
+```
+
+The `find ... -newer` test prints any WD or work.md whose mtime exceeds
+the cache's mtime; piping to `grep -q .` short-circuits on the first
+hit. When the cache is fresh, `find` finds nothing and we skip the
+resolver entirely — that's the cheap-path that makes `/work-resume`
+worth invoking after a `/clear`.
+
+After the conditional refresh, read `.work/<group-slug>/_readiness.json`
+to render the rest of this skill's output.
+
+**If JSON parse fails AFTER a fresh resolver run**, this is a real
+defect — either `work-resolve.sh` is broken or the cache file was
+clobbered. Do NOT silently fall back to parsing the markdown report.
+Surface the error explicitly:
+
+```
+ERROR: Could not parse .work/<group-slug>/_readiness.json after a
+       fresh resolver run. The cache may be corrupt.
+
+       Diagnostics:
+         <one-line python json.load error>
+
+       Recovery:
+         rm .work/<group-slug>/_readiness.json
+         bash .claude/scripts/work-resolve.sh "<group-slug>"
+       (and file an issue if it recurs.)
+```
+
+Stop after surfacing. A silent fallback would mask the underlying bug
+and let downstream skills consume stale or wrong state.
+
+---
+
+## Step 4 — Display compact status
+
+From the parsed JSON `summary` and `wds` array, render:
+
+```
+SUMMARY
+  <total> WDs · <ready> ready · <blocked> blocked · <specifying> specifying · <specified> specified · <implementing> implementing · <complete> complete
+
+ACTIVE
+  <only show WDs whose status is SPECIFYING, IMPLEMENTING, or BLOCKED>
+  WD-<nn>  <title>                  <STATUS>   <one-line context — for BLOCKED, the first blocker; for SPECIFYING/IMPLEMENTING, " feature: <slug>">
+  ...
+
+NEXT UP (if any READY or SPECIFIED WDs)
+  <first 3 READY or SPECIFIED WDs by deps_count ascending, unblocks descending>
+  WD-<nn>  <title>                  <READY|SPECIFIED>
+```
+
+Skip any section with no rows. If every WD is COMPLETE, replace ACTIVE
+and NEXT UP with:
+```
+✓ All work definitions complete.
+```
+
+Do NOT print the full status table — that's `/work-status`'s job. The
+goal here is to keep this skill's output under ~30 lines so it can be
+re-invoked cheaply after `/clear`.
+
+---
+
+## Step 5 — Determine the next command
+
+Apply this routing in order — first match wins:
+
+1. **Any `_decompose-progress.md` exists** → already handled in Step 2.
+
+2. **Group has zero WDs** (total == 0) → decomposition has not run yet.
+   Suggest:
+   ```
+   NEXT STEP
+     /work-decompose "<group-slug>"
+     This group has no work definitions yet — decompose it first.
+   ```
+
+3. **Any WD is SPECIFYING with a `.feature/<group>--<wd-slug>/` dir
+   present** → user has an in-flight specification feature. Suggest:
+   ```
+   NEXT STEP
+     /feature-resume "<group>--<wd-slug>"
+     <one sentence: "WD-<nn> is mid-spec — resume the specification feature">
+   ```
+   When more than one WD is SPECIFYING, pick the one whose
+   `.feature/<group>--<wd-slug>/status.md` was modified most recently
+   (active work tends to leave the freshest status mtime). Fall back to
+   the WD-NN.md mtime only when no matching `.feature/` directory
+   exists locally — in that case priority 5 already handled it.
+
+4. **Any WD is IMPLEMENTING with a `.feature/<group>--<wd-slug>/` dir
+   present** → user has an in-flight implementation feature. Suggest:
+   ```
+   NEXT STEP
+     /feature-resume "<group>--<wd-slug>"
+     <one sentence: "WD-<nn> is mid-implementation — resume it">
+   ```
+
+5. **Any WD is SPECIFYING/IMPLEMENTING but the matching `.feature/`
+   directory does NOT exist on this machine** → the in-flight feature
+   was authored on another machine or in a clobbered workspace. Surface:
+   ```
+   NOTE: WD-<nn> is <STATUS> but .feature/<slug>/ is not present here.
+         The feature was likely authored on another machine. Check git
+         to see if a feature PR exists; otherwise, treat the WD as
+         needing fresh planning.
+   ```
+   Do not auto-route — let the user decide.
+
+6. **Any WD is SPECIFIED** → planning is done, ready to implement.
+   Suggest:
+   ```
+   NEXT STEP
+     /work-start "<group-slug>" next
+     <one sentence: "<n> WD(s) planned and ready to implement">
+   ```
+
+7. **Any WD is READY** → planning is the next step. Suggest:
+   ```
+   NEXT STEP
+     /work-plan "<group-slug>" next
+     <one sentence: "<n> WD(s) ready to plan">
+   ```
+
+8. **All remaining WDs are BLOCKED** → list the unique unblock actions
+   (from `wds[*].blockers`). Group by blocker type:
+   ```
+   NEXT STEP — unblock to proceed
+     /spec-author "<id>" "<title>"   — for <list of WDs blocked on it>
+     /architect "<problem>"          — for <list of WDs blocked on it>
+     /research "<subject>"           — for <list of WDs blocked on it>
+   ```
+
+9. **All WDs are COMPLETE** → display:
+   ```
+   NEXT STEP
+     This group is finished. Run /feature-retro on individual features
+     if you haven't already, or /work "<goal>" to start a new group.
+   ```
+
+Stop after displaying the NEXT STEP block. Do not auto-invoke — the
+caller may want to switch groups or take a different path.
+
+---
+
+## Implementation notes
+
+- **No subagent dispatch.** This skill is intentionally lightweight. It
+  reads files and renders text. Heavy lifting is delegated to
+  `/work-status`, `/work-plan`, `/work-start`, and `/feature-resume`.
+- **JSON-first.** Always prefer `_readiness.json` over re-running the
+  resolver. The cache is regenerated whenever any WD frontmatter
+  changes, so staleness is bounded by file mtime.
+- **Idempotent.** Running `/work-resume` twice in a row reads the cache
+  twice with no side effects.
+- **Survives `/clear`.** All state lives in files. The skill needs no
+  conversation context to operate.

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -1,9 +1,9 @@
 ---
 description: "Start implementing a specified work definition — implementation pipeline only"
-argument-hint: "<group-slug> [WD-nn | next | --parallel [N]]"
+argument-hint: "<group-slug> [WD-nn | next | all | --parallel [N]]"
 ---
 
-# /work-start "<group-slug>" [WD-nn | next | --parallel [N]]
+# /work-start "<group-slug>" [WD-nn | next | all | --parallel [N]]
 
 Bridges a work definition from a work group into the implementation pipeline.
 Creates a `.feature/` directory and hands off to planning, testing, and
@@ -14,10 +14,29 @@ interface contracts), use `/work-plan` instead.
 - `<group-slug>` — the work group to draw from
 - `WD-nn` — start a specific work definition (e.g., WD-01)
 - `next` — auto-select the highest-value READY work definition
+- `all` — sequentially run every SPECIFIED WD (one subagent per WD,
+  waits for each to finish before starting the next). See "Sequential
+  all mode" below. **Use this for context-economy on multi-WD groups —
+  the parent stays small while each subagent gets a fresh context.**
 - `--parallel [N]` — start every SPECIFIED WD concurrently (optionally
   cap at N concurrent sub-agents). See "Parallel mode" section below.
 
 If no WD argument is provided, defaults to `next`.
+
+**Choosing between `all` and `--parallel`:**
+
+Both delegate to the same single-WD `/work-start` flow, so quality at
+arbitration boundaries is identical — both modes set
+`automation_mode: autonomous` for the dispatched sub-agents (escalations
+surface, routine choices auto-default).
+
+| | `all` (sequential) | `--parallel` |
+|---|---|---|
+| Subagents in flight | 1 at a time | N concurrent |
+| Wall clock | N × per-WD time | ~1 × per-WD time |
+| Token cost | Sum of per-WD costs | Sum (same total) |
+| Resource contention (DB, ports, manifest) | None | Possible |
+| Best for | Context economy, isolation | Wall-clock velocity |
 
 ---
 
@@ -52,6 +71,12 @@ Display opening header:
 ---
 
 ## Step 3 — Select work definition
+
+### If `all` is the argument:
+
+Skip the single-WD selection logic and go to the **Sequential all
+mode** section below. The rest of Step 3's single-WD paths (WD-nn /
+next) do not apply.
 
 ### If `--parallel` flag is present:
 
@@ -225,13 +250,26 @@ Stage Completion table — implementation stages only:
 | Implementation | pending |
 | Refactor | pending |
 
-### 4d — Update WD status
+### 4d — Claim the WD (SPECIFIED → IMPLEMENTING)
 
-Set the WD status with `sed` so the file does not need to be Read first
-(matches the pattern used in `scripts/work-finalize.sh`):
+Use `work-claim.sh` for the status transition. It does an atomic
+compare-and-swap under flock so two parallel sessions racing to start
+implementation on the same WD cannot both succeed — the second one
+gets a CONFLICT and bails out.
 
 ```bash
-sed -i "s/^status:.*$/status: IMPLEMENTING/" .work/<group-slug>/WD-<nn>.md
+if ! bash .claude/scripts/work-claim.sh "<group-slug>" "WD-<nn>" SPECIFIED IMPLEMENTING; then
+  echo ""
+  echo "Another session has already started this WD. Run:"
+  echo "  /work-resume \"<group-slug>\""
+  echo "to see what to do next (likely: /feature-resume \"<group>--<wd-slug>\")."
+  exit 1
+fi
+
+# Refresh the manifest table and readiness JSON cache so other skills
+# and parallel sessions see the new state without waiting for the next
+# /work-status call.
+bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
 ```
 
 The manifest table is automatically synced by `work-resolve.sh` — do not
@@ -249,6 +287,187 @@ Proceeding directly to work planning — specs and ADRs will be loaded
 from the resolved context.
 ```
 Invoke `/feature-plan "<slug>"`.
+
+---
+
+## Sequential all mode
+
+When invoked with `all`, `/work-start` runs every SPECIFIED work
+definition in the group **one at a time**, dispatching a separate
+sub-agent that executes the existing single-WD `/work-start` flow for
+each. The coordinator (this skill, in the user's conversation) carries
+only the dispatch state and one-line summaries of completed runs — the
+heavy 200K-per-WD planning + testing + implementation context lives
+inside each sub-agent and is gone when it returns.
+
+This is the structural automation of the
+`/clear` + `/work-resume` + `/work-start WD-N` rhythm: same per-WD
+context economy, same dependency-respecting selection, no `/clear` or
+`/work-resume` typed by the user during the run.
+
+### When to use `all` vs `--parallel`
+
+Both run every SPECIFIED WD in the group. The trade-off is wall-clock
+vs. resource isolation, NOT quality of arbitration — both modes
+delegate to the same single-WD `/work-start` flow which uses the same
+mode-gating in pipeline skills.
+
+`all` (sequential):
+- **Context economy is the priority** — multi-WD groups that would
+  otherwise accumulate context across skill switches.
+- **No spec/test resource contention** by construction — one
+  sub-agent at a time.
+- **One arbitration session per WD** — the user only sees prompts for
+  the WD currently in flight.
+
+`--parallel`:
+- Wall-clock speed is the priority AND the WDs are runtime-isolated.
+- N× token cost is acceptable.
+- Concurrent sub-agents may serialize on shared writes (manifest, KB)
+  — see Parallel mode caveats.
+
+Both modes use `automation_mode: autonomous` and
+`execution_strategy: balanced` for the dispatched sub-agents (set by
+the single-WD flow at Step 4c). Routine choices auto-default;
+escalations surface to the user.
+
+### Sequential-all flow
+
+Replace Steps 3–5 with this block when `all` is the argument.
+
+1. **Initial enumeration.** Read `_readiness.json` (refreshed by the
+   resolver call in Step 2) and collect every WD whose status is
+   `SPECIFIED`. If zero, report and stop:
+   ```
+   No SPECIFIED work definitions in '<group-slug>' — run /work-plan
+   "<group-slug>" all to specify READY WDs first, or check
+   /work-status for blockers.
+   ```
+
+2. **Show the plan.** Compute the initial run order — sort by
+   unblocking value (most downstream dependents first), tie-breaking
+   by fewer artifact dependencies. Display:
+   ```
+   ── Sequential start plan ──────────────────────
+   Group: <group-slug>
+   SPECIFIED WDs: <N>
+   Initial order (by unblocking value):
+     1. WD-<nn> — <title>  (unblocks: <list>)
+     2. WD-<nn> — ...
+   Note: a WD's completion may unblock a sibling that's currently
+   BLOCKED on a wd: dep — the loop re-enumerates between iterations,
+   so the run may include WDs not in this initial list.
+   ───────────────────────────────────────────────
+   ```
+   Use AskUserQuestion to confirm:
+     - "Run sequentially" (Recommended)
+     - "Cap at 3" (or another cap)
+     - "Stop"
+
+3. **Iterate until no eligible WD remains.** Loop:
+
+   a. **Re-enumerate.** Run `bash .claude/scripts/work-resolve.sh
+      "<group-slug>" >/dev/null` then re-read `_readiness.json`. Re-
+      enumerating is mandatory — completing a WD in iteration N may
+      satisfy a `wd:` or spec dep that promotes a sibling from
+      BLOCKED to SPECIFIED in iteration N+1.
+
+   b. **Pick the next.** From the current SPECIFIED list, pick the
+      WD with the highest unblocking value (same heuristic as Step 2).
+      Skip WDs the run has already dispatched (track in a dispatched
+      set keyed by WD id). If no SPECIFIED WD remains that hasn't been
+      dispatched, exit the loop.
+
+   c. **Honor the cap.** If the user chose a cap in Step 2 and the
+      dispatched count has reached it, exit the loop.
+
+   d. **Dispatch ONE sub-agent that recursively invokes the
+      single-WD `/work-start`.** This is critical — do NOT hand-roll
+      the feature creation + claim + pipeline dispatch logic in this
+      coordinator. The single-WD flow already does it correctly. Use
+      this prompt verbatim:
+      ```
+      You are the sequential pipeline runner for <group-slug> /
+      <wd-id>.
+
+      Invoke /work-start "<group-slug>" <wd-id>. The single-WD flow
+      will create the feature directory, claim the WD via
+      work-claim.sh (SPECIFIED → IMPLEMENTING), and hand off to
+      /feature-plan → /feature-test → /feature-implement →
+      /feature-refactor → /feature-pr.
+
+      Treat automation_mode as autonomous. Do not pause between
+      pipeline stages. If a stage escalates (test conflict, missing
+      tests, refactor escalation), record it in the feature's
+      cycle-log.md and continue with remaining stages where possible.
+
+      Distinguish two failure modes in your final return:
+
+      - If the /work-start invocation reports a `[claim] CONFLICT:`
+        message from work-claim.sh (another terminal advanced the WD
+        between the coordinator's enumeration and this dispatch),
+        return:
+          "<group-slug>--<wd-id>: SKIPPED — claim conflict"
+
+      - Any other failure (feature directory creation, status.md
+        write error, pipeline escalation, unexpected exception) is an
+        ERROR — return:
+          "<group-slug>--<wd-id>: ERROR — <one-line detail>"
+
+      Successful runs return:
+        "<group-slug>--<wd-id>: <COMPLETE | STOPPED_AT_<stage>> — <detail>"
+
+      Return exactly ONE line and nothing else after. The coordinator
+      parses this string.
+      ```
+
+   e. **Wait for the sub-agent to return.** The Agent tool blocks
+      until the child emits its final assistant message.
+
+   f. **Aggregate.** Append the sub-agent's summary to a results list.
+      Display incrementally:
+      ```
+      [<n>/<eligible>] <group-slug>--<wd-id>: <STATUS> — <detail>
+      ```
+
+   g. **Stop conditions.** Continue unless:
+      - The sub-agent returned `ERROR` or `STOPPED_AT_<stage>` AND
+        the user opts to halt (AskUserQuestion: "Continue with
+        remaining" / "Stop and inspect").
+      - SKIPPED returns are silent — log and continue (the coordinator
+        intentionally tolerates conflicts as parallel-session signals).
+
+4. **Final aggregate.** When the loop exits:
+   ```
+   ── Sequential run complete · <group-slug> ─────
+   Dispatched: <N>
+   Complete: <n>
+   Stopped mid-pipeline: <list with stage>
+   Errored: <list with detail>
+   Skipped (claim conflict / no longer eligible): <list>
+   ───────────────────────────────────────────────
+
+   Next steps:
+     <if any stopped/errored:> /feature-resume "<group>--<wd-id>" — inspect each
+     <if any new SPECIFIED post-run:> /work-start "<group-slug>" all — run the next batch
+     <if all complete:> the group is fully implemented; consider /feature-retro on each feature
+   ```
+
+### Concurrency caveats
+
+Sequential `all` avoids parallel-mode hazards by construction — one
+WD's pipeline finishes before the next starts. Two failure modes
+remain, both handled gracefully:
+
+- **Another terminal racing the same WD.** `work-claim.sh` (called
+  inside the dispatched single-WD flow at Step 4d) rejects the claim
+  with CONFLICT and exits 1. The sub-agent returns
+  `SKIPPED — claim conflict` and the coordinator continues to the next
+  WD. No corruption, no stuck loop.
+- **Status drift mid-run.** A WD that was SPECIFIED at Step 3a may be
+  IMPLEMENTING by Step 3b (another terminal got there). The
+  re-enumeration at the top of every iteration catches this — the
+  ineligible WD is filtered out before dispatch.
 
 ---
 

--- a/tests/scenario-work-claim.sh
+++ b/tests/scenario-work-claim.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Scenario: work-claim.sh atomic compare-and-swap on WD status.
+#
+# Tests:
+# 1. Claim succeeds when current status matches expected
+# 2. Claim fails (exit 1) when current status differs
+# 3. Bogus new-status is rejected (exit 2) before any write
+# 4. Missing WD file is rejected (exit 2)
+# 5. Two parallel claims of the same DRAFT → SPECIFYING transition: only one succeeds
+# 6. Status validation accepts all five lifecycle states
+# 7. Lock file is created during claim (proof of flock path)
+# 8. Lock is shared with work-resolve (same .work-resolve.lock filename)
+#
+# Run from repo root: bash tests/scenario-work-claim.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-work-claim"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+cleanup() { rm -rf "$TEST_BASE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: work-claim.sh atomic CAS on WD status"
+echo "──────────────────────────────────────────────────────────────────"
+
+cleanup
+
+setup_fixture() {
+  local proj="$TEST_BASE/project"
+  rm -rf "$TEST_BASE"
+  mkdir -p "$proj/.work/example" "$proj/.spec/registry" "$proj/.claude/scripts" "$proj/.decisions"
+  cp "$REPO_ROOT/scripts/work-claim.sh"   "$proj/.claude/scripts/"
+  cp "$REPO_ROOT/scripts/work-resolve.sh" "$proj/.claude/scripts/"
+  cp "$REPO_ROOT/scripts/work-lib.sh"     "$proj/.claude/scripts/"
+  cp "$REPO_ROOT/scripts/spec-lib.sh"     "$proj/.claude/scripts/"
+  echo '{"schema_version":2,"specs":[]}' > "$proj/.spec/registry/manifest.json"
+
+  cat > "$proj/.work/example/WD-01.md" <<'EOF'
+---
+id: WD-01
+title: First
+group: example
+status: DRAFT
+domains: [foo]
+artifact_deps: []
+produces: []
+---
+
+## Summary
+First.
+EOF
+  echo "$proj"
+}
+
+# ── Test 1: claim succeeds when status matches ──────────────────────────────
+
+echo ""
+echo "── Test 1: claim DRAFT → SPECIFYING when status is DRAFT"
+
+proj=$(setup_fixture)
+( cd "$proj" && bash .claude/scripts/work-claim.sh example WD-01 DRAFT SPECIFYING ) >/tmp/claim.out 2>&1
+rc=$?
+if [[ $rc -eq 0 ]] && grep -q "^status: SPECIFYING" "$proj/.work/example/WD-01.md"; then
+    pass "claim succeeded, status flipped"
+else
+    fail "claim should have succeeded" "rc=$rc, output: $(cat /tmp/claim.out)"
+fi
+
+# ── Test 2: claim fails when status differs ─────────────────────────────────
+
+echo ""
+echo "── Test 2: re-claim DRAFT → SPECIFYING fails (status is now SPECIFYING)"
+
+if ( cd "$proj" && bash .claude/scripts/work-claim.sh example WD-01 DRAFT SPECIFYING ) >/tmp/claim.out 2>&1; then
+    fail "claim should have failed with CONFLICT"
+else
+    rc=$?
+    if [[ $rc -eq 1 ]] && grep -q "CONFLICT" /tmp/claim.out; then
+        pass "claim correctly rejected with exit 1 + CONFLICT message"
+    else
+        fail "wrong failure mode" "rc=$rc, output: $(cat /tmp/claim.out)"
+    fi
+fi
+
+# ── Test 3: bogus new-status rejected ───────────────────────────────────────
+
+echo ""
+echo "── Test 3: bogus new-status 'SPECIFFIED' rejected (exit 2)"
+
+proj=$(setup_fixture)
+if ( cd "$proj" && bash .claude/scripts/work-claim.sh example WD-01 DRAFT SPECIFFIED ) >/tmp/claim.out 2>&1; then
+    fail "should have rejected typo"
+else
+    rc=$?
+    if [[ $rc -eq 2 ]] && grep -q "unknown new-status" /tmp/claim.out; then
+        pass "typo rejected with exit 2 before any write"
+    else
+        fail "wrong failure mode for typo" "rc=$rc, output: $(cat /tmp/claim.out)"
+    fi
+fi
+
+# Verify the WD is unchanged after the typo rejection
+if grep -q "^status: DRAFT" "$proj/.work/example/WD-01.md"; then
+    pass "WD unchanged after typo rejection"
+else
+    fail "WD was modified despite typo rejection" "$(grep '^status:' $proj/.work/example/WD-01.md)"
+fi
+
+# ── Test 4: missing WD file rejected ────────────────────────────────────────
+
+echo ""
+echo "── Test 4: missing WD file rejected (exit 2)"
+
+proj=$(setup_fixture)
+if ( cd "$proj" && bash .claude/scripts/work-claim.sh example WD-99 DRAFT SPECIFYING ) >/tmp/claim.out 2>&1; then
+    fail "should have rejected missing WD"
+else
+    rc=$?
+    if [[ $rc -eq 2 ]] && grep -q "WD file not found" /tmp/claim.out; then
+        pass "missing WD rejected with exit 2"
+    else
+        fail "wrong failure mode for missing WD" "rc=$rc, output: $(cat /tmp/claim.out)"
+    fi
+fi
+
+# ── Test 5: parallel claims — only one succeeds ─────────────────────────────
+
+echo ""
+echo "── Test 5: 5 parallel claims of DRAFT → SPECIFYING — exactly one wins"
+
+if ! command -v flock >/dev/null 2>&1; then
+    pass "skipped — flock not available; parallel safety not testable"
+    pass "skipped — flock not available; parallel safety not testable"
+else
+    proj=$(setup_fixture)
+
+    # Fire 5 concurrent claim attempts, capture their exit codes
+    rcs_file="/tmp/claim-rcs.$$"
+    : > "$rcs_file"
+    for i in 1 2 3 4 5; do
+        (
+            cd "$proj"
+            if bash .claude/scripts/work-claim.sh example WD-01 DRAFT SPECIFYING >/dev/null 2>&1; then
+                echo "0" >> "$rcs_file"
+            else
+                echo "$?" >> "$rcs_file"
+            fi
+        ) &
+    done
+    wait
+
+    successes=$(grep -c '^0$' "$rcs_file" || true)
+    conflicts=$(grep -c '^1$' "$rcs_file" || true)
+    rm -f "$rcs_file"
+
+    if [[ "$successes" -eq 1 ]]; then
+        pass "exactly one claim succeeded"
+    else
+        fail "wrong number of successes" "got $successes (expected 1)"
+    fi
+
+    if [[ "$conflicts" -eq 4 ]]; then
+        pass "four claims correctly rejected as CONFLICT"
+    else
+        fail "wrong number of conflicts" "got $conflicts (expected 4)"
+    fi
+fi
+
+# ── Test 6: lifecycle state validation ─────────────────────────────────────
+
+echo ""
+echo "── Test 6: each lifecycle state accepted as new-status"
+
+# Set up a fresh DRAFT each time and walk through the lifecycle
+walk_ok=true
+for transition in "DRAFT SPECIFYING" "SPECIFYING SPECIFIED" "SPECIFIED IMPLEMENTING" "IMPLEMENTING COMPLETE"; do
+    read -r expected new <<< "$transition"
+    proj=$(setup_fixture)
+    # Set status to expected
+    sed -i "s/^status:.*/status: $expected/" "$proj/.work/example/WD-01.md"
+    if ! ( cd "$proj" && bash .claude/scripts/work-claim.sh example WD-01 "$expected" "$new" ) >/dev/null 2>&1; then
+        walk_ok=false
+        break
+    fi
+done
+if [[ "$walk_ok" == "true" ]]; then
+    pass "all four lifecycle transitions accepted"
+else
+    fail "some lifecycle transition rejected"
+fi
+
+# ── Test 7: lock file created during claim ─────────────────────────────────
+
+echo ""
+echo "── Test 7: .work-resolve.lock created during claim"
+
+if command -v flock >/dev/null 2>&1; then
+    proj=$(setup_fixture)
+    ( cd "$proj" && bash .claude/scripts/work-claim.sh example WD-01 DRAFT SPECIFYING ) >/dev/null 2>&1
+    if [[ -f "$proj/.work/example/.work-resolve.lock" ]]; then
+        pass "lock file present"
+    else
+        fail "lock file not created"
+    fi
+else
+    pass "skipped — flock not available"
+fi
+
+# ── Test 8: claim and resolve share the lock (mutually exclusive) ──────────
+
+echo ""
+echo "── Test 8: claim uses the same .work-resolve.lock as work-resolve.sh"
+
+# We assert by file presence — both scripts use the same path. A more
+# rigorous test would block one and verify the other waits, but file
+# presence proves the namespace is shared.
+if command -v flock >/dev/null 2>&1; then
+    proj=$(setup_fixture)
+    ( cd "$proj" && bash .claude/scripts/work-claim.sh example WD-01 DRAFT SPECIFYING ) >/dev/null 2>&1
+    lock_after_claim="$proj/.work/example/.work-resolve.lock"
+    [[ -f "$lock_after_claim" ]] || fail "claim lock missing"
+
+    # Run resolve — uses same lock file
+    ( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>&1
+    if [[ -f "$lock_after_claim" ]]; then
+        pass "claim and resolve share .work-resolve.lock"
+    else
+        fail "lock disappeared between claim and resolve"
+    fi
+else
+    pass "skipped — flock not available"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "──────────────────────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+
+(( failed > 0 )) && exit 1
+exit 0

--- a/tests/scenario-work-readiness-cache.sh
+++ b/tests/scenario-work-readiness-cache.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+# Scenario: work-resolve.sh emits a structured `_readiness.json` cache
+# that downstream skills (/work-resume, /work-status --all, parallel
+# coordination) can read instead of parsing the markdown report.
+#
+# Tests:
+# 1. _readiness.json is written next to manifest.md after a normal run
+# 2. JSON parses as valid JSON (python3 json.load succeeds)
+# 3. summary counts match the resolver's stderr diagnostic line
+# 4. wds[] entries include id, title, status, deps_count, blockers, unblocks
+# 5. titles containing double quotes are correctly escaped
+# 6. blockers array is populated for BLOCKED WDs and empty for READY
+# 7. unblocks array reflects produces→deps relationships
+# 8. atomic write — _readiness.json.tmp.* is not left behind on success
+#
+# Run from repo root: bash tests/scenario-work-readiness-cache.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-work-readiness-cache"
+RESOLVE="$REPO_ROOT/scripts/work-resolve.sh"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+cleanup() { rm -rf "$TEST_BASE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: work-resolve.sh _readiness.json cache"
+echo "──────────────────────────────────────────────────────────────────"
+
+cleanup
+
+# Common fixture: 3 WDs — one READY, one BLOCKED on a missing spec, one
+# whose produces unblocks the BLOCKED one.
+
+setup_fixture() {
+  local proj="$TEST_BASE/project"
+  rm -rf "$TEST_BASE"
+  mkdir -p "$proj/.work/example" "$proj/.spec/registry" "$proj/.claude/scripts" "$proj/.decisions"
+
+  # Copy work scripts so the fixture is self-contained
+  cp "$REPO_ROOT/scripts/work-resolve.sh" "$proj/.claude/scripts/"
+  cp "$REPO_ROOT/scripts/work-lib.sh"     "$proj/.claude/scripts/"
+  cp "$REPO_ROOT/scripts/spec-lib.sh"     "$proj/.claude/scripts/"
+
+  cat > "$proj/.work/example/work.md" << 'EOF'
+---
+group: example
+external_deps: []
+---
+
+# Example
+## Goal
+Test readiness JSON cache.
+EOF
+
+  cat > "$proj/.work/example/manifest.md" << 'EOF'
+# example manifest
+
+## Work Definitions
+
+| WD | Title | Status | Domains | Deps | Produces |
+|----|-------|--------|---------|------|----------|
+EOF
+
+  # WD-01: produces a spec, no deps → READY
+  cat > "$proj/.work/example/WD-01.md" << 'EOF'
+---
+id: WD-01
+title: Foundation "with quotes" in title
+group: example
+status: DRAFT
+domains: [engine]
+artifact_deps: []
+produces:
+  - { type: spec, path: "engine/foundation-contract" }
+---
+
+## Summary
+Foundational spec.
+EOF
+
+  # WD-02: needs WD-01's spec APPROVED → initially BLOCKED
+  cat > "$proj/.work/example/WD-02.md" << 'EOF'
+---
+id: WD-02
+title: Consumer
+group: example
+status: DRAFT
+domains: [engine]
+artifact_deps:
+  - { type: spec, path: "engine/foundation-contract", required_state: APPROVED }
+---
+
+## Summary
+Consumes the foundation spec.
+EOF
+
+  # WD-03: independent, no deps → READY
+  cat > "$proj/.work/example/WD-03.md" << 'EOF'
+---
+id: WD-03
+title: Independent
+group: example
+status: DRAFT
+domains: [io]
+artifact_deps: []
+produces: []
+---
+
+## Summary
+Independent work.
+EOF
+
+  cat > "$proj/.spec/registry/manifest.json" << 'EOF'
+{ "schema_version": 2, "specs": [] }
+EOF
+
+  echo "$proj"
+}
+
+# Helper: run the resolver from inside the fixture project
+run_resolve() {
+  local proj="$1"
+  local group="$2"
+  ( cd "$proj" && bash .claude/scripts/work-resolve.sh "$group" ) 1>/tmp/resolve-stdout.$$ 2>/tmp/resolve-stderr.$$
+  local rc=$?
+  cat /tmp/resolve-stdout.$$
+  cat /tmp/resolve-stderr.$$ >&2
+  rm -f /tmp/resolve-stdout.$$ /tmp/resolve-stderr.$$
+  return $rc
+}
+
+# ── Test 1: cache file written ──────────────────────────────────────────────
+
+echo ""
+echo "── Test 1: _readiness.json is written after a resolver run"
+
+proj=$(setup_fixture)
+( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>/tmp/stderr.$$
+if [[ -f "$proj/.work/example/_readiness.json" ]]; then
+    pass "cache file exists"
+else
+    fail "cache file not created" "expected: $proj/.work/example/_readiness.json"
+fi
+
+# ── Test 2: cache file is valid JSON ────────────────────────────────────────
+
+echo ""
+echo "── Test 2: cache parses as valid JSON"
+
+if python3 -c "import json; json.load(open('$proj/.work/example/_readiness.json'))" 2>/tmp/jsonerr.$$; then
+    pass "valid JSON"
+else
+    fail "invalid JSON" "$(cat /tmp/jsonerr.$$)"
+fi
+rm -f /tmp/jsonerr.$$
+
+# ── Test 3: summary counts ──────────────────────────────────────────────────
+
+echo ""
+echo "── Test 3: summary counts (1 ready DRAFT no-deps, 1 blocked, 1 ready DRAFT no-deps)"
+# Note: the resolver classifies ALL DRAFTs with deps met as READY. So both
+# WD-01 (no deps) and WD-03 (no deps) should be READY; WD-02 BLOCKED.
+
+ready=$(python3 -c "import json; print(json.load(open('$proj/.work/example/_readiness.json'))['summary']['ready'])")
+blocked=$(python3 -c "import json; print(json.load(open('$proj/.work/example/_readiness.json'))['summary']['blocked'])")
+total_count=$(python3 -c "import json; print(json.load(open('$proj/.work/example/_readiness.json'))['summary']['total'])")
+
+if [[ "$ready" == "2" && "$blocked" == "1" && "$total_count" == "3" ]]; then
+    pass "summary: total=3 ready=2 blocked=1"
+else
+    fail "summary counts wrong" "got total=$total_count ready=$ready blocked=$blocked"
+fi
+
+# ── Test 4: wd entries shape ────────────────────────────────────────────────
+
+echo ""
+echo "── Test 4: wds[] entries have required fields"
+
+shape_ok=$(python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+required = {'id', 'title', 'status', 'deps_count', 'blockers', 'unblocks'}
+missing_for = []
+for wd in d['wds']:
+    miss = required - set(wd.keys())
+    if miss:
+        missing_for.append((wd.get('id', '?'), miss))
+print('MISSING:' + str(missing_for) if missing_for else 'OK')
+")
+
+if [[ "$shape_ok" == "OK" ]]; then
+    pass "all wds[] entries have required fields"
+else
+    fail "wds[] entries missing fields" "$shape_ok"
+fi
+
+# ── Test 5: title escaping ──────────────────────────────────────────────────
+
+echo ""
+echo "── Test 5: titles with embedded quotes are correctly escaped"
+
+title_check=$(python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+wd1 = next(w for w in d['wds'] if w['id'] == 'WD-01')
+expected = 'Foundation \"with quotes\" in title'
+print('OK' if wd1['title'] == expected else f'BAD: got {wd1[\"title\"]!r}')
+")
+
+if [[ "$title_check" == "OK" ]]; then
+    pass "embedded double quotes round-trip cleanly"
+else
+    fail "title escape broken" "$title_check"
+fi
+
+# ── Test 6: blockers populated for BLOCKED WD ───────────────────────────────
+
+echo ""
+echo "── Test 6: blockers array populated for BLOCKED, empty for READY"
+
+blocker_check=$(python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+wd1 = next(w for w in d['wds'] if w['id'] == 'WD-01')
+wd2 = next(w for w in d['wds'] if w['id'] == 'WD-02')
+ready_empty = wd1['status'] == 'READY' and wd1['blockers'] == []
+blocked_has  = wd2['status'] == 'BLOCKED' and len(wd2['blockers']) > 0
+print('OK' if (ready_empty and blocked_has) else f'BAD ready_empty={ready_empty} blocked_has={blocked_has}')
+")
+
+if [[ "$blocker_check" == "OK" ]]; then
+    pass "blockers shape correct"
+else
+    fail "blockers shape wrong" "$blocker_check"
+fi
+
+# ── Test 7: unblocks reflects produces→deps relationship ────────────────────
+
+echo ""
+echo "── Test 7: WD-01 unblocks WD-02 (via produces→deps)"
+
+unblocks_check=$(python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+wd1 = next(w for w in d['wds'] if w['id'] == 'WD-01')
+print('OK' if 'WD-02' in wd1['unblocks'] else f'BAD: {wd1[\"unblocks\"]!r}')
+")
+
+if [[ "$unblocks_check" == "OK" ]]; then
+    pass "WD-01 → WD-02 unblock edge present"
+else
+    fail "unblock edge missing" "$unblocks_check"
+fi
+
+# ── Test 8: atomic write — no .tmp leftover ─────────────────────────────────
+
+echo ""
+echo "── Test 8: no _readiness.json.tmp.* leftover after success"
+
+leftover=$(find "$proj/.work/example" -name '_readiness.json.tmp.*' 2>/dev/null)
+if [[ -z "$leftover" ]]; then
+    pass "no tmp file leftover"
+else
+    fail "tmp file not cleaned up" "$leftover"
+fi
+
+rm -f /tmp/stderr.$$
+
+# ── Test 9 (precursor): cache reflects status changes when resolver re-runs
+#
+# The /work-plan, /work-start, /feature-complete skills now call
+# `work-resolve.sh` after sed-mutating WD status. This test mimics that
+# flow — flip a WD's status on disk, re-run the resolver, confirm the
+# cache reflects the new state.
+
+echo ""
+echo "── Test 9: cache reflects WD status changes after a resolver re-run"
+
+# Reuse the 3-WD fixture from the earlier tests
+proj=$(setup_fixture)
+( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>&1
+
+before_wd1=$(python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+print(next(w for w in d['wds'] if w['id'] == 'WD-01')['status'])
+")
+
+# Mutate WD-01 to SPECIFIED (mimic /work-plan finishing)
+sed -i "s/^status:.*/status: SPECIFIED/" "$proj/.work/example/WD-01.md"
+
+# Re-run the resolver (mimic the new refresh-on-mutate pattern)
+( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>&1
+
+after_wd1=$(python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+print(next(w for w in d['wds'] if w['id'] == 'WD-01')['status'])
+")
+
+if [[ "$before_wd1" == "READY" && "$after_wd1" == "SPECIFIED" ]]; then
+    pass "cache reflects WD-01 transition READY → SPECIFIED"
+else
+    fail "cache stale after status change" "before=$before_wd1 after=$after_wd1"
+fi
+
+# ── Test 10a: stale .tmp.* files from a prior failed run ────────────────────
+# A previous run that died mid-write would leave _readiness.json.tmp.<PID>
+# behind. Successful subsequent runs should not be confused by them.
+# (The current trap cleans up the CURRENT run's tmp; orphans from prior
+# runs accumulate until manually removed. We assert here that the resolver
+# at minimum does not crash if it finds them, and that it produces a clean
+# successful output.)
+
+echo ""
+echo "── Test 10a: leftover .tmp.<other-pid> from prior crash does not break a fresh run"
+
+proj=$(setup_fixture)
+# Simulate orphan from a hypothetical prior crashed run
+touch "$proj/.work/example/_readiness.json.tmp.99999"
+( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>/tmp/stderr.$$
+
+if [[ -f "$proj/.work/example/_readiness.json" ]] && \
+   python3 -c "import json; json.load(open('$proj/.work/example/_readiness.json'))" 2>/dev/null; then
+    pass "fresh run succeeds despite orphan tmp file"
+else
+    fail "orphan tmp file broke the run" "stderr: $(cat /tmp/stderr.$$ 2>/dev/null)"
+fi
+rm -f /tmp/stderr.$$
+
+# ── Test 11: control character in WD title produces valid JSON ─────────────
+# json_escape strips ASCII control chars (0x00-0x08, 0x0B-0x0C, 0x0E-0x1F)
+# before applying escape transforms. Without this, a title containing a
+# stray BEL or NUL would produce invalid JSON that consumers cannot parse.
+
+echo ""
+echo "── Test 11: WD title with control chars yields valid JSON"
+
+proj=$(setup_fixture)
+# Inject a BEL (0x07) and a Form Feed (0x0C) into the title — both are
+# control chars json_escape should strip rather than emit raw.
+python3 -c "
+content = open('$proj/.work/example/WD-01.md').read()
+content = content.replace('Foundation \"with quotes\" in title',
+                          'Foundation\\x07with control\\x0Cchars')
+open('$proj/.work/example/WD-01.md', 'w').write(content)
+"
+
+( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>/tmp/stderr.$$
+
+if python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+wd1 = next(w for w in d['wds'] if w['id'] == 'WD-01')
+# Title should not contain BEL or FF — they were stripped
+assert '\x07' not in wd1['title'], 'BEL should have been stripped'
+assert '\x0c' not in wd1['title'], 'FF should have been stripped'
+print('OK')
+" 2>/tmp/jsonerr.$$; then
+    pass "control chars stripped, JSON remains valid"
+else
+    fail "control char handling broken" "$(cat /tmp/jsonerr.$$ 2>/dev/null)"
+fi
+rm -f /tmp/stderr.$$ /tmp/jsonerr.$$
+
+# ── Test 12: lock file is created when flock is available ──────────────────
+# Best-effort proof that flock-based serialization is wired up. We don't
+# test contention directly (hard in bash); we verify the lock file appears
+# alongside the cache, signaling the lock acquisition path ran.
+
+echo ""
+echo "── Test 12: .work-resolve.lock is created when flock is available"
+
+if command -v flock >/dev/null 2>&1; then
+    proj=$(setup_fixture)
+    ( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>/dev/null
+    if [[ -f "$proj/.work/example/.work-resolve.lock" ]]; then
+        pass "lock file present after a flock-equipped run"
+    else
+        fail "lock file not created"
+    fi
+else
+    pass "skipped — flock not available on this platform"
+fi
+
+# ── Test 12a: parallel runs serialize and produce consistent JSON ──────────
+# Two parallel resolvers MUST NOT interleave their writes such that one
+# stomps on the other's content. After both finish, the cache must be
+# valid JSON and reflect the (identical) input state. Without the lock
+# wrapping the compute phase, a slow read in one process and a fast
+# write in another can produce a fresh-mtime cache with stale content.
+
+echo ""
+echo "── Test 12a: 5 parallel resolvers leave a consistent JSON cache"
+
+if command -v flock >/dev/null 2>&1; then
+    proj=$(setup_fixture)
+    # Fire 5 concurrent resolvers
+    for i in 1 2 3 4 5; do
+        ( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>/dev/null &
+    done
+    wait
+
+    # The cache must exist and be valid JSON
+    if [[ -f "$proj/.work/example/_readiness.json" ]] && \
+       python3 -c "import json; json.load(open('$proj/.work/example/_readiness.json'))" 2>/dev/null; then
+        pass "parallel runs produce valid JSON"
+    else
+        fail "parallel runs produced invalid or missing JSON"
+    fi
+
+    # No leftover .tmp files from racing writes
+    leftover=$(find "$proj/.work/example" -name '_readiness.json.tmp.*' 2>/dev/null)
+    if [[ -z "$leftover" ]]; then
+        pass "no .tmp.* leftover after parallel runs"
+    else
+        fail "tmp files leaked from parallel runs" "$leftover"
+    fi
+
+    # Content correctness — JSON validity isn't enough. The lock-during-
+    # compute claim only holds if the cache content matches what's on
+    # disk. Mutate WD-01, run 5 parallel resolvers, then verify the cache
+    # reflects the post-mutation state (not a stale pre-mutation snapshot
+    # from a runner that read first but wrote last).
+    sed -i "s/^status: DRAFT$/status: SPECIFIED/" "$proj/.work/example/WD-01.md"
+    for i in 1 2 3 4 5; do
+        ( cd "$proj" && bash .claude/scripts/work-resolve.sh example ) >/dev/null 2>/dev/null &
+    done
+    wait
+    cache_status=$(python3 -c "
+import json
+d = json.load(open('$proj/.work/example/_readiness.json'))
+wd1 = next((w for w in d['wds'] if w['id'] == 'WD-01'), None)
+print(wd1['status'] if wd1 else 'MISSING')
+")
+    if [[ "$cache_status" == "SPECIFIED" ]]; then
+        pass "cache content reflects post-mutation state (not a stale snapshot)"
+    else
+        fail "cache shows stale content despite parallel runs" "got: $cache_status (expected SPECIFIED)"
+    fi
+else
+    pass "skipped — flock not available"
+    pass "skipped — flock not available"
+    pass "skipped — flock not available"
+fi
+
+# ── Test 13: empty group — valid JSON with empty wds[] ─────────────────────
+# Edge case: a group exists (e.g., just created via /work) but has no WD files
+# yet. The resolver must still emit valid JSON. Without this guarantee,
+# /work-resume's JSON read would fail on freshly-created groups.
+
+echo ""
+echo "── Test 13: empty group emits valid JSON with empty wds[]"
+
+empty_proj="$TEST_BASE/empty"
+rm -rf "$empty_proj"
+mkdir -p "$empty_proj/.work/empty-group" "$empty_proj/.spec/registry" "$empty_proj/.claude/scripts" "$empty_proj/.decisions"
+cp "$REPO_ROOT/scripts/work-resolve.sh" "$empty_proj/.claude/scripts/"
+cp "$REPO_ROOT/scripts/work-lib.sh"     "$empty_proj/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh"     "$empty_proj/.claude/scripts/"
+
+cat > "$empty_proj/.work/empty-group/work.md" << 'EOF'
+---
+group: empty-group
+external_deps: []
+---
+
+# Empty
+## Goal
+No WDs yet.
+EOF
+
+cat > "$empty_proj/.spec/registry/manifest.json" << 'EOF'
+{ "schema_version": 2, "specs": [] }
+EOF
+
+( cd "$empty_proj" && bash .claude/scripts/work-resolve.sh empty-group ) >/dev/null 2>/tmp/stderr.$$
+
+if [[ -f "$empty_proj/.work/empty-group/_readiness.json" ]] && \
+   python3 -c "
+import json
+d = json.load(open('$empty_proj/.work/empty-group/_readiness.json'))
+assert d['summary']['total'] == 0, f'expected total=0, got {d[\"summary\"][\"total\"]}'
+assert d['wds'] == [], f'expected empty wds, got {d[\"wds\"]}'
+" 2>/tmp/jsonerr.$$; then
+    pass "empty group → valid JSON, total=0, wds=[]"
+else
+    fail "empty group JSON wrong" "$(cat /tmp/jsonerr.$$ 2>/dev/null) / stderr: $(cat /tmp/stderr.$$ 2>/dev/null)"
+fi
+rm -f /tmp/stderr.$$ /tmp/jsonerr.$$
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "──────────────────────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+
+if (( failed > 0 )); then
+    exit 1
+fi
+exit 0

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -938,6 +938,27 @@ else
     fail ".spec/.split-plan.json should be in .gitignore"
 fi
 
+# Work-layer runtime artifacts: per-machine readiness cache and ephemeral
+# decompose checkpoint must be gitignored. Otherwise readiness recomputed
+# on each machine fights with itself in merge conflicts. Use grep -qxF
+# because the entries contain literal `*` glob chars that assert_file_contains
+# would interpret as regex quantifiers.
+if grep -qxF ".work/*/_readiness.json" "$ENHANCED_TARGET/.gitignore"; then
+    pass ".work/*/_readiness.json in .gitignore"
+else
+    fail ".work/*/_readiness.json should be in .gitignore"
+fi
+if grep -qxF ".work/*/_decompose-progress.md" "$ENHANCED_TARGET/.gitignore"; then
+    pass ".work/*/_decompose-progress.md in .gitignore"
+else
+    fail ".work/*/_decompose-progress.md should be in .gitignore"
+fi
+if grep -qxF ".work/*/.work-resolve.lock" "$ENHANCED_TARGET/.gitignore"; then
+    pass ".work/*/.work-resolve.lock in .gitignore"
+else
+    fail ".work/*/.work-resolve.lock should be in .gitignore"
+fi
+
 # Upgrade path: an existing install that already has the runtime block but
 # was made before v0.16.x should pick up the new entries on re-install.
 UPGRADE_GI_TARGET="$(make_temp)"
@@ -964,6 +985,21 @@ if grep -qxF ".spec/.split-plan.json" "$UPGRADE_GI_TARGET/.gitignore"; then
     pass "upgrade path adds .spec/.split-plan.json to existing .gitignore"
 else
     fail "upgrade should add .spec/.split-plan.json to existing .gitignore"
+fi
+if grep -qxF ".work/*/_readiness.json" "$UPGRADE_GI_TARGET/.gitignore"; then
+    pass "upgrade path adds .work/*/_readiness.json to existing .gitignore"
+else
+    fail "upgrade should add .work/*/_readiness.json to existing .gitignore"
+fi
+if grep -qxF ".work/*/_decompose-progress.md" "$UPGRADE_GI_TARGET/.gitignore"; then
+    pass "upgrade path adds .work/*/_decompose-progress.md to existing .gitignore"
+else
+    fail "upgrade should add .work/*/_decompose-progress.md to existing .gitignore"
+fi
+if grep -qxF ".work/*/.work-resolve.lock" "$UPGRADE_GI_TARGET/.gitignore"; then
+    pass "upgrade path adds .work/*/.work-resolve.lock to existing .gitignore"
+else
+    fail "upgrade should add .work/*/.work-resolve.lock to existing .gitignore"
 fi
 # Idempotent: running install twice must not duplicate entries.
 bash "$REPO_ROOT/install.sh" "$UPGRADE_GI_TARGET" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Three primitives that enable longer multi-WD planning sessions (the original 500K context wall) and safe parallel work across terminals.

- **`/work-resume`** — cheap "where am I, what's next" entry after `/clear`. Reads cached `_readiness.json` with mtime freshness check; routes to `/work-plan`, `/work-start`, `/feature-resume`, or an unblock action.
- **`/work-{plan,start} <group> all`** — sequential coordinator modes. One subagent per WD (recursively invoking the single-WD skill); parent stays ~6K while each subagent's heavy work lives in its own context window. Re-enumerates between iterations so newly-unblocked WDs are picked up.
- **`work-claim.sh`** — atomic compare-and-swap on WD status under flock. Two terminals running `/work-plan WD-01` simultaneously can no longer both succeed; the loser gets `CONFLICT` and the coordinator skips it.

Plus hardening: `flock` wraps the entire compute+write phase in `work-resolve.sh` (locking only the writes left a snapshot race that silently produced stale-content caches with fresh mtimes); EXIT trap cleans up partial-write tmp files; control-char-stripping in `json_escape`; `_decompose-progress.md` Phase A→B checkpoint with parse-confirm resume and orphan detection.

## Why

Token analysis of recent multi-WD jlsm sessions showed ~300–500K cache re-seed per skill switch, hitting the practical 500K input-token wall after 1–2 invocations. The new primitives let the user `/clear` between WDs (or use `all` to automate the rhythm via subagent dispatch) so context is per-WD instead of per-group. Parallel safety closes the same-WD race that would otherwise corrupt state when two terminals coordinate.

## What's NOT in scope

- Splitting `/spec-author` further (Option B was based on a wrong audit — Pass 2/3 are already subagents with their own context; more splitting would create more independent cache regions)
- A `--autonomous` flag for `/work-plan all` that mode-gates `/spec-author` Pass 2 arbitration (would compromise spec quality; intentionally deferred)
- Schema migration story for `_readiness.json` (defer until v2 happens)

## Test plan

- [x] All 14 work + install scenario suites pass — **253/253**
- [x] New `scenario-work-readiness-cache.sh` (16 cases) — JSON validity, parallel-run content correctness, control-char escape, orphan tmp recovery, empty groups, mutation-refresh roundtrip, lock-file presence
- [x] New `scenario-work-claim.sh` (10 cases) — CAS, 5-way parallel claim with exactly 1 winner, conflict messages, typo rejection, lifecycle state validation, lock sharing with resolver
- [x] Extended `test-install.sh` (+6 cases) — gitignore entries for `_readiness.json`, `_decompose-progress.md`, `.work-resolve.lock` plus upgrade-path migration
- [x] Fresh install validation: `bash install.sh /tmp/...` → 154 files created, all MANIFEST entries resolve, gitignore picks up new patterns
- [x] Three rounds of adversarial review

🤖 Generated with [Claude Code](https://claude.com/claude-code)