### PR TITLE
feat(work): dispatch marker for crash-resilient sub-agent dispatch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -137,6 +137,7 @@
 .claude/scripts/work-validate.sh
 .claude/scripts/work-context.sh
 .claude/scripts/work-finalize.sh
+.claude/scripts/work-dispatch.sh
 .claude/scripts/work-index.sh
 .claude/scripts/feature-state-reconcile.sh
 .claude/scripts/narrative-wrapper.sh

--- a/install.sh
+++ b/install.sh
@@ -312,6 +312,7 @@ install_file "$SCRIPT_DIR/scripts/work-claim.sh" "$TARGET/.claude/scripts/work-c
 install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/work-validate.sh"
 install_file "$SCRIPT_DIR/scripts/work-context.sh" "$TARGET/.claude/scripts/work-context.sh"
 install_file "$SCRIPT_DIR/scripts/work-finalize.sh" "$TARGET/.claude/scripts/work-finalize.sh"
+install_file "$SCRIPT_DIR/scripts/work-dispatch.sh" "$TARGET/.claude/scripts/work-dispatch.sh"
 install_file "$SCRIPT_DIR/scripts/work-index.sh" "$TARGET/.claude/scripts/work-index.sh"
 install_file "$SCRIPT_DIR/scripts/feature-state-reconcile.sh" "$TARGET/.claude/scripts/feature-state-reconcile.sh"
 install_file "$SCRIPT_DIR/scripts/narrative-wrapper.sh" "$TARGET/.claude/scripts/narrative-wrapper.sh"
@@ -346,6 +347,7 @@ chmod +x "$TARGET/.claude/scripts/work-claim.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-finalize.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/work-dispatch.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-index.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/feature-state-reconcile.sh" 2>/dev/null || true
 
@@ -436,6 +438,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
+      "Bash(bash .claude/scripts/work-dispatch.sh:*)",
       "Bash(bash .claude/scripts/work-index.sh:*)",
       "Bash(bash .claude/scripts/feature-state-reconcile.sh:*)"
     ]
@@ -554,6 +557,7 @@ HOOKJSON
       "Bash(bash .claude/scripts/work-validate.sh:*)",
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
+      "Bash(bash .claude/scripts/work-dispatch.sh:*)",
       "Bash(bash .claude/scripts/work-index.sh:*)",
       "Bash(bash .claude/scripts/feature-state-reconcile.sh:*)"
         ] | unique)' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
@@ -587,6 +591,7 @@ NEW_GITIGNORE_ENTRIES=(
     ".work/*/_readiness.json"
     ".work/*/_decompose-progress.md"
     ".work/*/.work-resolve.lock"
+    ".work/*/_dispatch-*.json"
 )
 
 if [[ "$DIFF_MODE" != "1" ]]; then
@@ -605,6 +610,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
 .work/*/_readiness.json
 .work/*/_decompose-progress.md
 .work/*/.work-resolve.lock
+.work/*/_dispatch-*.json
 __pycache__/
 GITIGNOREBLOCK
         echo -e "  ${GREEN}write${NC} .gitignore  (runtime file entries)"

--- a/scripts/work-dispatch.sh
+++ b/scripts/work-dispatch.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# work-dispatch.sh — track WD sub-agent dispatches so payload loss / cancel
+# does not silently corrupt the orchestrator's view of in-flight work.
+#
+# Background. The /work-start coordinator dispatches each WD's
+# implementation as a sub-agent (Agent tool call). The Agent call blocks
+# until the child emits its final assistant message — and the coordinator
+# parses that message into one of three return shapes (COMPLETE,
+# STOPPED_AT_<stage>, ERROR).
+#
+# Two failure modes break that contract without touching the WD's
+# manifest status or the .feature/ working dir:
+#
+#   1. Tool error: Agent returns "[Tool result missing due to internal
+#      error]". The payload is gone. The coordinator has no return-line
+#      to parse and no signal of whether the sub-agent ran, partially
+#      ran, or never started.
+#
+#   2. User stop: Agent returns "The user doesn't want to proceed with
+#      this tool use. The tool use was rejected." (e.g. user pressed
+#      ESC during the dispatch). Sub-agent never started.
+#
+# In both cases the coordinator's task list / TaskTool entry sits at
+# in_progress and recovery requires manual filesystem inspection.
+#
+# This script writes a small JSON marker per dispatch
+# (.work/<group>/_dispatch-<wd-id>.json, gitignored) that the
+# coordinator updates as it dispatches and acknowledges. /work-resume
+# scans for unacknowledged markers and surfaces them as recovery
+# candidates.
+#
+# Schema (current: schema_version 1):
+#   {
+#     "schema_version": 1,
+#     "wd_id": "WD-02",
+#     "group": "auto-index-maintenance",
+#     "dispatched_at": "2026-05-09T20:30:00Z",
+#     "ack": false,
+#     "result": null,
+#     "failure_reason": null,
+#     "acknowledged_at": null
+#   }
+#
+# Subcommands:
+#   begin <group> <wd-id>
+#     Write a fresh marker (dispatched_at=NOW, ack=false). Exits 0 even
+#     if a marker already exists — the coordinator is the sole writer
+#     and a re-dispatch overwrites the previous attempt.
+#
+#   ack <group> <wd-id> <result-line>
+#     Mark the marker as acknowledged. <result-line> is the exact one-
+#     line return string the coordinator parsed (COMPLETE, STOPPED_AT_*,
+#     ERROR, or whatever the child sent). Used when the dispatch
+#     completed cleanly.
+#
+#   fail <group> <wd-id> <reason>
+#     Mark the marker as acknowledged with a failure reason. <reason>
+#     is one of: payload-lost | user-stopped | parse-failed | <free-text>.
+#     Used when the coordinator decides the dispatch did not yield a
+#     parseable result. ack flips to true so the marker stops appearing
+#     in stuck-list, but the failure_reason is preserved for /work-resume
+#     to surface during recovery.
+#
+#   status <group> <wd-id>
+#     Print the marker's JSON contents to stdout. Exit 0 if marker
+#     exists, exit 1 if absent (with no output).
+#
+#   stuck <group>
+#     One line per unacknowledged marker:
+#       <wd-id>|<dispatched_at>|<has_result>|<failure_reason>
+#     The list is empty (and exit 0) when no markers are unacknowledged.
+#
+#   clear <group> <wd-id>
+#     Delete the marker file. Idempotent — exit 0 even if absent.
+#     Called by /work-resume after the user resolves the stuck dispatch.
+#
+# Atomic writes: every write goes through .tmp.$$ + rename to prevent
+# torn reads when /work-resume reads the marker concurrently with a
+# dispatcher writing it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# work-lib provides work_find_root + work_require_deps. work-dispatch
+# does not mutate the WD frontmatter, so it does NOT need the resolver
+# lock — markers are per-WD files and only the coordinator writes them.
+source "$SCRIPT_DIR/work-lib.sh"
+work_require_deps
+
+usage() {
+  cat >&2 <<EOF
+Usage:
+  work-dispatch.sh begin   <group> <wd-id>
+  work-dispatch.sh ack     <group> <wd-id> <result-line>
+  work-dispatch.sh fail    <group> <wd-id> <reason>
+  work-dispatch.sh status  <group> <wd-id>
+  work-dispatch.sh stuck   <group>
+  work-dispatch.sh clear   <group> <wd-id>
+
+See the comment at the top of this file for details.
+EOF
+  exit 2
+}
+
+# Strip control bytes that would break JSON. Mirrors json_escape in
+# work-resolve.sh — the result-line argument can contain anything the
+# sub-agent put on its final line, including stray bytes from a piped
+# log capture. Drop 0x00–0x08, 0x0B–0x0C, 0x0E–0x1F before escaping.
+json_escape() {
+  local s="$1"
+  s="${s//$'\x00'/}"
+  s="${s//$'\x01'/}"
+  s="${s//$'\x02'/}"
+  s="${s//$'\x03'/}"
+  s="${s//$'\x04'/}"
+  s="${s//$'\x05'/}"
+  s="${s//$'\x06'/}"
+  s="${s//$'\x07'/}"
+  s="${s//$'\x08'/}"
+  s="${s//$'\x0B'/}"
+  s="${s//$'\x0C'/}"
+  s="${s//$'\x0E'/}"
+  s="${s//$'\x0F'/}"
+  s="${s//$'\x10'/}"
+  s="${s//$'\x11'/}"
+  s="${s//$'\x12'/}"
+  s="${s//$'\x13'/}"
+  s="${s//$'\x14'/}"
+  s="${s//$'\x15'/}"
+  s="${s//$'\x16'/}"
+  s="${s//$'\x17'/}"
+  s="${s//$'\x18'/}"
+  s="${s//$'\x19'/}"
+  s="${s//$'\x1A'/}"
+  s="${s//$'\x1B'/}"
+  s="${s//$'\x1C'/}"
+  s="${s//$'\x1D'/}"
+  s="${s//$'\x1E'/}"
+  s="${s//$'\x1F'/}"
+  s="${s//\\/\\\\}"   # backslash first
+  s="${s//\"/\\\"}"   # double-quote
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+now_utc() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+marker_path() {
+  local work_root="$1" group="$2" wd_id="$3"
+  printf '%s/%s/_dispatch-%s.json' "$work_root" "$group" "$wd_id"
+}
+
+require_group_dir() {
+  local work_root="$1" group="$2"
+  local group_dir="$work_root/$group"
+  if [[ ! -d "$group_dir" ]]; then
+    echo "ERROR: work group not found: $group ($group_dir)" >&2
+    exit 2
+  fi
+  printf '%s' "$group_dir"
+}
+
+# Atomic write helper. Writes to <path>.tmp.<pid> then renames.
+write_marker() {
+  local path="$1" content="$2"
+  local tmp="${path}.tmp.$$"
+  printf '%s' "$content" > "$tmp"
+  mv "$tmp" "$path"
+}
+
+# Read a top-level scalar string field from a flat JSON object. Returns
+# empty when the field is absent, the literal string null, or the JSON
+# is malformed. Mirrors the grep-based reader pattern used elsewhere in
+# scripts/ so we do not add a jq dependency.
+read_field() {
+  local path="$1" field="$2"
+  [[ -f "$path" ]] || return 0
+  grep -oE "\"$field\":[[:space:]]*\"[^\"]*\"" "$path" 2>/dev/null \
+    | head -1 \
+    | sed -E "s/^\"$field\":[[:space:]]*\"([^\"]*)\"$/\1/" \
+    | head -1 || true
+}
+
+# Read a top-level boolean (true|false) field. Empty string when
+# absent or not a boolean.
+read_bool_field() {
+  local path="$1" field="$2"
+  [[ -f "$path" ]] || return 0
+  grep -oE "\"$field\":[[:space:]]*(true|false)" "$path" 2>/dev/null \
+    | head -1 \
+    | sed -E "s/^\"$field\":[[:space:]]*(true|false)$/\1/" \
+    | head -1 || true
+}
+
+cmd_begin() {
+  local group="$1" wd_id="$2"
+  local work_root group_dir marker now content
+  work_root="$(work_find_root)" || exit 2
+  group_dir="$(require_group_dir "$work_root" "$group")"
+  marker="$(marker_path "$work_root" "$group" "$wd_id")"
+  now="$(now_utc)"
+  content=$(cat <<EOF
+{"schema_version":1,"wd_id":"$(json_escape "$wd_id")","group":"$(json_escape "$group")","dispatched_at":"$now","ack":false,"result":null,"failure_reason":null,"acknowledged_at":null}
+EOF
+)
+  write_marker "$marker" "$content"
+  echo "[dispatch] begin $group/$wd_id at $now"
+}
+
+cmd_ack() {
+  local group="$1" wd_id="$2" result_line="${3:-}"
+  local work_root marker now dispatched_at content
+  work_root="$(work_find_root)" || exit 2
+  require_group_dir "$work_root" "$group" >/dev/null
+  marker="$(marker_path "$work_root" "$group" "$wd_id")"
+
+  if [[ ! -f "$marker" ]]; then
+    # No marker — the coordinator never called begin (older kit, or a
+    # manual dispatch). Create one in the acknowledged state so we have
+    # a record. The dispatched_at falls back to now since we lost it.
+    now="$(now_utc)"
+    dispatched_at="$now"
+  else
+    dispatched_at="$(read_field "$marker" "dispatched_at")"
+    [[ -z "$dispatched_at" ]] && dispatched_at="$(now_utc)"
+    now="$(now_utc)"
+  fi
+
+  content=$(cat <<EOF
+{"schema_version":1,"wd_id":"$(json_escape "$wd_id")","group":"$(json_escape "$group")","dispatched_at":"$dispatched_at","ack":true,"result":"$(json_escape "$result_line")","failure_reason":null,"acknowledged_at":"$now"}
+EOF
+)
+  write_marker "$marker" "$content"
+  echo "[dispatch] ack $group/$wd_id"
+}
+
+cmd_fail() {
+  local group="$1" wd_id="$2" reason="${3:-unspecified}"
+  local work_root marker now dispatched_at content
+  work_root="$(work_find_root)" || exit 2
+  require_group_dir "$work_root" "$group" >/dev/null
+  marker="$(marker_path "$work_root" "$group" "$wd_id")"
+
+  if [[ ! -f "$marker" ]]; then
+    dispatched_at="$(now_utc)"
+    now="$dispatched_at"
+  else
+    dispatched_at="$(read_field "$marker" "dispatched_at")"
+    [[ -z "$dispatched_at" ]] && dispatched_at="$(now_utc)"
+    now="$(now_utc)"
+  fi
+
+  content=$(cat <<EOF
+{"schema_version":1,"wd_id":"$(json_escape "$wd_id")","group":"$(json_escape "$group")","dispatched_at":"$dispatched_at","ack":true,"result":null,"failure_reason":"$(json_escape "$reason")","acknowledged_at":"$now"}
+EOF
+)
+  write_marker "$marker" "$content"
+  echo "[dispatch] fail $group/$wd_id ($reason)"
+}
+
+cmd_status() {
+  local group="$1" wd_id="$2"
+  local work_root marker
+  work_root="$(work_find_root)" || exit 2
+  require_group_dir "$work_root" "$group" >/dev/null
+  marker="$(marker_path "$work_root" "$group" "$wd_id")"
+  if [[ ! -f "$marker" ]]; then
+    exit 1
+  fi
+  cat "$marker"
+}
+
+cmd_stuck() {
+  local group="$1"
+  local work_root group_dir
+  work_root="$(work_find_root)" || exit 2
+  group_dir="$(require_group_dir "$work_root" "$group")"
+
+  shopt -s nullglob
+  local marker
+  for marker in "$group_dir"/_dispatch-*.json; do
+    local ack wd_id dispatched_at result failure has_result
+    ack="$(read_bool_field "$marker" "ack")"
+    if [[ "$ack" != "true" ]]; then
+      wd_id="$(read_field "$marker" "wd_id")"
+      dispatched_at="$(read_field "$marker" "dispatched_at")"
+      result="$(read_field "$marker" "result")"
+      failure="$(read_field "$marker" "failure_reason")"
+      if [[ -n "$result" ]]; then
+        has_result="true"
+      else
+        has_result="false"
+      fi
+      printf '%s|%s|%s|%s\n' "$wd_id" "$dispatched_at" "$has_result" "$failure"
+    fi
+  done
+  shopt -u nullglob
+}
+
+cmd_clear() {
+  local group="$1" wd_id="$2"
+  local work_root marker
+  work_root="$(work_find_root)" || exit 2
+  require_group_dir "$work_root" "$group" >/dev/null
+  marker="$(marker_path "$work_root" "$group" "$wd_id")"
+  if [[ -f "$marker" ]]; then
+    rm -f "$marker"
+    echo "[dispatch] cleared $group/$wd_id"
+  fi
+  exit 0
+}
+
+[[ $# -ge 1 ]] || usage
+
+case "$1" in
+  begin)
+    [[ $# -eq 3 ]] || usage
+    cmd_begin "$2" "$3" ;;
+  ack)
+    [[ $# -ge 3 ]] || usage
+    cmd_ack "$2" "$3" "${4:-}" ;;
+  fail)
+    [[ $# -ge 3 ]] || usage
+    cmd_fail "$2" "$3" "${4:-unspecified}" ;;
+  status)
+    [[ $# -eq 3 ]] || usage
+    cmd_status "$2" "$3" ;;
+  stuck)
+    [[ $# -eq 2 ]] || usage
+    cmd_stuck "$2" ;;
+  clear)
+    [[ $# -eq 3 ]] || usage
+    cmd_clear "$2" "$3" ;;
+  -h|--help|help)
+    usage ;;
+  *)
+    echo "ERROR: unknown subcommand: $1" >&2
+    usage ;;
+esac

--- a/skills/work-resume/SKILL.md
+++ b/skills/work-resume/SKILL.md
@@ -260,6 +260,77 @@ re-invoked cheaply after `/clear`.
 
 Apply this routing in order — first match wins:
 
+0. **Any unacknowledged dispatch marker exists** → a previous
+   `/work-start` (sequential `all` or `--parallel`) dispatched a
+   sub-agent whose result was never confirmed by the coordinator.
+   Two known causes:
+   - The Agent tool returned `[Tool result missing due to internal error]`
+     (payload-lost), or
+   - The user pressed ESC and the dispatch returned `The user doesn't
+     want to proceed with this tool use. The tool use was rejected.`
+     (user-stopped).
+
+   In either case the WD's manifest status and `.feature/` dir do not
+   tell the full story — the coordinator's task list says
+   `in_progress` but no result was ever recorded. The dispatch marker
+   is the durable record.
+
+   Run:
+   ```bash
+   bash .claude/scripts/work-dispatch.sh stuck "<group-slug>"
+   ```
+   One line per unacknowledged marker:
+   `<wd-id>|<dispatched_at>|<has_result>|<failure_reason>`. If the
+   list is empty, fall through to rule 1.
+
+   For each stuck marker, gather filesystem evidence:
+   - Does `.feature/<group-slug>--<wd-slug>/` exist?
+   - Is the WD's frontmatter status `IMPLEMENTING` (work-claim ran)
+     or still `SPECIFIED` (sub-agent never claimed)?
+   - Does `.feature/<...>/cycle-log.md` exist with content (sub-agent
+     ran TDD cycles)?
+
+   Display:
+   ```
+   ⚠ STUCK DISPATCHES detected in <group-slug>:
+
+     WD-<nn> — dispatched <dispatched_at>
+       Reason   : <failure_reason or "no result received">
+       WD status: <SPECIFIED | IMPLEMENTING>
+       .feature/: <present | absent>
+       Cycle log: <empty | <N> cycles recorded>
+
+       Recommendation:
+         <see action selection below>
+   ```
+
+   Action selection per stuck marker:
+   - **`failure_reason: user-stopped` AND WD status is SPECIFIED AND
+     `.feature/` is absent** → the dispatch was cancelled before any
+     work happened. Recommend re-dispatch:
+     ```
+     /work-start "<group-slug>" <wd-id>
+     ```
+   - **`failure_reason: payload-lost` (or any reason) AND WD status is
+     IMPLEMENTING AND `.feature/` is present** → the sub-agent at
+     least claimed the WD and started; the result was lost. Recommend
+     `/feature-resume "<group-slug>--<wd-slug>"` to inspect actual
+     state and continue from where the sub-agent left off.
+   - **Any other shape** → surface the evidence and let the user
+     decide; do not auto-route.
+
+   After the user acts (re-dispatch, /feature-resume, or accepts the
+   loss), they should clear the marker:
+   ```bash
+   bash .claude/scripts/work-dispatch.sh clear "<group-slug>" "<wd-id>"
+   ```
+   `/work-resume` SHOULD remind the user of this at the end of the
+   stuck-marker block.
+
+   Do NOT silently proceed to the rest of the routing list while
+   markers are unacknowledged — recovery is the user's call, not the
+   skill's.
+
 1. **Any `_decompose-progress.md` exists** → already handled in Step 2.
 
 2. **Group has zero WDs** (total == 0) → decomposition has not run yet.

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -384,8 +384,21 @@ Replace Steps 3–5 with this block when `all` is the argument.
    d. **Dispatch ONE sub-agent that recursively invokes the
       single-WD `/work-start`.** This is critical — do NOT hand-roll
       the feature creation + claim + pipeline dispatch logic in this
-      coordinator. The single-WD flow already does it correctly. Use
-      this prompt verbatim:
+      coordinator. The single-WD flow already does it correctly.
+
+      **Before the Agent call**, write a dispatch marker so a
+      lost-payload or rejected-dispatch failure does not leave the
+      coordinator's task list silently out of sync with reality:
+      ```bash
+      bash .claude/scripts/work-dispatch.sh begin "<group-slug>" "<wd-id>"
+      ```
+      This creates `.work/<group-slug>/_dispatch-<wd-id>.json` with
+      `ack: false`. Step 3f flips it to `ack: true` once the result is
+      parsed (or marks `failure_reason` when parsing fails). The marker
+      is what `/work-resume` uses to detect stuck dispatches and
+      surface them as recovery candidates.
+
+      **Then invoke the sub-agent** with this prompt verbatim:
       ```
       You are the sequential pipeline runner for <group-slug> /
       <wd-id>.
@@ -424,16 +437,68 @@ Replace Steps 3–5 with this block when `all` is the argument.
    e. **Wait for the sub-agent to return.** The Agent tool blocks
       until the child emits its final assistant message.
 
-   f. **Aggregate.** Append the sub-agent's summary to a results list.
-      Display incrementally:
+   f. **Classify the return and update the marker.** The Agent tool
+      returns one of four shapes. Treat each distinctly — silent
+      assumptions corrupt the task list:
+
+      - **Clean return** matching `<group-slug>--<wd-id>: <STATUS> — <detail>`
+        (where STATUS is one of `COMPLETE`, `STOPPED_AT_<stage>`,
+        `ERROR`, `SKIPPED`). Acknowledge:
+        ```bash
+        bash .claude/scripts/work-dispatch.sh ack "<group-slug>" "<wd-id>" "<exact return line>"
+        ```
+        Append to the aggregate results list.
+
+      - **Payload lost** — the Agent return literally equals
+        `[Tool result missing due to internal error]` or otherwise
+        contains no parseable result. The sub-agent may have run,
+        partially run, or never started; the result is gone. Mark:
+        ```bash
+        bash .claude/scripts/work-dispatch.sh fail "<group-slug>" "<wd-id>" "payload-lost"
+        ```
+        Surface to the user via AskUserQuestion: "Pause for
+        `/work-resume <group-slug>` recovery" / "Continue with the
+        next WD (recovery later)" / "Stop the run". Do NOT advance
+        the coordinator's TaskTool entry to `completed` — leave it
+        `in_progress` so the user sees that it needs attention. The
+        marker is the durable record; recovery is `/work-resume`.
+
+      - **User stopped** — the Agent return contains
+        `The user doesn't want to proceed with this tool use. The tool
+        use was rejected.` The sub-agent never started. Mark:
+        ```bash
+        bash .claude/scripts/work-dispatch.sh fail "<group-slug>" "<wd-id>" "user-stopped"
+        ```
+        Surface to the user via AskUserQuestion: "Re-dispatch this WD"
+        / "Continue with the next WD" / "Stop the run". Re-dispatching
+        is safe because the sub-agent never claimed; `/work-start`
+        will see the WD still SPECIFIED (or IMPLEMENTING if a previous
+        attempt got further) and the marker will be overwritten on
+        the next `begin`.
+
+      - **Parse failed** — the return is a string but does not match
+        the expected shape. Mark:
+        ```bash
+        bash .claude/scripts/work-dispatch.sh fail "<group-slug>" "<wd-id>" "parse-failed: <first 80 chars of return>"
+        ```
+        Surface the same recovery prompt as payload-lost. The marker
+        records the unparseable tail so `/work-resume` can show it.
+
+      Append to the aggregate. Display incrementally:
       ```
       [<n>/<eligible>] <group-slug>--<wd-id>: <STATUS> — <detail>
+      ```
+      For payload-lost / user-stopped / parse-failed lines, show:
+      ```
+      [<n>/<eligible>] <group-slug>--<wd-id>: DISPATCH FAILURE (<reason>) — recoverable via /work-resume
       ```
 
    g. **Stop conditions.** Continue unless:
       - The sub-agent returned `ERROR` or `STOPPED_AT_<stage>` AND
         the user opts to halt (AskUserQuestion: "Continue with
         remaining" / "Stop and inspect").
+      - The dispatch hit `payload-lost` / `user-stopped` /
+        `parse-failed` AND the user picked "Pause" / "Stop" in 3f.
       - SKIPPED returns are silent — log and continue (the coordinator
         intentionally tolerates conflicts as parallel-session signals).
 
@@ -539,9 +604,17 @@ Replace Steps 3–5 with this block when `--parallel` is set.
    touch the `.work/` tree and are fast. Fanning out here adds no
    measurable benefit and risks racing on `manifest.md` regeneration.
 
-5. **Dispatch sub-agents concurrently.** Spawn one sub-agent per WD in
-   a **single message with multiple Agent tool calls**. Each sub-agent
-   receives this prompt:
+5. **Dispatch sub-agents concurrently.** First, write a dispatch
+   marker for every WD that's about to be dispatched (so a payload-
+   loss or user-stop on any single sub-agent can be recovered). Run
+   sequentially before the Agent calls:
+   ```bash
+   for wd_id in <list of WD ids being dispatched>; do
+     bash .claude/scripts/work-dispatch.sh begin "<group-slug>" "$wd_id"
+   done
+   ```
+   Then spawn one sub-agent per WD in a **single message with multiple Agent tool calls**.
+   Each sub-agent receives this prompt:
    ```
    You are the parallel pipeline runner for <feature-slug>.
    The feature directory exists at .feature/<feature-slug>/.
@@ -559,18 +632,31 @@ Replace Steps 3–5 with this block when `--parallel` is set.
      "<feature-slug>: <COMPLETE | STOPPED_AT_<stage> | ERROR> — <detail>"
    ```
 
-6. **Aggregate results.** When all sub-agents return, summarize:
+6. **Aggregate results — classify each return.** Use the same four-way
+   classification as Sequential mode Step 3f (clean / payload-lost /
+   user-stopped / parse-failed). For each sub-agent's return:
+   - Clean: `bash .claude/scripts/work-dispatch.sh ack "<group>" "<wd-id>" "<line>"`
+   - Payload lost: `bash .claude/scripts/work-dispatch.sh fail "<group>" "<wd-id>" "payload-lost"`
+   - User stopped: `bash .claude/scripts/work-dispatch.sh fail "<group>" "<wd-id>" "user-stopped"`
+   - Parse failed: `bash .claude/scripts/work-dispatch.sh fail "<group>" "<wd-id>" "parse-failed: <first 80 chars>"`
+
+   Then summarize:
    ```
    ── Parallel run complete · <group-slug> ───────
    Dispatched: <N>
    Complete: <n>/<N>
    Stopped mid-pipeline: <list with stage>
    Errored: <list with detail>
+   Dispatch failures (payload-lost / user-stopped / parse-failed):
+     <list with WD-id and reason>
    ───────────────────────────────────────────────
    ```
    For stopped or errored WDs, the user's next action is usually
    `/feature-resume "<feature-slug>"` to pick up where each sub-agent
-   left off.
+   left off. For dispatch failures, the next action is
+   `/work-resume "<group-slug>"` — it scans the dispatch markers and
+   surfaces each stuck WD with the right recovery path (re-dispatch,
+   inspect, or accept the partial result).
 
 ### Concurrency caveats (documented, user-accepted)
 

--- a/tests/scenario-work-dispatch-recovery.sh
+++ b/tests/scenario-work-dispatch-recovery.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Scenario: work-dispatch.sh marker lifecycle for crash-resilient sub-agent
+# dispatch.
+#
+# Background: /work-start dispatches each WD as a sub-agent via Agent. When
+# the Agent call returns "[Tool result missing due to internal error]" or
+# "The user doesn't want to proceed with this tool use" the orchestrator
+# loses the result payload. Without a disk-side record of the dispatch the
+# task list says in_progress and recovery requires manual filesystem
+# inspection. work-dispatch.sh writes a marker per dispatch so recovery
+# can reason about the actual state.
+#
+# Layered cover:
+#
+#   1. begin writes a marker in dispatch-pending state.
+#   2. ack writes a marker in acknowledged state with the result line.
+#   3. fail records a payload-lost / user-stopped reason and acks.
+#   4. stuck enumerates only unacknowledged markers (one row per stuck WD).
+#   5. status returns the marker JSON; exit 1 when absent.
+#   6. clear deletes the marker; clearing an absent marker is a no-op.
+#   7. JSON output survives a result line containing newline / tab /
+#      backslash / control bytes (same robustness work-resolve.sh has).
+#   8. Re-dispatching the same WD overwrites the previous marker (the
+#      coordinator is the sole writer).
+#
+# Run from repo root: bash tests/scenario-work-dispatch-recovery.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+WORK_DISPATCH="$REPO_ROOT/scripts/work-dispatch.sh"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "scenario: work-dispatch.sh marker lifecycle"
+echo "────────────────────────────────────────────────"
+
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine/work-dispatch.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.work/auto-index/auto-index"   # extra dir for work_find_root
+GROUP_DIR="$PROJ/.work/auto-index"
+echo '---' > "$GROUP_DIR/WD-01.md"
+echo '---' > "$GROUP_DIR/WD-02.md"
+echo '---' > "$GROUP_DIR/WD-03.md"
+cd "$PROJ"
+
+# ── 1. begin writes a marker in dispatch-pending state ───────────────────
+
+bash "$WORK_DISPATCH" begin auto-index WD-01 >/dev/null
+MARKER_01="$GROUP_DIR/_dispatch-WD-01.json"
+
+if [[ -f "$MARKER_01" ]]; then
+  pass "begin: marker file created"
+else
+  fail "begin: marker file created" "$MARKER_01 missing"
+fi
+
+if grep -q '"ack":false' "$MARKER_01"; then
+  pass "begin: ack flag is false"
+else
+  fail "begin: ack flag is false"
+fi
+
+if grep -q '"wd_id":"WD-01"' "$MARKER_01"; then
+  pass "begin: wd_id recorded"
+else
+  fail "begin: wd_id recorded"
+fi
+
+if grep -qE '"dispatched_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:]+Z"' "$MARKER_01"; then
+  pass "begin: dispatched_at is ISO-8601 UTC"
+else
+  fail "begin: dispatched_at is ISO-8601 UTC"
+fi
+
+# ── 2. ack writes the result line ────────────────────────────────────────
+
+bash "$WORK_DISPATCH" ack auto-index WD-01 \
+    "auto-index--WD-01: COMPLETE — feature merged" >/dev/null
+
+if grep -q '"ack":true' "$MARKER_01"; then
+  pass "ack: ack flag flipped to true"
+else
+  fail "ack: ack flag flipped to true"
+fi
+
+if grep -q "COMPLETE" "$MARKER_01"; then
+  pass "ack: result line stored"
+else
+  fail "ack: result line stored"
+fi
+
+if grep -qE '"acknowledged_at":"[0-9]{4}-' "$MARKER_01"; then
+  pass "ack: acknowledged_at populated"
+else
+  fail "ack: acknowledged_at populated"
+fi
+
+# ── 3. fail records a payload-lost reason and acks ───────────────────────
+
+bash "$WORK_DISPATCH" begin auto-index WD-02 >/dev/null
+bash "$WORK_DISPATCH" fail auto-index WD-02 "payload-lost" >/dev/null
+MARKER_02="$GROUP_DIR/_dispatch-WD-02.json"
+
+if grep -q '"failure_reason":"payload-lost"' "$MARKER_02"; then
+  pass "fail: failure_reason stored"
+else
+  fail "fail: failure_reason stored"
+fi
+
+if grep -q '"ack":true' "$MARKER_02"; then
+  pass "fail: ack flag flipped to true (so it stops appearing in stuck)"
+else
+  fail "fail: ack flag flipped to true (so it stops appearing in stuck)"
+fi
+
+if grep -q '"result":null' "$MARKER_02"; then
+  pass "fail: result remains null (no result was received)"
+else
+  fail "fail: result remains null (no result was received)"
+fi
+
+# ── 4. stuck enumerates only unacknowledged markers ──────────────────────
+
+# Create one more in begin state to verify stuck picks it up.
+bash "$WORK_DISPATCH" begin auto-index WD-03 >/dev/null
+
+stuck_out="$(bash "$WORK_DISPATCH" stuck auto-index)"
+
+if echo "$stuck_out" | grep -q '^WD-03|'; then
+  pass "stuck: unacknowledged WD-03 listed"
+else
+  fail "stuck: unacknowledged WD-03 listed" "got: $stuck_out"
+fi
+
+if echo "$stuck_out" | grep -q '^WD-01|'; then
+  fail "stuck: acknowledged WD-01 NOT listed" "WD-01 should be filtered out"
+else
+  pass "stuck: acknowledged WD-01 NOT listed"
+fi
+
+if echo "$stuck_out" | grep -q '^WD-02|'; then
+  fail "stuck: ack-failed WD-02 NOT listed" "WD-02 should be filtered out (ack=true)"
+else
+  pass "stuck: ack-failed WD-02 NOT listed"
+fi
+
+# ── 5. status returns marker JSON; exit 1 when absent ────────────────────
+
+if bash "$WORK_DISPATCH" status auto-index WD-01 | grep -q '"wd_id":"WD-01"'; then
+  pass "status: returns JSON for present marker"
+else
+  fail "status: returns JSON for present marker"
+fi
+
+if ! bash "$WORK_DISPATCH" status auto-index WD-99 >/dev/null 2>&1; then
+  pass "status: exits non-zero for absent marker"
+else
+  fail "status: exits non-zero for absent marker"
+fi
+
+# ── 6. clear deletes the marker; absent clear is a no-op ─────────────────
+
+bash "$WORK_DISPATCH" clear auto-index WD-03 >/dev/null
+if [[ ! -f "$GROUP_DIR/_dispatch-WD-03.json" ]]; then
+  pass "clear: marker file removed"
+else
+  fail "clear: marker file removed"
+fi
+
+if bash "$WORK_DISPATCH" clear auto-index WD-99 >/dev/null 2>&1; then
+  pass "clear: idempotent on absent marker"
+else
+  fail "clear: idempotent on absent marker"
+fi
+
+# ── 7. JSON output survives newline / tab / control bytes in result ──────
+
+bash "$WORK_DISPATCH" begin auto-index WD-03 >/dev/null
+bash "$WORK_DISPATCH" ack auto-index WD-03 \
+    $'auto-index--WD-03: STOPPED_AT_test\nstray newline\ttab\\backslash"quote' \
+    >/dev/null
+
+# The marker should still be one valid JSON line — no raw newlines, no
+# raw quotes, no raw control bytes in the body.
+if python3 -c "import json,sys; json.load(open('$GROUP_DIR/_dispatch-WD-03.json'))" 2>/dev/null; then
+  pass "ack: result containing newline / tab / backslash / quote stays valid JSON"
+else
+  fail "ack: result containing newline / tab / backslash / quote stays valid JSON" \
+       "$(cat "$GROUP_DIR/_dispatch-WD-03.json")"
+fi
+
+# ── 8. re-dispatch overwrites prior marker ───────────────────────────────
+
+bash "$WORK_DISPATCH" begin auto-index WD-01 >/dev/null
+if grep -q '"ack":false' "$MARKER_01"; then
+  pass "begin: re-dispatch resets ack to false"
+else
+  fail "begin: re-dispatch resets ack to false"
+fi
+
+# ── Final report ─────────────────────────────────────────────────────────
+
+echo ""
+echo "── Summary ──"
+echo "  Passed: $passed/$total"
+echo "  Failed: $failed/$total"
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -962,6 +962,11 @@ if grep -qxF ".work/*/.work-resolve.lock" "$ENHANCED_TARGET/.gitignore"; then
 else
     fail ".work/*/.work-resolve.lock should be in .gitignore"
 fi
+if grep -qxF ".work/*/_dispatch-*.json" "$ENHANCED_TARGET/.gitignore"; then
+    pass ".work/*/_dispatch-*.json in .gitignore"
+else
+    fail ".work/*/_dispatch-*.json should be in .gitignore"
+fi
 
 # Upgrade path: an existing install that already has the runtime block but
 # was made before v0.16.x should pick up the new entries on re-install.
@@ -1004,6 +1009,11 @@ if grep -qxF ".work/*/.work-resolve.lock" "$UPGRADE_GI_TARGET/.gitignore"; then
     pass "upgrade path adds .work/*/.work-resolve.lock to existing .gitignore"
 else
     fail "upgrade should add .work/*/.work-resolve.lock to existing .gitignore"
+fi
+if grep -qxF ".work/*/_dispatch-*.json" "$UPGRADE_GI_TARGET/.gitignore"; then
+    pass "upgrade path adds .work/*/_dispatch-*.json to existing .gitignore"
+else
+    fail "upgrade should add .work/*/_dispatch-*.json to existing .gitignore"
 fi
 # Idempotent: running install twice must not duplicate entries.
 bash "$REPO_ROOT/install.sh" "$UPGRADE_GI_TARGET" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Two failure modes were silently corrupting `/work-start`'s view of in-flight
work, requiring manual filesystem inspection to recover:

1. **Tool-error**: Agent returns `[Tool result missing due to internal error]`.
   Sub-agent payload is gone; coordinator's task list says `in_progress` with
   no signal of actual state.
2. **User-stopped**: Agent returns `The user doesn't want to proceed with this
   tool use. The tool use was rejected.` (e.g. ESC during dispatch).

This PR makes recovery automatic via a per-dispatch JSON marker.

### What's new

- **`scripts/work-dispatch.sh`** — `begin` / `ack` / `fail` / `status` / `stuck`
  / `clear` subcommands write/read a small marker at
  `.work/<group>/_dispatch-<wd-id>.json`. Atomic writes via `.tmp.$$` + rename;
  JSON-escapes control bytes in result lines (mirrors `work-resolve.sh`).
- **`/work-start` updates** — sequential `all` mode and `--parallel` mode
  both call `begin` before the Agent dispatch, then classify the return
  into four shapes (clean / payload-lost / user-stopped / parse-failed) and
  call the appropriate marker action. Surfaces dispatch failures in the
  run summary; prompts the user via AskUserQuestion (Pause/Continue/Stop).
- **`/work-resume` updates** — new rule 0 in Step 5 routing: any unacknowledged
  dispatch marker pre-empts every other rule. Gathers filesystem evidence
  (WD status, `.feature/` presence, cycle-log content) and recommends the
  right recovery: re-dispatch when no work happened, `/feature-resume` when
  the sub-agent claimed and started, manual decision otherwise.
- **Install plumbing** — MANIFEST entry, `install.sh` install + chmod +
  permission allowlist, gitignore for `.work/*/_dispatch-*.json` (both new
  install and upgrade paths).

## Test plan

- [x] `bash tests/scenario-work-dispatch-recovery.sh` — 19/19 assertions pass
      covering marker lifecycle (begin, ack, fail, stuck enumeration filters
      ack=true, status exit codes, clear idempotency, JSON robustness against
      control bytes / newlines / quotes, re-dispatch overwrite)
- [x] `bash tests/test-install.sh` — 72/72 (was 70/70; +2 for new gitignore
      assertions, both new-install and upgrade-path)
- [x] All other `scenario-work-*.sh` tests still pass (no FAIL lines)
- [x] `bash -n scripts/work-dispatch.sh` clean
- [x] Smoke-tested begin → cat marker manually

## Self-review notes

- Read the changed sections of `/work-start` SKILL.md end-to-end after
  edits to verify the begin/ack/fail flow doesn't have step-letter
  conflicts (caught and fixed one during editing).
- Verified the `parallel pipeline runner` substring + `single message
  with multiple Agent tool calls` substring still grep-match on a single
  line (a previous edit had wrapped the latter — caught by
  `scenario-work-start-parallel.sh` and fixed).
- Confirmed `install_file` overwrites kit-managed files, so existing
  installs picking up `work-dispatch.sh` on upgrade get the latest
  version (no surprise from the seed-file "skip if exists" semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)