### PR TITLE
feat(kb): canonical schema + writer enforcement + curate drift detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -213,6 +213,8 @@ _install_seed "$SCRIPT_DIR/kb/_refs/complexity-notation.md"           "$TARGET/.
 _install_seed "$SCRIPT_DIR/kb/_refs/benchmarking-methodology.md"      "$TARGET/.kb/_refs/benchmarking-methodology.md"
 _install_seed "$SCRIPT_DIR/kb/_refs/adversarial-finding-template.md"  "$TARGET/.kb/_refs/adversarial-finding-template.md"
 _install_seed "$SCRIPT_DIR/kb/_refs/feature-footprint-template.md"    "$TARGET/.kb/_refs/feature-footprint-template.md"
+_install_seed "$SCRIPT_DIR/kb/_refs/frontmatter.md"                   "$TARGET/.kb/_refs/frontmatter.md"
+_install_seed "$SCRIPT_DIR/kb/_refs/detail-companion.md"              "$TARGET/.kb/_refs/detail-companion.md"
 
 # ── Decisions seed files (never overwrite — same as KB) ──────────────────────
 

--- a/kb/CLAUDE.md
+++ b/kb/CLAUDE.md
@@ -6,7 +6,7 @@
 
 > Pull model. Navigate: topic → category → subject file.
 > Do not scan this directory recursively.
-> Structure: .kb/<topic>/<category>/<subject>.md
+> Structure: `.kb/<topic>/<category>/<subject>.md`
 
 ## Topic Map
 
@@ -17,10 +17,42 @@
 | Date | Topic | Category | Subject |
 |------|-------|----------|---------|
 
+## Where does X go?
+
+The KB has two cross-cutting categorization axes. Use these rules to decide:
+
+- **Domain topics** describe a subject area: how something works, how it's
+  built, what tradeoffs it exposes. Examples: `algorithms/`, `data-structures/`,
+  `distributed-systems/`, `systems/`. Most `type: research` entries live here.
+
+- **`patterns/`** describes lens-shaped findings: bug patterns, anti-patterns,
+  fix patterns. Categories under `patterns/` are named for the **concern**
+  (`validation/`, `concurrency/`, `resource-management/`), not for the domain
+  the bug was discovered in. All `type: adversarial-finding` entries live
+  under `patterns/`.
+
+Decision rule: **What is the entry primarily teaching the reader?**
+- "How algorithm X works" → domain topic.
+- "Anti-pattern Y to avoid in code that does Z" → `patterns/<concern>/`.
+
+A finding discovered while researching SQL parsing belongs at
+`patterns/validation/<finding>.md`, not at `algorithms/sql-extensions/<finding>.md`.
+The research entry that surveys SQL parsing can `related:` link to the finding.
+
+## Filename uniqueness
+
+Filenames MUST be unique across the entire `.kb/` tree, not just within their
+category. Two entries in different folders with the same filename break grep
+and hide cross-cutting evidence. If you need two related entries, disambiguate
+by name (`builder-pre-validation-mutation.md` vs `multi-step-init-no-rollback.md`).
+
 ## Shared References
+
+`_refs/frontmatter.md` — **canonical schema** for all entries; writers MUST validate against it
+`_refs/adversarial-finding-template.md` — schema instance for `type: adversarial-finding` entries
+`_refs/feature-footprint-template.md` — schema instance for `type: feature-footprint` entries
+`_refs/detail-companion.md` — `<subject>-detail.md` split convention
 `_refs/complexity-notation.md` — notation key used in algorithm files
 `_refs/benchmarking-methodology.md` — how benchmark figures are cited
-`_refs/adversarial-finding-template.md` — schema for `type: adversarial-finding` entries
-`_refs/feature-footprint-template.md` — schema for `type: feature-footprint` entries
 
 Older entries: [_archive.md](_archive.md)

--- a/kb/_refs/adversarial-finding-template.md
+++ b/kb/_refs/adversarial-finding-template.md
@@ -2,6 +2,7 @@
 type: reference-fragment
 title: Adversarial Finding Entry Template
 ---
+
 # Adversarial Finding Entry Template
 
 KB entries with `type: adversarial-finding` capture bug patterns and tendencies
@@ -9,35 +10,52 @@ discovered through adversarial testing (aTDD rounds, audit passes, or enhanced
 TDD defensive vectors). They persist across features and inform future test
 writing and implementation.
 
+> **Authoritative schema:** `_refs/frontmatter.md`. This template instantiates
+> the schema for adversarial findings; it does not extend or override it. If
+> the two diverge, frontmatter.md wins.
+
 ## Frontmatter
 
 ```yaml
 ---
 title: "<Pattern name>"
 type: adversarial-finding
-domain: "<security | memory-safety | performance | concurrency | data-integrity>"
-severity: "<tendency | confirmed | critical>"
+domain: "<security|memory-safety|performance|concurrency|data-integrity|validation>"
+severity: "<tendency|confirmed|critical>"
 applies_to:
   - "<file path pattern or module name>"
+last_researched: "YYYY-MM-DD"
+research_status: "active"
+
+# Optional but strongly recommended for searchability:
+aliases: []
+tags: ["adversarial-finding", "<domain>", "<concern>"]
 related: []
 decision_refs: []
-research_status: active
-last_researched: "<YYYY-MM-DD>"
+sources: []
+confidence: "<low|medium|high>"
 ---
 ```
 
-### Field definitions
+### Field-specific guidance for adversarial findings
 
-- `type: adversarial-finding` — distinguishes from standard research entries
-- `domain` — the risk domain; used by test-writer to load relevant findings
+- `tags` SHOULD always include `adversarial-finding` plus the `domain` value
+  plus any concern tags that apply (e.g. `correctness`, `data-integrity`).
+  This makes the finding discoverable via `kb-search.sh` and tag-overlap
+  cross-reference repair.
 - `severity`:
-  - `tendency` — recurring anti-pattern, not always a bug
-  - `confirmed` — verified bug class, reproduced across features
-  - `critical` — security or data-integrity bug requiring immediate attention
-- `applies_to` — file patterns where this finding is relevant (e.g., `modules/jlsm-table/src/main/**`)
-- `related` — paths to other KB entries covering related concepts (e.g., a concurrency finding
-  might relate to a data-structures entry about the concurrent collection involved)
-- `decision_refs` — ADR slugs from `.decisions/` that this finding is relevant to
+  - `tendency` — recurring anti-pattern, not always a bug.
+  - `confirmed` — verified bug class, reproduced in code.
+  - `critical` — security or data-integrity bug requiring immediate attention.
+- `confidence`:
+  - `medium` — single audit confirmation. **This is the writer's default.**
+  - `high` — observed in 2+ separate audits/features. Earned, not asserted.
+- `applies_to` MUST be non-empty. An adversarial finding with no scope is not
+  actionable for the test writer that consumes it.
+- `decision_refs` — ADR slugs from `.decisions/` that this finding is
+  relevant to (no `.md` extension, no full path).
+
+For full field semantics see `frontmatter.md`.
 
 ## Required sections
 
@@ -51,18 +69,37 @@ last_researched: "<YYYY-MM-DD>"
 <!-- Root cause: spec gap, performance shortcut, language default -->
 
 ## Test guidance
-<!-- Specific test vectors the test-writer should add when working in this domain -->
+<!-- Specific test vectors the test-writer should add when working in this domain.
+     Include the exact assertion shape (exception type, message contents). -->
 
 ## Found in
-<!-- Features where this was discovered, with round/date -->
+<!-- Features where this was discovered, with round/date.
+     Each entry counts as evidence for confidence upgrade. -->
 - <feature-slug> (round N, YYYY-MM-DD): <one-line description>
 ```
 
+Section names are case-sensitive — the audit and curate scanners look for
+exact matches.
+
 ## How it's used
 
-- **Test writer** reads findings matching the current feature's domain during
-  defensive vector generation (Step 1b)
+- **Test writer** reads findings matching the current feature's `domain` and
+  `applies_to` patterns during defensive vector generation.
 - **Spec analyst** reads findings during aTDD round analysis to avoid
-  re-discovering known patterns
+  re-discovering known patterns.
 - **Domain scout** surfaces findings during `/feature-domains` when a domain
-  has adversarial coverage
+  has adversarial coverage.
+- **`/curate`** flags entries with `confidence: high` but only one entry in
+  `## Found in` for confidence downgrade.
+
+## Where adversarial findings should live
+
+Adversarial findings SHOULD be filed under `patterns/<domain>/`, not under a
+research-style topic such as `algorithms/<area>/`. The category split is
+**by lens** (validation, concurrency, resource-management) so the test-writer
+loading findings for a given concern finds them in one place.
+
+A finding discovered while researching SQL parsing belongs at
+`patterns/validation/<finding-name>.md`, with a `related:` link from the
+`algorithms/sql-extensions/<feature>.md` research entry. Putting it in
+`algorithms/sql-extensions/` puts it where readers don't search for it.

--- a/kb/_refs/detail-companion.md
+++ b/kb/_refs/detail-companion.md
@@ -1,0 +1,107 @@
+---
+type: reference-fragment
+title: Detail Companion Convention
+---
+
+# Detail Companion Convention
+
+Some KB entries grow past the size where a single file serves the reader well.
+The detail-companion convention splits such an entry into two files: a main
+article that fits in a research-agent's context budget, and a `-detail.md`
+companion that holds long code skeletons, extended edge cases, and active
+research notes that exceed the main article's scope.
+
+The split is a tool for context efficiency. It is NOT a tool for hiding
+unfinished content or for sidestepping the schema.
+
+## When to split
+
+Split an entry when ALL of the following are true:
+
+- The main article exceeds ~200 lines or ~12 000 characters.
+- The overflow is concentrated in one or two sections (typically a code
+  skeleton, an extended edge-case list, or a research-directions section).
+- The overflow content is genuinely optional for most readers — readers asking
+  "what is X" or "how does X compare to Y" should never need the detail file.
+
+If the overflow is spread evenly across the article, the entry is too broad
+for one subject and SHOULD be split into multiple subject files instead.
+
+## Naming and placement
+
+- Main file: `<subject>.md` at its normal location (e.g. `data-structures/caching/byte-budget-cache.md`).
+- Detail file: `<subject>-detail.md` in the **same directory**.
+- One main may have at most one detail companion.
+- Do not nest detail companions (`<subject>-detail-detail.md` is not allowed).
+
+## Frontmatter requirements (the part that has been silently broken)
+
+A detail companion MUST carry frontmatter, even though it is consumed via
+include from the main file. Detail files without frontmatter are invisible to
+tag-overlap scans, link-rot checks, and cross-reference repair.
+
+```yaml
+---
+title: "<parent title> — Detail"
+type: detail-companion
+companion_to: "<topic>/<category>/<subject>.md"
+last_researched: "YYYY-MM-DD"   # SHOULD match parent
+research_status: "<parent's status>"
+applies_to: []                  # MAY be empty; parent's applies_to is canonical
+---
+```
+
+The `companion_to:` field is mandatory. It points at the parent so `/curate`
+can verify the link is bidirectional (parent ends with `@./<subject>-detail.md`,
+companion's `companion_to:` points at parent).
+
+## Linking from the parent
+
+The main article includes the detail file via Claude Code's `@`-include
+syntax, typically at the end of a section that would otherwise overflow:
+
+```markdown
+## code-skeleton
+
+@./<subject>-detail.md
+```
+
+This works inside Claude Code but does NOT render in plain Markdown viewers
+(e.g. GitHub web). Therefore:
+
+- The main article MUST be useful on its own when read on the web. The detail
+  file holds *additional* depth, not load-bearing primary content.
+- The main article SHOULD include a one-sentence pointer at the include site
+  for web readers: e.g. "Full code skeleton: see [byte-budget-cache-detail.md](byte-budget-cache-detail.md)."
+
+## What goes in the companion
+
+Acceptable content:
+- Full code skeletons (Java/Python/Rust) longer than ~50 lines.
+- Extended edge-case enumerations beyond the 5–7 most important.
+- Active-research-direction notes (open questions, draft directions).
+- Reference implementations with extended commentary.
+
+Unacceptable content (move to the main article or a separate subject):
+- The article's `summary`, `tradeoffs`, `practical-usage`, or `sources`.
+- Anything a "what is X" / "when do I use X" / "what are the tradeoffs"
+  question would need.
+- Findings or audit results — those belong in adversarial-finding entries.
+
+## Indexing
+
+In the parent category's `CLAUDE.md`, the detail companion is NOT a separate
+subject. List the parent normally; do not give the companion its own row in
+the contents table. (`/curate` flags detail companions that have their own
+row as index drift.)
+
+## Validation rules `/curate` enforces
+
+1. Every `<subject>-detail.md` has frontmatter.
+2. Every `<subject>-detail.md` has `type: detail-companion` and `companion_to:`
+   pointing at an existing parent.
+3. Every parent that includes `@./<subject>-detail.md` has a corresponding
+   detail file.
+4. The category index does not list detail companions as standalone subjects.
+5. Detail companions never appear in `Recently Added` in the root index
+   independently of their parent.

--- a/kb/_refs/feature-footprint-template.md
+++ b/kb/_refs/feature-footprint-template.md
@@ -2,6 +2,7 @@
 type: reference-fragment
 title: Feature Footprint Entry Template
 ---
+
 # Feature Footprint Entry Template
 
 KB entries with `type: feature-footprint` are condensed records of what a
@@ -9,35 +10,54 @@ feature built, what domains it touched, and what was learned. Generated during
 `/feature-retro`, they provide cross-reference context for future features
 working in the same areas.
 
+> **Authoritative schema:** `_refs/frontmatter.md`. This template instantiates
+> the schema for feature footprints; it does not extend or override it. If the
+> two diverge, frontmatter.md wins.
+
 ## Frontmatter
 
 ```yaml
 ---
 title: "<feature-slug>"
 type: feature-footprint
-domains: ["<domain1>", "<domain2>"]
-constructs: ["<ClassName>", "<InterfaceName>"]
+domains: ["<domain-1>", "<domain-2>"]
+constructs: ["<TypeName>", "<InterfaceName>"]
 applies_to:
   - "<file path pattern>"
+last_researched: "YYYY-MM-DD"
+research_status: "stable"
+
+# Optional but recommended:
 related: []
 decision_refs: []
 spec_refs: []
-research_status: stable
-last_researched: "<YYYY-MM-DD>"
+tags: []
 ---
 ```
 
-### Field definitions
+### Field-specific guidance for feature footprints
 
-- `type: feature-footprint` — distinguishes from research and adversarial entries
-- `domains` — the domains this feature touched (from domain analysis)
-- `constructs` — key types added or modified (public API surface)
-- `applies_to` — file patterns this feature owns
-- `related` — paths to other KB entries covering related concepts
-- `decision_refs` — ADR slugs from `.decisions/` that governed this feature
-- `spec_refs` — spec IDs from `.spec/` that this feature implements
-- `research_status: stable` — footprints don't go stale in the same way;
-  they're historical records. Use `stable` (12-month staleness review)
+- `domains` (plural, list) — the domains this feature touched. Distinct from
+  adversarial-finding's singular `domain`. Use the same vocabulary as the
+  domain tags in `frontmatter.md`.
+- `constructs` — key public types added or modified. These are the names a
+  future reader is most likely to grep for. Class names, interface names,
+  not method names.
+- `applies_to` — file patterns this feature owns. MUST be non-empty.
+- `decision_refs` — ADR slugs from `.decisions/` that governed this feature.
+- `spec_refs` — spec IDs from `.spec/` that this feature implements.
+- `research_status: stable` — footprints don't go stale in the same way as
+  research; they're historical records. The default and expected value is
+  `stable`. Only mark `archived` if the feature was wholly removed.
+
+For full field semantics see `frontmatter.md`.
+
+## Where feature footprints should live
+
+Feature footprints live under `architecture/feature-footprints/` and follow
+the naming pattern `<feature-slug>.md` (or `<feature-slug>--wd-<NN>.md` for
+work-decomposed features). Avoid placing them anywhere else — they are
+historical artifacts, not research, and `/curate` distinguishes them by path.
 
 ## Required sections
 
@@ -64,8 +84,10 @@ last_researched: "<YYYY-MM-DD>"
 ## How it's used
 
 - **Domain scout** reads footprints during `/feature-domains` to understand
-  what prior work exists in a domain
-- **Curation** (`/curate`) cross-references footprints with git history to
-  detect drift, stale dependencies, and orphaned code
+  what prior work exists in a domain.
+- **`/curate`** cross-references footprints with git history to detect
+  drift, stale dependencies, and orphaned code.
 - **Test writer** uses the adversarial findings section to find relevant
-  patterns when writing tests for constructs in the same domain
+  patterns when writing tests for constructs in the same domain.
+- **`/work-decompose`** uses `constructs` and `applies_to` to find
+  dependencies between work units.

--- a/kb/_refs/frontmatter.md
+++ b/kb/_refs/frontmatter.md
@@ -69,17 +69,21 @@ research_status: "<status>"               # MUST be one of: active, stable, arch
 - `last_researched` — date the entry's content was last verified against
   reality. Updated on every meaningful edit, not just creation. ISO format,
   always in quotes (`"2026-05-09"`, not bare `2026-05-09`).
-- `research_status`:
+- `research_status` — one of:
   - `active` — under ongoing investigation; expect changes within ~30 days.
-  - `stable` — verified, low expected churn. Default for completed research.
-  - `archived` — superseded or retired. Kept for historical reference; readers
-    should prefer the entry that replaced it.
+  - `mature` — verified by production use or extensive audits; ~6-month review.
+  - `stable` — verified, low expected churn; ~12-month review. Default for
+    completed research.
+  - `deprecated` — superseded by a newer entry; the body SHOULD point at the
+    successor. Readers should prefer the successor.
 
 ## Optional core fields (every type)
 
 ```yaml
 aliases: ["<other name>", "<another name>"]   # synonyms for grep / search
 tags: ["<tag-1>", "<tag-2>"]                  # vocabulary below
+topic: "<topic>"                               # informational; path is canonical
+category: "<category>"                         # informational; path is canonical
 related:                                       # other KB entries
   - "<topic>/<category>/<subject>.md"
 decision_refs: []                              # ADR slugs (no .md extension)
@@ -91,6 +95,11 @@ sources:                                       # citations (see Source format)
     type: "<docs|paper|blog|repo|standard>"
 confidence: "<low|medium|high>"                # earned, not asserted
 ```
+
+`topic` and `category` are optional and informational. The file's path is
+canonical — if the path says `data-structures/caching/`, the topic is
+`data-structures` and category is `caching`. When these fields are present,
+they MUST match the path. `/curate` flags mismatches as drift.
 
 ### Tag vocabulary
 
@@ -262,7 +271,12 @@ When a `/curate` schema-drift pass encounters legacy frontmatter:
 - Missing `type:` otherwise becomes `type: research`.
 - Missing `last_researched:` becomes the file's last git-commit date.
 - Missing `research_status:` becomes `stable` for footprints, `active` for everything else.
+- `research_status: archived` is renamed to `deprecated` (the canonical schema
+  uses `deprecated` for "superseded by a newer entry").
 - `confidence: high` without ≥2 corroborating sources/audits is downgraded to `medium` and flagged for human review.
+- Frontmatter `topic:` / `category:` that disagree with the file's path are
+  rewritten to match the path (path is canonical; the fields are
+  informational mirrors).
 
 Migration is opt-in per entry — `/curate` proposes patches and the user
 accepts or declines each one. Bulk silent rewrites are not allowed.

--- a/kb/_refs/frontmatter.md
+++ b/kb/_refs/frontmatter.md
@@ -1,0 +1,268 @@
+---
+type: reference-fragment
+title: KB Frontmatter Schema (Canonical)
+---
+
+# KB Frontmatter Schema (Canonical)
+
+Every KB entry begins with a YAML frontmatter block. This file defines the
+authoritative schema. Every other template (`adversarial-finding-template.md`,
+`feature-footprint-template.md`) MUST align with it. Writer skills (`/research`,
+the audit pipeline, `/feature-retro`) MUST validate against it before writing.
+
+If you are reading this because a `/curate` scan flagged a schema drift, the
+patch is to bring the entry into alignment with this file — not to extend the
+schema to match the entry.
+
+## Why a single schema matters
+
+Inconsistent frontmatter breaks every cross-cutting query the KB depends on:
+
+- `kb-search.sh` ranks by tags and applies_to. Missing tags = missing matches.
+- `/curate` cross-reference repair finds tag-overlap pairs. Missing tags =
+  missing repair candidates.
+- The Research Agent walks `related:` for depth-1 traversal. Missing related =
+  isolated entries that never surface.
+- Tag-based filtering (test-writer, audit) loads findings by `domain`. Missing
+  domain = invisible to the loader.
+
+Schema drift looks cosmetic but degrades search and discoverability silently.
+
+## Entry types
+
+Every entry has exactly one `type`. The type determines which type-specific
+fields are required.
+
+| `type:` value          | Purpose                                         | Template                              |
+|------------------------|-------------------------------------------------|---------------------------------------|
+| `research`             | Algorithm / pattern / system survey + tradeoffs | (this file — see "Research entry")    |
+| `adversarial-finding`  | Bug pattern from audit / aTDD / defensive TDD   | `adversarial-finding-template.md`     |
+| `feature-footprint`    | What a feature built + where it lives           | `feature-footprint-template.md`       |
+| `reference-fragment`   | Schema/convention docs in `_refs/` only         | (this file is one)                    |
+| `detail-companion`     | The `-detail.md` half of a split entry          | `detail-companion.md`                 |
+
+**Default type when unset:** `research`. A writer that creates an entry without
+a `type:` field is producing a research-style entry. (Writers SHOULD set it
+explicitly. Readers MUST treat omission as `research`.)
+
+## Required core fields (every type)
+
+```yaml
+---
+title: "<Human-readable title>"           # MUST be present, in quotes
+type: "<entry type>"                      # MUST be one of the values above
+applies_to:                               # MUST be a list (may be empty for cross-cutting research)
+  - "<file/module path or pattern>"
+last_researched: "YYYY-MM-DD"             # MUST be ISO date, in quotes
+research_status: "<status>"               # MUST be one of: active, stable, archived
+---
+```
+
+### Field semantics
+
+- `title` — exact, human-readable. Will be used as the subject row's display
+  name in category indexes. Avoid filename-style kebab-case here.
+- `type` — see entry-types table above. One value, never a list.
+- `applies_to` — file/module patterns this entry is *about*. For research
+  entries that survey a general algorithm, an empty list is acceptable. For
+  adversarial findings and feature footprints, this MUST be non-empty.
+- `last_researched` — date the entry's content was last verified against
+  reality. Updated on every meaningful edit, not just creation. ISO format,
+  always in quotes (`"2026-05-09"`, not bare `2026-05-09`).
+- `research_status`:
+  - `active` — under ongoing investigation; expect changes within ~30 days.
+  - `stable` — verified, low expected churn. Default for completed research.
+  - `archived` — superseded or retired. Kept for historical reference; readers
+    should prefer the entry that replaced it.
+
+## Optional core fields (every type)
+
+```yaml
+aliases: ["<other name>", "<another name>"]   # synonyms for grep / search
+tags: ["<tag-1>", "<tag-2>"]                  # vocabulary below
+related:                                       # other KB entries
+  - "<topic>/<category>/<subject>.md"
+decision_refs: []                              # ADR slugs (no .md extension)
+spec_refs: []                                  # spec IDs from .spec/
+sources:                                       # citations (see Source format)
+  - url: "https://example.com/page"
+    title: "<source title>"
+    accessed: "YYYY-MM-DD"
+    type: "<docs|paper|blog|repo|standard>"
+confidence: "<low|medium|high>"                # earned, not asserted
+```
+
+### Tag vocabulary
+
+Tags are the primary cross-cutting query dimension. Use these conventions:
+
+- **Domain tags**: `concurrency`, `validation`, `resource-management`,
+  `serialization`, `caching`, `networking`, `consensus`, `replication`,
+  `security`, `compression`, `encryption`, `partitioning`.
+- **Concern tags**: `correctness`, `performance`, `memory-safety`,
+  `data-integrity`, `availability`.
+- **Discovery tags** (adversarial-finding only): `adversarial-finding`,
+  `defensive-test-vector`, `audit-confirmed`.
+- **Construct tags**: `builder`, `record`, `interface`, `closeable`,
+  `iterator`, `cache`, `lock`.
+
+Tags MUST be lowercase kebab-case. Do not invent new tag spellings for
+existing concepts (e.g. don't introduce `concurrent` when `concurrency`
+exists). When unsure, grep `kb/` for the existing spelling.
+
+### Confidence
+
+`confidence` is earned, not asserted by the author:
+
+- `high` — verified across **2 or more independent sources** (research) OR
+  **observed in 2 or more separate audits/features** (adversarial-finding).
+- `medium` — single strong source / one audit confirmation.
+- `low` — speculative; not yet validated against multiple data points.
+
+Writers MUST NOT default to `high`. The audit pipeline and `/research` writer
+SHOULD start at `medium` and require explicit corroboration evidence to upgrade
+to `high`. `/curate` flags `confidence: high` entries with single-source or
+single-audit provenance for downgrade.
+
+### Source format
+
+Cite each external source as a structured object. Bare URLs without `accessed:`
+dates are rejected at write time — wiki-style sources rot, and an undated
+citation cannot be re-verified.
+
+```yaml
+sources:
+  - url: "https://github.com/owner/repo/wiki/Page"
+    title: "Page Title"
+    accessed: "2026-05-09"
+    type: "docs"
+  - url: "https://arxiv.org/abs/2404.12345"
+    title: "Paper Title (Author et al., 2024)"
+    accessed: "2026-05-09"
+    type: "paper"
+```
+
+`type:` values: `docs`, `paper`, `blog`, `repo`, `standard`, `talk`.
+
+## Type-specific required fields
+
+### Research entry (`type: research`)
+
+No additional required fields beyond core. Optional fields commonly used:
+
+```yaml
+complexity:
+  time_build: "<big-O>"
+  time_query: "<big-O>"
+  space:      "<big-O>"
+```
+
+### Adversarial finding (`type: adversarial-finding`)
+
+```yaml
+domain: "<security|memory-safety|performance|concurrency|data-integrity|validation>"
+severity: "<tendency|confirmed|critical>"
+```
+
+- `domain` is one value, used by the test-writer to load relevant findings.
+- `severity`:
+  - `tendency` — recurring anti-pattern, not always a bug.
+  - `confirmed` — verified bug class, reproduced in code.
+  - `critical` — security or data-integrity bug requiring immediate attention.
+
+### Feature footprint (`type: feature-footprint`)
+
+```yaml
+domains: ["<domain-1>", "<domain-2>"]
+constructs: ["<TypeName>", "<InterfaceName>"]
+```
+
+- `domains` (plural) — the domains this feature touched. Distinct from
+  adversarial-finding's singular `domain`.
+- `constructs` — key public types added or modified.
+
+Feature footprints SHOULD live under `architecture/feature-footprints/` and
+SHOULD use `research_status: stable` (footprints are historical records, not
+research that goes stale on a fixed cadence).
+
+### Detail companion (`type: detail-companion`)
+
+A detail companion is the bottom half of a split entry. See
+`detail-companion.md` for the full convention. Required core fields apply,
+plus:
+
+```yaml
+companion_to: "<topic>/<category>/<subject>.md"   # MUST point at the parent
+```
+
+The companion's `title` SHOULD be the parent's title plus " — Detail".
+
+## Filename rules
+
+- Lowercase kebab-case: `byte-budget-cache-variable-size-entries.md`.
+- ASCII only, no spaces, no underscores.
+- A filename MUST be unique across the entire KB tree, not just within its
+  category. If `partial-init-no-rollback.md` exists in `patterns/validation/`,
+  do not also create `patterns/resource-management/partial-init-no-rollback.md`
+  — disambiguate (e.g. `builder-pre-validation-mutation.md`,
+  `multi-step-init-no-rollback.md`). Cross-folder collisions break grep and
+  hide pattern-recurrence evidence under separate filenames.
+
+`/curate` flags cross-folder filename collisions as drift candidates.
+
+## What lives in `_refs/` only
+
+`type: reference-fragment` is reserved for schema and convention docs that
+ship with vallorcine and are referenced from elsewhere. Do not invent new
+`reference-fragment` entries inside a project's KB; that namespace is for the
+kit, not the project.
+
+## Required body sections by type
+
+These are listed for completeness; full templates are in the per-type files.
+
+| Type                  | Required H2 sections (in order)                               |
+|-----------------------|---------------------------------------------------------------|
+| `research`            | `summary`, `how-it-works`, `tradeoffs`, `practical-usage`, `sources` |
+| `adversarial-finding` | `What happens`, `Why implementations default to this`, `Test guidance`, `Found in` |
+| `feature-footprint`   | `What it built`, `Key constructs`, `Adversarial findings`, `Cross-references` |
+| `detail-companion`    | (free-form; this file does not gate body content)             |
+
+Section names are case-sensitive and used by the audit and curate scanners.
+Re-naming `## Sources` to `## References` will cause sources to drop out of
+link-rot scans.
+
+## Validating an entry
+
+A writer skill validating an entry SHOULD:
+
+1. Parse the YAML frontmatter. Reject if missing or malformed.
+2. Confirm `type` is one of the known values; default to `research` if absent.
+3. Confirm all core required fields are present and non-empty (except
+   `applies_to` which may be empty for general research).
+4. Confirm type-specific required fields are present.
+5. Confirm `last_researched` matches `^\d{4}-\d{2}-\d{2}$`.
+6. Confirm `research_status` is one of the three allowed values.
+7. Confirm tags (if present) are all lowercase kebab-case.
+8. Confirm sources (if present) all have `url`, `title`, and `accessed`.
+9. Confirm filename does not collide with another KB entry under any topic.
+10. Confirm `type: reference-fragment` only appears in `_refs/`.
+
+`/curate` runs these same checks against existing entries and flags
+deviations.
+
+## Migration rules for legacy entries
+
+Some KB instances have entries authored before this schema was canonical.
+When a `/curate` schema-drift pass encounters legacy frontmatter:
+
+- A bare-URL source becomes `{ url, title: "<derived from URL>", accessed: "<git-blame-date>", type: "<inferred>" }`.
+- Missing `type:` on an entry under `architecture/feature-footprints/` becomes `type: feature-footprint`.
+- Missing `type:` on an entry containing the section `## What happens` AND a `## Found in` becomes `type: adversarial-finding`.
+- Missing `type:` otherwise becomes `type: research`.
+- Missing `last_researched:` becomes the file's last git-commit date.
+- Missing `research_status:` becomes `stable` for footprints, `active` for everything else.
+- `confidence: high` without ≥2 corroborating sources/audits is downgraded to `medium` and flagged for human review.
+
+Migration is opt-in per entry — `/curate` proposes patches and the user
+accepts or declines each one. Bulk silent rewrites are not allowed.

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1871,6 +1871,206 @@ if [[ -n "$LENS_REGISTRY" ]] && [[ -d ".spec" && -f ".spec/registry/manifest.jso
     fi
 fi
 
+# ── Analysis 23: Cross-folder KB filename collisions ────────────────────────
+# Two entries with the same filename under different folders silently fragment
+# search and pattern-recurrence evidence. Flag every collision pair.
+#
+# Output: KB_COLLISION|<basename>|<path1>|<path2>[|<path3>...]
+
+> "$TMPDIR_SCAN/kb-collisions.txt"
+if [[ -d ".kb" ]]; then
+    find .kb -type f -name '*.md' \
+        -not -name 'CLAUDE.md' \
+        -not -path '*/_refs/*' \
+        -not -path '*/_archive*' \
+        2>/dev/null | awk -F/ '{ name=$NF; print name "|" $0 }' \
+      | sort \
+      | awk -F'|' '
+            $1 != prev_name { if (count > 1) print prev_line; prev_name = $1; prev_line = "KB_COLLISION|" $1 "|" $2; count = 1; next }
+            { prev_line = prev_line "|" $2; count++ }
+            END { if (count > 1) print prev_line }
+        ' >> "$TMPDIR_SCAN/kb-collisions.txt"
+fi
+
+# ── Analysis 24: KB frontmatter schema drift ────────────────────────────────
+# Validates each KB entry against .kb/_refs/frontmatter.md. Emits one row per
+# distinct issue per entry so the user can address each independently.
+#
+# Output: KB_SCHEMA|<path>|<issue-code>|<detail>
+
+> "$TMPDIR_SCAN/kb-schema-drift.txt"
+if [[ -d ".kb" ]]; then
+    find .kb -type f -name '*.md' \
+        -not -name 'CLAUDE.md' \
+        -not -path '*/_refs/*' \
+        -not -path '*/_archive*' \
+        2>/dev/null | while IFS= read -r kb_file; do
+
+        # Extract frontmatter block (lines between the first two --- markers).
+        # Skip files without a frontmatter block.
+        fm="$(awk '
+            BEGIN { in_fm = 0; found = 0 }
+            /^---[[:space:]]*$/ {
+                if (in_fm == 0) { in_fm = 1; found = 1; next }
+                else            { in_fm = 0; exit }
+            }
+            in_fm == 1 { print }
+            END { if (!found) exit 1 }
+        ' "$kb_file" 2>/dev/null)" || {
+            echo "KB_SCHEMA|$kb_file|missing-frontmatter|no YAML block at top of file" \
+                >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+            continue
+        }
+
+        # Field extraction. Each helper returns the raw value or empty string.
+        get_field() {
+            echo "$fm" | grep -E "^${1}:" | head -1 | sed -E "s/^${1}:[[:space:]]*//" | tr -d '"' || true
+        }
+        has_field() {
+            echo "$fm" | grep -qE "^${1}:"
+        }
+
+        title="$(get_field title)"
+        type_field="$(get_field type)"
+        last_researched="$(get_field last_researched)"
+        research_status="$(get_field research_status)"
+        confidence="$(get_field confidence)"
+        topic_field="$(get_field topic)"
+        category_field="$(get_field category)"
+
+        # Required core fields (per frontmatter.md).
+        [[ -z "$title" ]] && \
+            echo "KB_SCHEMA|$kb_file|missing-title|required field 'title' is empty or absent" \
+                >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+        [[ -z "$last_researched" ]] && \
+            echo "KB_SCHEMA|$kb_file|missing-last-researched|required field 'last_researched' is empty or absent" \
+                >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+        if [[ -n "$last_researched" && ! "$last_researched" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "KB_SCHEMA|$kb_file|bad-last-researched|value '$last_researched' is not ISO YYYY-MM-DD" \
+                >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+        fi
+        [[ -z "$research_status" ]] && \
+            echo "KB_SCHEMA|$kb_file|missing-research-status|required field 'research_status' is empty or absent" \
+                >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+        if [[ -n "$research_status" ]]; then
+            case "$research_status" in
+                active|mature|stable|deprecated) ;;
+                archived)
+                    echo "KB_SCHEMA|$kb_file|legacy-research-status|value 'archived' is legacy; canonical is 'deprecated'" \
+                        >> "$TMPDIR_SCAN/kb-schema-drift.txt" ;;
+                *)
+                    echo "KB_SCHEMA|$kb_file|bad-research-status|value '$research_status' not in {active,mature,stable,deprecated}" \
+                        >> "$TMPDIR_SCAN/kb-schema-drift.txt" ;;
+            esac
+        fi
+
+        # Type-specific required fields.
+        case "$type_field" in
+            adversarial-finding)
+                has_field domain   || echo "KB_SCHEMA|$kb_file|missing-domain|adversarial-finding requires 'domain' field" \
+                    >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+                has_field severity || echo "KB_SCHEMA|$kb_file|missing-severity|adversarial-finding requires 'severity' field" \
+                    >> "$TMPDIR_SCAN/kb-schema-drift.txt" ;;
+            feature-footprint)
+                has_field domains    || echo "KB_SCHEMA|$kb_file|missing-domains|feature-footprint requires 'domains' field" \
+                    >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+                has_field constructs || echo "KB_SCHEMA|$kb_file|missing-constructs|feature-footprint requires 'constructs' field" \
+                    >> "$TMPDIR_SCAN/kb-schema-drift.txt" ;;
+            detail-companion)
+                has_field companion_to || echo "KB_SCHEMA|$kb_file|missing-companion-to|detail-companion requires 'companion_to' field" \
+                    >> "$TMPDIR_SCAN/kb-schema-drift.txt" ;;
+            "")
+                # No type field — usually means writer used legacy template.
+                # Heuristic: if file has 'What happens' + 'Found in' it should be adversarial-finding.
+                if grep -q '^## What happens' "$kb_file" 2>/dev/null && \
+                   grep -q '^## Found in' "$kb_file" 2>/dev/null; then
+                    echo "KB_SCHEMA|$kb_file|missing-type|file looks like adversarial-finding (has 'What happens' + 'Found in') but type is unset" \
+                        >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+                else
+                    echo "KB_SCHEMA|$kb_file|missing-type|required field 'type' is unset (defaults to 'research'; set explicitly)" \
+                        >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+                fi ;;
+            research|reference-fragment) ;;
+            *)
+                echo "KB_SCHEMA|$kb_file|bad-type|value '$type_field' not in {research,adversarial-finding,feature-footprint,detail-companion,reference-fragment}" \
+                    >> "$TMPDIR_SCAN/kb-schema-drift.txt" ;;
+        esac
+
+        # Confidence overclaim heuristic: confidence: high requires ≥2
+        # corroborating sources (sources URLs) or ≥2 entries in '## Found in'.
+        if [[ "$confidence" == "high" ]]; then
+            sources_count="$(echo "$fm" | grep -cE '^[[:space:]]*-[[:space:]]+url:' || true)"
+            found_in_count=0
+            if grep -q '^## Found in' "$kb_file" 2>/dev/null; then
+                found_in_count="$(awk '
+                    /^## Found in/ { in_section = 1; next }
+                    in_section && /^## / { exit }
+                    in_section && /^- / { count++ }
+                    END { print count + 0 }
+                ' "$kb_file" 2>/dev/null || echo 0)"
+            fi
+            corroboration=$(( sources_count > found_in_count ? sources_count : found_in_count ))
+            if (( corroboration < 2 )); then
+                echo "KB_SCHEMA|$kb_file|confidence-overclaim|confidence: high but only $corroboration corroborating source/finding (need ≥2)" \
+                    >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+            fi
+        fi
+
+        # Path ↔ frontmatter consistency for topic / category fields.
+        # The path is canonical; populated fields MUST match.
+        path_topic="$(echo "$kb_file" | awk -F/ '{ print $2 }')"
+        path_category="$(echo "$kb_file" | awk -F/ '{ print $3 }')"
+        if [[ -n "$topic_field" && "$topic_field" != "$path_topic" ]]; then
+            echo "KB_SCHEMA|$kb_file|topic-mismatch|frontmatter topic='$topic_field' but path implies '$path_topic'" \
+                >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+        fi
+        if [[ -n "$category_field" && "$category_field" != "$path_category" ]]; then
+            echo "KB_SCHEMA|$kb_file|category-mismatch|frontmatter category='$category_field' but path implies '$path_category'" \
+                >> "$TMPDIR_SCAN/kb-schema-drift.txt"
+        fi
+    done
+fi
+
+# ── Analysis 25: KB type ↔ location mismatch ───────────────────────────────
+# Adversarial-finding entries belong under patterns/<concern>/, not under
+# research-style topics. Feature-footprints belong under
+# architecture/feature-footprints/. Catches mis-filed findings that hide from
+# the test-writer.
+#
+# Output: KB_LOCATION|<path>|<expected-prefix>|<actual-prefix>|<reason>
+
+> "$TMPDIR_SCAN/kb-location-mismatch.txt"
+if [[ -d ".kb" ]]; then
+    find .kb -type f -name '*.md' \
+        -not -name 'CLAUDE.md' \
+        -not -path '*/_refs/*' \
+        -not -path '*/_archive*' \
+        2>/dev/null | while IFS= read -r kb_file; do
+
+        type_field="$(awk '
+            BEGIN { in_fm = 0 }
+            /^---[[:space:]]*$/ { in_fm = !in_fm; next }
+            in_fm && /^type:/ { sub(/^type:[[:space:]]*/, ""); gsub(/"/, ""); print; exit }
+        ' "$kb_file" 2>/dev/null)"
+
+        rel="${kb_file#.kb/}"
+        topic="${rel%%/*}"
+
+        case "$type_field" in
+            adversarial-finding)
+                if [[ "$topic" != "patterns" ]]; then
+                    echo "KB_LOCATION|$kb_file|patterns/<concern>/|$topic/|adversarial-finding outside patterns/" \
+                        >> "$TMPDIR_SCAN/kb-location-mismatch.txt"
+                fi ;;
+            feature-footprint)
+                if [[ "$rel" != "architecture/feature-footprints/"* ]]; then
+                    echo "KB_LOCATION|$kb_file|architecture/feature-footprints/|$topic/|feature-footprint outside architecture/feature-footprints/" \
+                        >> "$TMPDIR_SCAN/kb-location-mismatch.txt"
+                fi ;;
+        esac
+    done
+fi
+
 # ── Write summary file ──────────────────────────────────────────────────────
 
 SCAN_DATE="$(date +%Y-%m-%d)"
@@ -2357,6 +2557,70 @@ if [[ -s "$TMPDIR_SCAN/link-rot.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# KB filename collisions (Analysis 23)
+if [[ -s "$TMPDIR_SCAN/kb-collisions.txt" ]]; then
+    echo "## KB Filename Collisions" >> "$SUMMARY_FILE"
+    echo "Two or more KB entries share a filename under different folders." >> "$SUMMARY_FILE"
+    echo "Cross-folder collisions silently fragment search and pattern-recurrence" >> "$SUMMARY_FILE"
+    echo "evidence — \`grep partial-init-no-rollback.md\` returns N hits and the" >> "$SUMMARY_FILE"
+    echo "reader has to triangulate which is canonical." >> "$SUMMARY_FILE"
+    echo "Resolve by renaming the lesser-used variants to disambiguate." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Filename | Locations |" >> "$SUMMARY_FILE"
+    echo "|----------|-----------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ name path1 rest; do
+        # Multiple paths may follow; concatenate with <br> for readability.
+        if [[ -n "$rest" ]]; then
+            locations="$path1<br>$(echo "$rest" | tr '|' '\n' | sed 's/^/<br>/' | tr -d '\n')"
+            locations="${locations//<br><br>/<br>}"
+        else
+            locations="$path1"
+        fi
+        echo "| $name | $locations |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/kb-collisions.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+# KB schema drift (Analysis 24)
+if [[ -s "$TMPDIR_SCAN/kb-schema-drift.txt" ]]; then
+    echo "## KB Schema Drift" >> "$SUMMARY_FILE"
+    echo "KB entries whose frontmatter does not match the canonical schema at" >> "$SUMMARY_FILE"
+    echo "\`.kb/_refs/frontmatter.md\`. Each row is one issue per entry; an" >> "$SUMMARY_FILE"
+    echo "entry with multiple issues appears multiple times. Drift breaks" >> "$SUMMARY_FILE"
+    echo "tag-based search, cross-reference repair, and type-aware loaders." >> "$SUMMARY_FILE"
+    echo "Issue codes: \`missing-*\` (required field absent), \`bad-*\` (value" >> "$SUMMARY_FILE"
+    echo "outside allowed enum), \`legacy-*\` (deprecated value used)," >> "$SUMMARY_FILE"
+    echo "\`confidence-overclaim\` (\`high\` without ≥2 corroborations)," >> "$SUMMARY_FILE"
+    echo "\`*-mismatch\` (frontmatter field disagrees with file path)." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Entry | Issue | Detail |" >> "$SUMMARY_FILE"
+    echo "|-------|-------|--------|" >> "$SUMMARY_FILE"
+    # Sort so a reader sees all issues for one entry together.
+    sort "$TMPDIR_SCAN/kb-schema-drift.txt" 2>/dev/null \
+      | while IFS='|' read -r _ kb_file issue detail; do
+            echo "| $kb_file | $issue | $detail |" >> "$SUMMARY_FILE"
+        done
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+# KB type ↔ location mismatch (Analysis 25)
+if [[ -s "$TMPDIR_SCAN/kb-location-mismatch.txt" ]]; then
+    echo "## KB Type/Location Mismatch" >> "$SUMMARY_FILE"
+    echo "KB entries whose declared \`type:\` does not match their location." >> "$SUMMARY_FILE"
+    echo "Adversarial findings filed under \`algorithms/\` or \`systems/\` are" >> "$SUMMARY_FILE"
+    echo "invisible to the test-writer that loads findings from" >> "$SUMMARY_FILE"
+    echo "\`patterns/<concern>/\`. Resolve by relocating the entry, updating" >> "$SUMMARY_FILE"
+    echo "the type to match the location, or splitting into a research entry" >> "$SUMMARY_FILE"
+    echo "(at the current path) plus a finding (under \`patterns/\`)." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Entry | Expected Prefix | Actual Prefix | Reason |" >> "$SUMMARY_FILE"
+    echo "|-------|-----------------|---------------|--------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ kb_file expected actual reason; do
+        echo "| $kb_file | $expected | $actual | $reason |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/kb-location-mismatch.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # Falsification lens staleness (Analysis 22)
 if [[ -s "$TMPDIR_SCAN/falsification-stale.txt" ]]; then
     echo "## Falsification Lens Staleness" >> "$SUMMARY_FILE"
@@ -2411,6 +2675,9 @@ echo "  Aging obligations: $(wc -l < "$TMPDIR_SCAN/aging-obligations.txt" 2>/dev
 echo "  Subdivision candidates: $(wc -l < "$TMPDIR_SCAN/spec-subdivision-candidates.txt" 2>/dev/null || echo 0)"
 echo "  Link rot in KB: $(wc -l < "$TMPDIR_SCAN/link-rot.txt" 2>/dev/null || echo 0)"
 echo "  Falsification staleness: $(wc -l < "$TMPDIR_SCAN/falsification-stale.txt" 2>/dev/null || echo 0)"
+echo "  KB filename collisions: $(wc -l < "$TMPDIR_SCAN/kb-collisions.txt" 2>/dev/null || echo 0)"
+echo "  KB schema drift: $(wc -l < "$TMPDIR_SCAN/kb-schema-drift.txt" 2>/dev/null || echo 0)"
+echo "  KB type/location mismatch: $(wc -l < "$TMPDIR_SCAN/kb-location-mismatch.txt" 2>/dev/null || echo 0)"
 
 # ── Update curation state ─────────────────────────────────────────────────
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1131,9 +1131,14 @@ Then use AskUserQuestion to get the user's choice:
 Do not proceed until the user has responded.
 
 If **create**: for each pattern, invoke
-`/research "<subject>" context: "audit adversarial pattern from <target>. Suggested: <topic>/adversarial-findings"` as a sub-agent with the pattern's
-description and affected constructs as context. After all creates complete,
-rename: `mv kb-suggestions.md kb-suggestions.applied.md`
+`/research "<subject>" context: "audit adversarial pattern from <target>. Suggested: patterns/<concern>"` as a sub-agent with the pattern's
+description and affected constructs as context. The `<concern>` is the
+pattern's lens (`validation`, `concurrency`, `resource-management`,
+`testing`, `transactions`), NOT the discovery domain. `/research` will
+infer `type: adversarial-finding` from the hint and use the
+adversarial-finding template at `.kb/_refs/adversarial-finding-template.md`.
+
+After all creates complete, rename: `mv kb-suggestions.md kb-suggestions.applied.md`
 
 If **select**: present each pattern individually for create/skip. After all
 items are processed, rename the file.

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -25,6 +25,9 @@ couldn't see because they each had a narrower scope.
 13. Aging open obligations — obligations on specs that haven't been committed in 30+ days
 14. Link rot — KB-cited URLs that no longer resolve (4xx or connection failures)
 15. Falsification-lens staleness — APPROVED specs authored before a falsification lens shipped that match the lens's keywords (candidates for re-falsification under the newer lens)
+16. KB filename collisions — entries sharing a filename across folders (silently fragments search and pattern-recurrence evidence)
+17. KB schema drift — frontmatter that does not match `.kb/_refs/frontmatter.md` (missing/bad-enum fields, confidence overclaim, path/frontmatter mismatch)
+18. KB type/location mismatch — adversarial findings outside `patterns/<concern>/` or feature-footprints outside `architecture/feature-footprints/`
 
 **Flags:**
 - `--init` — first-time scan (ignores last-scanned SHA, good for new installs)
@@ -627,6 +630,105 @@ The "Decline — concerns are interlocked" option is important. Subdivision
 fragments a coherent contract when forced; it should never be automatic.
 Honest declines are a feature, not a failure.
 
+### 2r — KB structural drift
+
+**Guard:** Only run this step if any of the following sections exist in the
+scan summary: "KB Filename Collisions", "KB Schema Drift", "KB Type/Location
+Mismatch". If none exist, skip entirely.
+
+These three analyses share a goal — keep the KB's structure aligned with
+`.kb/_refs/frontmatter.md` so search, cross-reference repair, and type-aware
+loaders work. They are presented together because the user's typical action
+is the same: review one entry's drift and apply the patch.
+
+**KB filename collisions** (from "KB Filename Collisions" in scan summary):
+
+1. Each row shows a filename that exists at 2+ paths under different
+   folders. Cross-folder collisions silently fragment grep, pattern-
+   recurrence evidence, and `kb-search.sh` ranking. A reader running
+   `grep partial-init-no-rollback.md .kb` gets N hits and cannot tell
+   which is canonical.
+2. Resolve by renaming the lesser-used variant(s) to disambiguate (e.g.,
+   `builder-pre-validation-mutation.md` and `multi-step-init-no-rollback.md`).
+3. Alternatively, if the collision is intentional and benign, dismiss with a
+   one-line reason — but the default assumption is that a collision is drift.
+
+For each collision, use AskUserQuestion with options:
+- **"Rename one variant"** (description: "Choose which path keeps the name; the
+  other gets a more specific filename. /curate updates references that point
+  at the renamed file.")
+- **"Merge into one entry"** (description: "If the entries cover the same
+  pattern, merge into the canonical location and delete the duplicate.
+  Append the deleted entry's `## Audit Findings` history to the kept entry.")
+- **"Dismiss as intentional"** (description: "Record in review log; won't
+  resurface")
+- **"Skip"** (description: "Defer to next /curate pass")
+
+**KB schema drift** (from "KB Schema Drift" in scan summary):
+
+1. Each row is one issue per entry. Issue codes:
+   - `missing-frontmatter` — no YAML block at top.
+   - `missing-<field>` — required core or type-specific field absent.
+   - `bad-<field>` — value outside the allowed enum (e.g.
+     `research_status: foo`).
+   - `legacy-<field>` — deprecated value in use (e.g.
+     `research_status: archived` should be `deprecated`).
+   - `confidence-overclaim` — `confidence: high` without ≥2 corroborating
+     sources or `## Found in` entries.
+   - `topic-mismatch` / `category-mismatch` — frontmatter field disagrees
+     with the file's path (path is canonical).
+2. An entry with multiple issues appears multiple times. Resolve them
+   together when picking that entry.
+3. Drift breaks tag-based search, cross-reference repair, and the
+   type-aware loaders in `/research`, audit, and feature-retro.
+
+For each entry (group rows by path), use AskUserQuestion with options:
+- **"Apply patches"** (description: "/curate proposes the minimal edits — add
+  missing fields with derived values, fix enum values, downgrade
+  unsupported confidence, sync topic/category to path. Review each patch
+  before write.")
+- **"Walk one issue at a time"** (description: "Present each issue individually
+  with its own apply/skip choice. Use when patches need per-issue judgment.")
+- **"Dismiss the entry"** (description: "The drift is intentional or the
+  entry is being retired. Record in review log.")
+- **"Skip"** (description: "Defer to next /curate pass")
+
+When applying patches, derive values from the entry's existing content where
+possible — e.g., infer missing `last_researched` from git-blame's most-recent
+commit, infer missing `type:` from section headings (`## What happens` +
+`## Found in` ⇒ `adversarial-finding`).
+
+**KB type/location mismatch** (from "KB Type/Location Mismatch" in scan summary):
+
+1. Each row shows an entry whose declared `type:` does not match its path
+   prefix:
+   - `type: adversarial-finding` MUST live under `patterns/<concern>/`.
+   - `type: feature-footprint` MUST live under
+     `architecture/feature-footprints/`.
+2. Adversarial findings in `algorithms/` or `systems/` are invisible to the
+   test-writer that loads findings from `patterns/<concern>/` — they don't
+   show up in defensive-vector generation or audit lens loads. The bug they
+   describe gets re-discovered.
+
+For each mismatch, use AskUserQuestion with options:
+- **"Relocate the entry"** (description: "Move to the canonical path under
+  `patterns/<concern>/` (for findings) or `architecture/feature-footprints/`
+  (for footprints). Update all incoming `related:` links. /curate proposes
+  a destination; the user can override.")
+- **"Re-classify the type"** (description: "The entry isn't actually a finding
+  / footprint — it's research that mentions a finding. Change `type:` to
+  `research`, leave the location, and split the actual finding into a new
+  entry under `patterns/`.")
+- **"Dismiss as intentional"** (description: "Rare; the location is
+  deliberately non-canonical. Record in review log.")
+- **"Skip"** (description: "Defer to next /curate pass")
+
+When relocating, propose the destination as `patterns/<concern>/<basename>` —
+the writer must still pick the appropriate concern (`validation`,
+`concurrency`, `resource-management`, `testing`, `transactions`).
+`/curate` infers the concern from the entry's `domain:` field (for
+adversarial-findings) or asks the user.
+
 ---
 
 ## Step 2.5 — Merge in unresolved prior items
@@ -771,6 +873,15 @@ I scanned <N> commits since last review and found <N> items:
 
  19. Spec <ID> — authored <date>, predates <lens> lens (matched keyword "<word>")
      → I'll show the lens scope so you can run a depth pass or decline
+
+ 20. <N> KB filename collisions — `<basename>` exists at <N> paths
+     → I'll show each so you can rename, merge, or dismiss
+
+ 21. <N> KB schema-drift issues across <M> entries
+     → I'll group by entry and propose patches against `.kb/_refs/frontmatter.md`
+
+ 22. <N> KB type/location mismatches — adversarial-findings outside `patterns/` or footprints outside `architecture/feature-footprints/`
+     → I'll propose a relocation or type reclassification per entry
 
 Items you don't address are saved automatically — run /curate anytime to pick them up.
 ```
@@ -1149,6 +1260,99 @@ If "Dismiss" (verify mode only): append
 `.curate/verify-dismissed.txt`. Prompt for a one-line reason; default
 to "user dismissed".
 
+**KB filename collision:** Read both/all colliding entries and present a
+side-by-side: title, type, last_researched, audit-finding count, and the
+first sentence of `## summary` or `## What happens`. Help the user judge
+which is canonical. Present:
+
+```
+── Filename collision: <basename> ─────────────
+  [A] <path-A>
+      type: <type>, last: <date>, citations: <N>
+      "<first-sentence>"
+
+  [B] <path-B>
+      type: <type>, last: <date>, citations: <N>
+      "<first-sentence>"
+```
+
+Use AskUserQuestion:
+  - "Rename A" — A becomes a more specific filename; user proposes the new name
+  - "Rename B" — B becomes a more specific filename; user proposes the new name
+  - "Merge into A" — fold B's audit-findings into A, delete B, update incoming `related:` links
+  - "Merge into B" — fold A's audit-findings into B, delete A, update incoming `related:` links
+  - "Dismiss as intentional" — record in review log; won't resurface
+  - "Skip" — defer
+
+When renaming, do NOT just `git mv` the file — also update every `related:`
+entry in the rest of `.kb/` that points at the old path, and check
+`@./` includes from any parent file (detail-companion convention) for
+broken references. Stage the rename + reference updates as one commit; do
+not push unless the user requests it.
+
+**KB schema drift:** Read the entry and present the issues grouped together:
+
+```
+── Schema drift: <path> ──────────────────────
+  Issues (<N>):
+    · missing-type — required field 'type' is unset
+    · missing-last-researched — field absent
+    · confidence-overclaim — confidence: high but only 1 corroborating finding
+
+  Frontmatter (current):
+    title: "<title>"
+    research_status: "active"
+    confidence: "high"
+    ...
+
+  Proposed patches (per .kb/_refs/frontmatter.md):
+    + type: adversarial-finding   (inferred from sections '## What happens' + '## Found in')
+    + last_researched: "2026-04-12"   (from git-blame)
+    ~ confidence: medium   (downgrade from high; only 1 finding)
+```
+
+Use AskUserQuestion:
+  - "Apply patches" — write all proposed patches at once
+  - "Walk one at a time" — present each issue individually with its own apply/skip
+  - "Dismiss the entry" — drift is intentional; record in review log
+  - "Skip" — defer
+
+When applying, derive values where possible:
+- `last_researched` → most-recent git commit touching the file
+- `type` → infer from sections (`## What happens` + `## Found in` ⇒ `adversarial-finding`; entry under `architecture/feature-footprints/` ⇒ `feature-footprint`; otherwise `research`)
+- `research_status: archived` → rewrite to `deprecated`
+- `topic:` / `category:` mismatches → rewrite to match the path
+- `confidence: high` overclaim → downgrade to `medium`
+
+Always stage the patches; do not commit unless explicitly requested.
+
+**KB type/location mismatch:** Read the entry. Determine the expected location:
+- `type: adversarial-finding` → `patterns/<concern>/<basename>`. Infer
+  `<concern>` from the entry's `domain:` field (`validation`, `concurrency`,
+  `resource-management`, `data-integrity`, etc.). If the domain doesn't map
+  cleanly, ask the user with AskUserQuestion listing the existing
+  `patterns/` subfolders.
+- `type: feature-footprint` → `architecture/feature-footprints/<basename>`.
+
+Present:
+
+```
+── Type/location mismatch: <path> ────────────
+  Type: <type>
+  Current location: <topic>/<category>/
+  Canonical location: <expected-prefix>
+  Reason: <reason>
+```
+
+Use AskUserQuestion:
+  - "Relocate" — move to the canonical location, update incoming `related:` links and any `@./` includes
+  - "Re-classify type" — entry is research that mentions a finding; change `type:` to `research`, leave at current path. Then ask if the user wants to also create a new finding entry under `patterns/<concern>/`
+  - "Dismiss as intentional" — rare; record in review log
+  - "Skip" — defer
+
+When relocating, the same care as for filename collisions applies — update
+every incoming `related:` link, check `@./` includes, stage as one commit.
+
 After completing the action, mark it `resolved` in the review log. Then
 **ALWAYS re-present the remaining items** (renumbered) so the user can
 continue. Only proceed to Step 5 when the user says "done" or all items
@@ -1213,6 +1417,9 @@ across runs. Use these conventions:
 | Cross-ref repair | `crossref:<artifact-id>` |
 | Subdivision candidate | `subdivision:<spec-id>` |
 | Bookkeeping repair | `scan-bookkeeping:<repair-name>` |
+| KB filename collision | `kb-collision:<basename>` |
+| KB schema drift | `kb-schema:<path>:<issue-code>` |
+| KB type/location mismatch | `kb-location:<path>` |
 
 The append helper is duplicate-safe — re-appending an identical row is a
 no-op, so resuming a previous /curate session does not duplicate entries.

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -1287,8 +1287,8 @@ Use AskUserQuestion:
 When renaming, do NOT just `git mv` the file — also update every `related:`
 entry in the rest of `.kb/` that points at the old path, and check
 `@./` includes from any parent file (detail-companion convention) for
-broken references. Stage the rename + reference updates as one commit; do
-not push unless the user requests it.
+broken references. Stage the rename + reference updates with `git add`;
+do not commit unless the user explicitly requests it.
 
 **KB schema drift:** Read the entry and present the issues grouped together:
 
@@ -1351,7 +1351,8 @@ Use AskUserQuestion:
   - "Skip" — defer
 
 When relocating, the same care as for filename collisions applies — update
-every incoming `related:` link, check `@./` includes, stage as one commit.
+every incoming `related:` link, check `@./` includes, stage with `git add`,
+let the user commit.
 
 After completing the action, mark it `resolved` in the review log. Then
 **ALWAYS re-present the remaining items** (renumbered) so the user can

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -158,15 +158,39 @@ skip that facet. Note it in the display so the user knows it's already covered.
 ### Placement determination
 
 For each facet, suggest:
+- **Entry type** — one of `research`, `adversarial-finding`, `feature-footprint`.
+  Inferred from the context hint (see "Entry-type inference" below). Determines
+  which template is used and which type-specific fields are required.
 - **Topic** — broad domain (e.g. `algorithms`, `systems`, `ml`). Check
   `.kb/CLAUDE.md` Topic Map for existing topics. Prefer existing topics.
 - **Category** — focused cluster within the topic (e.g. `vector-indexing`,
   `partitioning`). Check `.kb/<topic>/CLAUDE.md` for existing categories.
-  Prefer existing categories when the fit is good.
+  Prefer existing categories when the fit is good. For `adversarial-finding`
+  entries, the category is the **concern lens** (`validation`, `concurrency`,
+  `resource-management`), and the topic is `patterns`. Findings discovered
+  while researching SQL parsing belong at `patterns/validation/`, not at
+  `algorithms/sql-extensions/` — the lens, not the discovery domain.
 - **Filename** — kebab-case of the facet's core concept
 
 If a topic or category doesn't exist yet, note that it will be created. New
 topics need a one-line description.
+
+### Entry-type inference
+
+Read the context hint (if any). Apply these rules:
+
+- Hint matches `feature-retro footprint`, `Suggested: architecture/feature-footprints`, or otherwise indicates this is a per-feature record →
+  **`feature-footprint`**. Use the template at `.kb/_refs/feature-footprint-template.md`.
+  Default placement: `architecture/feature-footprints/<feature-slug>.md`.
+- Hint matches `audit adversarial pattern`, `Suggested: patterns/<concern>`, `Suggested: <topic>/adversarial-findings`, mentions a specific bug pattern, or otherwise indicates a finding from audit / aTDD / defensive testing →
+  **`adversarial-finding`**. Use the template at `.kb/_refs/adversarial-finding-template.md`.
+  Default placement: `patterns/<concern>/<finding-name>.md`.
+- Otherwise (research surveys, algorithms, systems, tradeoffs) →
+  **`research`**. Use the inline Subject File Template below.
+
+Surface the inferred type in the facet plan (Step 4) so the user can correct
+it before any file is written. If unsure, ask the user with AskUserQuestion
+listing the three types as options.
 
 ### Cap
 
@@ -238,14 +262,79 @@ Display: `── Writing KB entries ──────────────�
 
 Write one full article per confirmed facet.
 
+### Pre-write checks (run BEFORE creating any file)
+
+The canonical schema lives at `.kb/_refs/frontmatter.md`. Read it once at the
+start of this step. Every entry written below MUST conform.
+
+For each facet, run two checks before opening the writer:
+
+1. **Cross-folder filename uniqueness.** Run:
+
+   ```bash
+   find .kb -type f -name "<filename>.md" -not -path "*/_refs/*"
+   ```
+
+   If the result contains any path other than the one you are about to write
+   to, STOP. The filename collides with an existing entry under a different
+   folder. Either:
+   - Pick a more specific filename (`builder-pre-validation-mutation.md`
+     instead of `partial-init-no-rollback.md`), or
+   - Confirm with the user via AskUserQuestion that this is intentional (very
+     rare; usually it isn't).
+
+   Do not write the file under a colliding name. Cross-folder collisions
+   silently fragment search and pattern-recurrence evidence.
+
+2. **Type sanity check.** The inferred type from Step 3 determines which
+   template you use:
+   - `research` → inline Subject File Template (below)
+   - `adversarial-finding` → `.kb/_refs/adversarial-finding-template.md`
+   - `feature-footprint` → `.kb/_refs/feature-footprint-template.md`
+
+   For `adversarial-finding`, confirm the path begins with `patterns/<concern>/`.
+   For `feature-footprint`, confirm the path begins with
+   `architecture/feature-footprints/`. If a path violates these rules, the
+   inferred type is wrong (or the path is wrong) — re-confirm with the user
+   before writing.
+
+### Per-facet write rules
+
 - Path: `.kb/<topic>/<category>/<filename>.md`
-- Use the Subject File Template below
-- Keep under 200 lines; extract overflow to `<subject>-detail.md` with
-  `@./<subject>-detail.md` at the bottom
+- Template: per Type sanity check above
+- Keep under 200 lines; extract overflow to `<subject>-detail.md` per
+  `.kb/_refs/detail-companion.md` (frontmatter is required on the companion)
 - If file already exists: append `## Updates YYYY-MM-DD` section — NEVER overwrite
 - Populate `applies_to:` from the context hint if it implies specific files
+  (REQUIRED for `adversarial-finding` and `feature-footprint`)
 - Populate `decision_refs:` from the context hint if it references an ADR
 - Populate `related:` — see cross-linking rules below
+
+### Frontmatter validation (run AFTER drafting, BEFORE writing)
+
+Validate the drafted frontmatter against `.kb/_refs/frontmatter.md`:
+
+1. Required core fields present and non-empty (except `applies_to` which MAY
+   be empty for general research): `title`, `type`, `applies_to`,
+   `last_researched`, `research_status`.
+2. `type` is one of: `research`, `adversarial-finding`, `feature-footprint`,
+   `detail-companion`. (`reference-fragment` is reserved for kit `_refs/`.)
+3. Type-specific required fields present:
+   - `adversarial-finding` → `domain`, `severity`
+   - `feature-footprint` → `domains`, `constructs`
+4. `last_researched` matches `^\d{4}-\d{2}-\d{2}$` and is quoted.
+5. `research_status` is one of `active`, `mature`, `stable`, `deprecated`.
+6. `tags` (if present) all lowercase kebab-case.
+7. `sources` (if present) all carry `url`, `title`, and `accessed`. No bare
+   URLs.
+8. `confidence` defaults to `medium` for new entries. Set `high` ONLY when
+   the entry has ≥2 corroborating sources (research) or ≥2 audit findings
+   (adversarial-finding). Otherwise use `medium` or `low`. Never default to
+   `high`.
+9. If `topic:` or `category:` are populated, they MUST match the file's path.
+
+If any check fails, fix the draft and re-validate. Do not write a file that
+fails validation.
 
 ### Cross-linking rules
 
@@ -316,19 +405,23 @@ To query what's in the KB later: `/kb "<question>"`
 
 ## Subject File Template
 
+For `type: research` entries only. For other types, use the templates at
+`.kb/_refs/adversarial-finding-template.md` and
+`.kb/_refs/feature-footprint-template.md`. The canonical schema for all types
+is at `.kb/_refs/frontmatter.md`.
+
 ```markdown
 ---
 title: "<Full Name of Algorithm/Concept>"
+type: research
 aliases: ["<shorthand>", "<alternate name>"]
-topic: "<topic>"
-category: "<category>"
 tags: ["<tag1>", "<tag2>"]
 complexity:
   time_build: "<e.g. O(n log n)>"
   time_query: "<e.g. O(log n)>"
   space: "<e.g. O(n * M)>"
 research_status: "<active | mature | stable | deprecated>"
-confidence: "<high | medium | low>"
+confidence: "<medium | low>"   # default medium; upgrade to high only with ≥2 corroborating sources
 last_researched: "<YYYY-MM-DD>"
 applies_to: []
 related: []
@@ -337,7 +430,7 @@ sources:
   - url: "<URL>"
     title: "<title>"
     accessed: "<YYYY-MM-DD>"
-    type: "<paper | docs | blog | repo | benchmark>"
+    type: "<paper | docs | blog | repo | standard>"
 ---
 
 # <Full Name>
@@ -416,15 +509,24 @@ class SubjectName:
 
 ### Confidence field guidance
 
-Set `confidence` based on the strength of the sources backing the entry's claims:
+`confidence` is **earned**, not author-asserted. Default new entries to
+`medium`. Upgrade to `high` ONLY when the corroboration evidence below is
+present in the entry. `/curate` flags `high` entries that don't meet the
+bar for downgrade.
 
-- **high** — claims backed by peer-reviewed papers, official documentation, or verified benchmarks
-- **medium** — claims from reputable blog posts, conference talks, or the model's training knowledge that aligns with multiple sources
-- **low** — claims from a single unverified source, the model's general knowledge without corroboration, or extrapolations
+- **high** — claims backed by **2 or more independent sources**: e.g. a
+  peer-reviewed paper plus an official implementation, or two independent
+  audits confirming the same pattern. The corroboration MUST be visible in
+  the entry's `sources:` list (research) or `## Found in` section
+  (adversarial-finding).
+- **medium** — claims from a single strong source (one paper, one official
+  doc, one audit confirmation). **This is the default for new entries.**
+- **low** — claims from a single unverified source, the model's general
+  knowledge without corroboration, or extrapolations.
 
 When updating an existing entry, reassess confidence if new sources materially
-change the evidence base. Confidence can go up (new paper corroborates a blog
-claim) or down (a cited benchmark turns out to be synthetic).
+change the evidence base. Confidence can go up (a second source corroborates a
+prior claim) or down (a cited benchmark turns out to be synthetic).
 
 ---
 
@@ -530,7 +632,13 @@ Any prior errors found and corrected, with explanation.
 - [ ] Facet plan confirmed by user before any files were written
 - [ ] Each additional facet beyond the first has explicit justification
 - [ ] All subject files are at .kb/<topic>/<category>/<subject>.md
-- [ ] Every subject file has topic and category in frontmatter
+- [ ] Every subject file has a `type:` frontmatter field set to one of
+      `research`, `adversarial-finding`, `feature-footprint`
+- [ ] Cross-folder filename uniqueness verified (no `find .kb -name <file>.md`
+      hits outside the intended path)
+- [ ] Frontmatter validated against `.kb/_refs/frontmatter.md` (required core
+      fields present, type-specific fields present, no `confidence: high`
+      without ≥2 corroborating sources)
 - [ ] Every subject file has sources frontmatter with URLs and accessed dates
 - [ ] Every ## section heading is lowercase and hyphenated
 - [ ] code-skeleton section contains runnable pseudocode

--- a/tests/scenario-curate-kb-schema-drift.sh
+++ b/tests/scenario-curate-kb-schema-drift.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+# Scenario: /curate KB structural drift detectors (Analyses 23, 24, 25).
+#
+# Validates curate-scan.sh's three KB-quality analyses:
+#
+#   23. Cross-folder filename collisions
+#   24. Schema drift (frontmatter validation)
+#   25. Type ↔ location mismatch
+#
+# Layered cover:
+#
+#   1. Two files with the same name under different folders are flagged.
+#   2. A file with no frontmatter is flagged.
+#   3. Missing required fields (title, last_researched, research_status) are flagged.
+#   4. Bad enum values (research_status not in {active,mature,stable,deprecated}) are flagged.
+#   5. Legacy research_status (archived) is flagged with a distinct issue code.
+#   6. Type-specific required fields (domain/severity, domains/constructs) are flagged when missing.
+#   7. confidence: high without ≥2 corroborating sources is flagged as overclaim.
+#   8. topic/category fields that disagree with the file's path are flagged.
+#   9. type: adversarial-finding outside patterns/ is flagged as location mismatch.
+#  10. type: feature-footprint outside architecture/feature-footprints/ is flagged.
+#  11. Files with valid frontmatter and correct location are NOT flagged.
+#  12. _refs/ files and CLAUDE.md files are excluded from all three analyses.
+#
+# Run from repo root: bash tests/scenario-curate-kb-schema-drift.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+assert_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$desc"
+  else
+    fail "$desc" "pattern not found: $pattern"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$desc"
+  else
+    fail "$desc" "pattern unexpectedly found: $pattern"
+  fi
+}
+
+echo ""
+echo "scenario: /curate KB schema drift (Analyses 23, 24, 25)"
+echo "────────────────────────────────────────────────"
+
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine/curate-kb-schema.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.kb/_refs" \
+         "$PROJ/.kb/algorithms/encryption" \
+         "$PROJ/.kb/patterns/validation" \
+         "$PROJ/.kb/patterns/concurrency" \
+         "$PROJ/.kb/architecture/feature-footprints" \
+         "$PROJ/.kb/systems/database-engines" \
+         "$PROJ/.curate"
+cd "$PROJ"
+
+# Init git so timestamp logic works.
+git init -q
+git config user.email test@example.com
+git config user.name "Test"
+
+# .kb root index with no entries (script tolerates this).
+cat > .kb/CLAUDE.md << 'EOF'
+# Knowledge Base — Root Index
+## Topic Map
+| Topic | Path | Categories | Files | Last Updated |
+|-------|------|------------|-------|--------------|
+EOF
+
+# _refs file should be excluded from all analyses.
+cat > .kb/_refs/frontmatter.md << 'EOF'
+---
+type: reference-fragment
+title: KB Frontmatter Schema
+---
+# Schema reference (must be ignored by scan).
+EOF
+
+# ── Fixture 1: filename collision ──────────────────────────────────────────
+# Same filename in two patterns/ subfolders.
+cat > .kb/patterns/validation/partial-init-no-rollback.md << 'EOF'
+---
+title: "Partial Init No Rollback (Validation)"
+type: adversarial-finding
+domain: validation
+severity: confirmed
+applies_to: ["modules/foo"]
+last_researched: "2026-04-22"
+research_status: stable
+---
+# Partial Init No Rollback
+## What happens
+Builder mutation before validation.
+## Why implementations default to this
+Reads naturally.
+## Test guidance
+Test reverse order.
+## Found in
+- feature-a (round 1, 2026-04-22): noted
+EOF
+
+cat > .kb/patterns/concurrency/partial-init-no-rollback.md << 'EOF'
+---
+title: "Partial Init No Rollback (Concurrency)"
+type: adversarial-finding
+domain: concurrency
+severity: confirmed
+applies_to: ["modules/bar"]
+last_researched: "2026-04-22"
+research_status: stable
+---
+# Partial Init No Rollback (Concurrency)
+## What happens
+Multi-step init across threads.
+## Why implementations default to this
+Single-threaded mental model.
+## Test guidance
+Inject failures.
+## Found in
+- feature-b (round 1, 2026-04-22): noted
+EOF
+
+# ── Fixture 2: schema drift (multiple issues per file) ─────────────────────
+
+# Missing title + missing last_researched + bad research_status.
+cat > .kb/systems/database-engines/missing-fields.md << 'EOF'
+---
+type: research
+research_status: foo
+applies_to: []
+---
+# Entry With Missing Fields
+EOF
+
+# Legacy research_status: archived.
+cat > .kb/systems/database-engines/legacy-status.md << 'EOF'
+---
+title: "Legacy Status Entry"
+type: research
+research_status: archived
+last_researched: "2025-01-01"
+applies_to: []
+---
+# Legacy Status
+EOF
+
+# Adversarial-finding missing required domain + severity.
+cat > .kb/patterns/validation/missing-finding-fields.md << 'EOF'
+---
+title: "Finding Without Domain"
+type: adversarial-finding
+applies_to: ["modules/foo"]
+last_researched: "2026-04-22"
+research_status: stable
+---
+# Finding Without Domain
+## What happens
+Test
+## Why implementations default to this
+Test
+## Test guidance
+Test
+## Found in
+- feature (round 1, 2026-04-22): noted
+EOF
+
+# Feature-footprint missing required domains + constructs.
+cat > .kb/architecture/feature-footprints/missing-footprint-fields.md << 'EOF'
+---
+title: "footprint-missing-fields"
+type: feature-footprint
+applies_to: ["modules/x"]
+last_researched: "2026-04-22"
+research_status: stable
+---
+# footprint-missing-fields
+EOF
+
+# Confidence overclaim — high but only 1 source.
+cat > .kb/systems/database-engines/confidence-overclaim.md << 'EOF'
+---
+title: "Confidence Overclaim Entry"
+type: research
+applies_to: []
+last_researched: "2026-04-22"
+research_status: stable
+confidence: high
+sources:
+  - url: "https://example.com/single"
+    title: "Single source"
+    accessed: "2026-04-22"
+    type: docs
+---
+# Single-source High-confidence
+EOF
+
+# Topic/category mismatch — frontmatter says different from path.
+cat > .kb/systems/database-engines/path-mismatch.md << 'EOF'
+---
+title: "Path Mismatch Entry"
+type: research
+topic: algorithms
+category: encryption
+applies_to: []
+last_researched: "2026-04-22"
+research_status: stable
+---
+# Path Mismatch
+EOF
+
+# Missing frontmatter entirely.
+cat > .kb/systems/database-engines/no-frontmatter.md << 'EOF'
+# No frontmatter at all
+
+This file has no YAML block.
+EOF
+
+# ── Fixture 3: type/location mismatch ──────────────────────────────────────
+
+# Adversarial-finding under algorithms/ instead of patterns/.
+cat > .kb/algorithms/encryption/asymmetric-operand-assumption.md << 'EOF'
+---
+title: "Asymmetric Operand Assumption"
+type: adversarial-finding
+domain: data-integrity
+severity: tendency
+applies_to: ["modules/sql"]
+last_researched: "2026-03-25"
+research_status: active
+---
+# Asymmetric Operand Assumption
+## What happens
+SQL translator assumes left=field.
+## Why implementations default to this
+Common case.
+## Test guidance
+Test reversed.
+## Found in
+- sql-feature (round 1, 2026-03-25): noted
+EOF
+
+# Feature-footprint outside architecture/feature-footprints/.
+cat > .kb/algorithms/encryption/wrong-place-footprint.md << 'EOF'
+---
+title: "wrong-place-footprint"
+type: feature-footprint
+domains: [encryption]
+constructs: [Encryptor]
+applies_to: ["modules/enc"]
+last_researched: "2026-04-22"
+research_status: stable
+---
+# wrong-place-footprint
+## What it built
+Encryptor.
+EOF
+
+# ── Fixture 4: a CLEAN entry that should NOT be flagged ────────────────────
+
+cat > .kb/patterns/validation/clean-finding.md << 'EOF'
+---
+title: "Clean Finding"
+type: adversarial-finding
+domain: validation
+severity: confirmed
+applies_to: ["modules/clean"]
+last_researched: "2026-04-22"
+research_status: stable
+confidence: medium
+---
+# Clean Finding
+## What happens
+Test
+## Why implementations default to this
+Test
+## Test guidance
+Test
+## Found in
+- a-feature (round 1, 2026-04-22): noted
+EOF
+
+git add -A
+git commit -q --date='2026-04-22T00:00:00Z' -m "fixtures"
+
+# Run scan with link-rot disabled to keep the test fast.
+MAX_LINK_ROT_URLS=0 \
+    bash "$REPO_ROOT/scripts/curate-scan.sh" --init >/dev/null 2>&1 || true
+
+SUMMARY="$PROJ/.curate/scan-summary.md"
+
+if [[ ! -s "$SUMMARY" ]]; then
+    fail "scan-summary.md was created and non-empty"
+    echo ""
+    echo "── Summary ──"
+    echo "  Passed: $passed/$total"
+    echo "  Failed: $failed/$total"
+    [[ $failed -eq 0 ]] && exit 0 || exit 1
+fi
+
+# ── Analysis 23: filename collisions ──────────────────────────────────────
+
+assert_contains "$SUMMARY" "## KB Filename Collisions" \
+    "section: KB Filename Collisions present"
+
+assert_contains "$SUMMARY" "partial-init-no-rollback.md" \
+    "collision: partial-init-no-rollback flagged"
+
+# ── Analysis 24: schema drift ─────────────────────────────────────────────
+
+assert_contains "$SUMMARY" "## KB Schema Drift" \
+    "section: KB Schema Drift present"
+
+assert_contains "$SUMMARY" "missing-fields.md.*missing-title" \
+    "drift: missing-title issue raised"
+
+assert_contains "$SUMMARY" "missing-fields.md.*missing-last-researched" \
+    "drift: missing-last-researched issue raised"
+
+assert_contains "$SUMMARY" "missing-fields.md.*bad-research-status" \
+    "drift: bad-research-status issue raised"
+
+assert_contains "$SUMMARY" "legacy-status.md.*legacy-research-status" \
+    "drift: legacy-research-status (archived) flagged"
+
+assert_contains "$SUMMARY" "missing-finding-fields.md.*missing-domain" \
+    "drift: adversarial-finding missing-domain"
+
+assert_contains "$SUMMARY" "missing-finding-fields.md.*missing-severity" \
+    "drift: adversarial-finding missing-severity"
+
+assert_contains "$SUMMARY" "missing-footprint-fields.md.*missing-domains" \
+    "drift: feature-footprint missing-domains"
+
+assert_contains "$SUMMARY" "missing-footprint-fields.md.*missing-constructs" \
+    "drift: feature-footprint missing-constructs"
+
+assert_contains "$SUMMARY" "confidence-overclaim.md.*confidence-overclaim" \
+    "drift: confidence-overclaim flagged"
+
+assert_contains "$SUMMARY" "path-mismatch.md.*topic-mismatch" \
+    "drift: topic-mismatch flagged"
+
+assert_contains "$SUMMARY" "path-mismatch.md.*category-mismatch" \
+    "drift: category-mismatch flagged"
+
+assert_contains "$SUMMARY" "no-frontmatter.md.*missing-frontmatter" \
+    "drift: missing-frontmatter flagged"
+
+# Clean entry should NOT appear in schema drift.
+assert_not_contains "$SUMMARY" "clean-finding.md.*missing-" \
+    "drift: clean entry not flagged for missing fields"
+
+# _refs files should NEVER appear as findings of the three KB-quality
+# analyses (23, 24, 25). They MAY appear in general git-history analyses
+# like Churn Hotspots — that's expected for a file that gets edited.
+# Extract just the three KB-quality sections and check those.
+KB_QUALITY_SECTIONS="$(awk '
+    /^## KB Filename Collisions/ { in_section = 1 }
+    /^## KB Schema Drift/        { in_section = 1 }
+    /^## KB Type\/Location/      { in_section = 1 }
+    /^## / && !/^## KB / && in_section { in_section = 0 }
+    in_section { print }
+' "$SUMMARY")"
+if echo "$KB_QUALITY_SECTIONS" | grep -qE '\| \.kb/_refs/'; then
+    fail "exclude: _refs files not flagged in KB-quality analyses" \
+        "row matched: $(echo "$KB_QUALITY_SECTIONS" | grep -E '\| \.kb/_refs/' | head -1)"
+else
+    pass "exclude: _refs files not flagged in KB-quality analyses"
+fi
+
+# ── Analysis 25: type/location mismatch ───────────────────────────────────
+
+assert_contains "$SUMMARY" "## KB Type/Location Mismatch" \
+    "section: KB Type/Location Mismatch present"
+
+assert_contains "$SUMMARY" "asymmetric-operand-assumption.md.*adversarial-finding outside patterns" \
+    "location: adversarial-finding outside patterns/ flagged"
+
+assert_contains "$SUMMARY" "wrong-place-footprint.md.*feature-footprint outside architecture/feature-footprints" \
+    "location: feature-footprint outside architecture/feature-footprints/ flagged"
+
+# Clean entry should NOT appear in location mismatch.
+assert_not_contains "$SUMMARY" "clean-finding.md.*outside" \
+    "location: clean entry not flagged"
+
+# ── Final report ──────────────────────────────────────────────────────────
+
+echo ""
+echo "── Summary ──"
+echo "  Passed: $passed/$total"
+echo "  Failed: $failed/$total"
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -119,6 +119,10 @@ for extra in \
     ".kb/CLAUDE.md" \
     ".kb/_refs/complexity-notation.md" \
     ".kb/_refs/benchmarking-methodology.md" \
+    ".kb/_refs/adversarial-finding-template.md" \
+    ".kb/_refs/feature-footprint-template.md" \
+    ".kb/_refs/frontmatter.md" \
+    ".kb/_refs/detail-companion.md" \
     ".decisions/CLAUDE.md"; do
     if assert_file_exists "$TARGET/$extra"; then
         :


### PR DESCRIPTION
## Summary

Three-phase fix for KB schema drift surfaced in a jlsm KB review (4 frontmatter
variants in active use, two cross-folder filename collisions, adversarial
findings filed under research-style topics where the test-writer never sees them).

- **Phase 1 (`kb/_refs/`):** Canonical frontmatter schema (`frontmatter.md`) is
  the single authoritative reference for all entry types. Realigned the existing
  `adversarial-finding-template.md` and `feature-footprint-template.md` as schema
  instances. Added `detail-companion.md` formalizing the `<subject>-detail.md`
  split convention with required frontmatter on companions (was silently
  optional, breaking tag-overlap scans). Updated `kb/CLAUDE.md` with two
  decision rules: where research vs adversarial findings live, and filename
  uniqueness across the entire `.kb/` tree.

- **Phase 2 (`/research`):** Type-aware writing — infers
  `research | adversarial-finding | feature-footprint` from the context hint
  and selects the appropriate template. Cross-folder filename collision check
  before any KB write. Frontmatter validation against the canonical schema.
  Confidence discipline: writer defaults to `medium`, never `high` without
  ≥2 corroborating sources/findings. Audit feedback hint repointed at
  `patterns/<concern>` (the lens) instead of the never-existed
  `<topic>/adversarial-findings`.

- **Phase 3 (`/curate`):** Three new scan analyses act as the scan-time
  backstop when a writer skips its in-prompt validation:
  - **Cross-folder filename collisions** (Analysis 23)
  - **Schema drift** (Analysis 24) — 12 distinct issue codes covering
    missing/bad/legacy field values, confidence overclaim, and path/frontmatter
    mismatches
  - **Type ↔ location mismatch** (Analysis 25) — adversarial findings outside
    `patterns/`, footprints outside `architecture/feature-footprints/`

  SKILL.md gains Section 2r and three Step-4 routing blocks (rename/merge/dismiss;
  apply-patches/walk/dismiss; relocate/re-classify/dismiss). All resolutions
  stage rather than commit — drift remediation stays reviewer-gated.

## Test plan

- [x] Install regression: `bash tests/test-install.sh` — 70/70 pass (extended
      coverage to verify all six `_refs/` files install)
- [x] New regression: `bash tests/scenario-curate-kb-schema-drift.sh` — 21/21
      assertions cover all 12 drift issue codes, collision detection,
      type/location mismatch, and clean-entry exemption
- [x] All other curate scenarios continue to pass (no FAIL lines in
      `scenario-curate-*.sh`)
- [ ] Live integration against jlsm — deferred; the slow link-rot analysis
      makes the full scan take 10+ minutes. Fixture test fully exercises the
      new logic; jlsm scan after upgrade is the ground-truth validation

## Upgrade impact

- New installs: get all four refreshed `_refs/` files via `install.sh`
- Existing installs: get the new `_refs/` files (including `frontmatter.md`
  and `detail-companion.md`) on next `/upgrade-vallorcine` — `upgrade.sh`
  already globs `kb/_refs/*.md`. The kb root index is preserved if the user
  has topics; the canonical schema lives in `_refs/` so writers consult it
  even when the root index is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)