### PR TITLE
feat(kb): KB→code citation hook + /curate drift analysis

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -139,6 +139,7 @@
 .claude/scripts/work-finalize.sh
 .claude/scripts/work-dispatch.sh
 .claude/scripts/work-index.sh
+.claude/scripts/check-kb-ref.sh
 .claude/scripts/feature-state-reconcile.sh
 .claude/scripts/narrative-wrapper.sh
 .claude/scripts/narrative/model.py

--- a/install.sh
+++ b/install.sh
@@ -314,6 +314,7 @@ install_file "$SCRIPT_DIR/scripts/work-context.sh" "$TARGET/.claude/scripts/work
 install_file "$SCRIPT_DIR/scripts/work-finalize.sh" "$TARGET/.claude/scripts/work-finalize.sh"
 install_file "$SCRIPT_DIR/scripts/work-dispatch.sh" "$TARGET/.claude/scripts/work-dispatch.sh"
 install_file "$SCRIPT_DIR/scripts/work-index.sh" "$TARGET/.claude/scripts/work-index.sh"
+install_file "$SCRIPT_DIR/scripts/check-kb-ref.sh" "$TARGET/.claude/scripts/check-kb-ref.sh"
 install_file "$SCRIPT_DIR/scripts/feature-state-reconcile.sh" "$TARGET/.claude/scripts/feature-state-reconcile.sh"
 install_file "$SCRIPT_DIR/scripts/narrative-wrapper.sh" "$TARGET/.claude/scripts/narrative-wrapper.sh"
 chmod +x "$TARGET/.claude/scripts/narrative-wrapper.sh" 2>/dev/null || true
@@ -349,6 +350,7 @@ chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-finalize.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-dispatch.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-index.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/check-kb-ref.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/feature-state-reconcile.sh" 2>/dev/null || true
 
 # ── Merge driver for index files ──────────────────────────────────────────────
@@ -440,6 +442,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
       "Bash(bash .claude/scripts/work-dispatch.sh:*)",
       "Bash(bash .claude/scripts/work-index.sh:*)",
+      "Bash(bash .claude/scripts/check-kb-ref.sh:*)",
       "Bash(bash .claude/scripts/feature-state-reconcile.sh:*)"
     ]
   },
@@ -450,6 +453,17 @@ if [[ "$DIFF_MODE" != "1" ]]; then
           {
             "type": "command",
             "command": "bash .claude/scripts/token-stop-hook.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/scripts/check-kb-ref.sh"
           }
         ]
       }
@@ -494,6 +508,26 @@ HOOKJSON
         echo -e "  ${GREEN}merge${NC} SubagentStart/SubagentStop hooks added to settings.json"
     elif [[ -f "$SETTINGS_FILE" ]]; then
         echo -e "  ${YELLOW}skip${NC}  settings.json exists but jq not available — add subagent hooks manually"
+    fi
+
+    # ── PostToolUse hook: KB-citation enforcement (Write|Edit) ────────
+    # Auto-disables when .kb/ has no entries (the script self-gates) so
+    # projects that don't use vallorcine for code-relevant research
+    # aren't nagged.
+    KBREF_MARKER="check-kb-ref"
+    if [[ -f "$SETTINGS_FILE" ]] && grep -qF "$KBREF_MARKER" "$SETTINGS_FILE" 2>/dev/null; then
+        echo -e "  ${YELLOW}skip${NC}  KB-ref hook already registered"
+    elif [[ -f "$SETTINGS_FILE" ]] && command -v jq &>/dev/null; then
+        jq '.hooks.PostToolUse = ((.hooks.PostToolUse // []) + [{
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [{
+                "type": "command",
+                "command": "bash .claude/scripts/check-kb-ref.sh"
+            }]
+        }])' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
+        echo -e "  ${GREEN}merge${NC} PostToolUse KB-ref hook added to settings.json"
+    elif [[ -f "$SETTINGS_FILE" ]]; then
+        echo -e "  ${YELLOW}skip${NC}  settings.json exists but jq not available — add PostToolUse KB-ref hook manually"
     fi
 
     # ── PreCompact hook for crash recovery ───────────────────────────

--- a/rules/kb-protocol.md
+++ b/rules/kb-protocol.md
@@ -20,3 +20,36 @@ Structure:
 
 ## To load a decision
   Read .decisions/CLAUDE.md → .decisions/<slug>/adr.md
+
+## KB → code citation convention
+
+Source files SHOULD declare which KB articles informed them. A future reader
+of `modules/auth/KeyStore.java` should be able to find the research that
+explains the design without grepping the KB.
+
+Comment forms:
+- `// KB: <path>` for languages with `//` comments (Java, JS, TS, Go, Rust, C, C++)
+- `# KB: <path>` for Python, Bash, Ruby, Perl
+- `<!-- KB: <path> -->` for HTML, XML, Markdown
+
+Multiple citations may appear comma-separated on one line, OR on separate
+`KB:` lines:
+
+```java
+// KB: .kb/algorithms/encryption/three-level-keys.md
+// KB: .kb/patterns/validation/silent-fallthrough.md
+```
+
+The `check-kb-ref.sh` PostToolUse hook (registered in `settings.json`)
+fires on Write/Edit. It:
+
+1. Auto-disables when `.kb/` has no entries beyond `_refs/` (projects that
+   don't use the KB are not nagged).
+2. Validates that each cited path exists.
+3. Validates that the cited entry's `applies_to:` includes the file path.
+4. When no citation is present and at least one KB entry's `applies_to`
+   covers the file path, suggests those entries.
+
+`/curate` Analysis 26 closes the loop after the fact: it scans changed
+source files for `KB:` citations and flags drift the hook missed
+(citation predates an entry rename, kit installed mid-stream, etc.).

--- a/scripts/check-kb-ref.sh
+++ b/scripts/check-kb-ref.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# check-kb-ref.sh — PostToolUse hook for Write/Edit that links source code
+# back to the KB.
+#
+# Purpose. Vallorcine ships a structured KB; without a back-link from code to
+# KB, articles drift from the implementations they describe and a future
+# reader has no way to find the research that informed a design choice.
+# `@spec` annotations cover spec→code; this hook covers KB→code.
+#
+# Convention. A source file SHOULD declare which KB articles informed it:
+#
+#     // KB: .kb/algorithms/encryption/three-level-key-hierarchy.md
+#     // KB: .kb/patterns/validation/silent-fallthrough.md, .kb/systems/database-engines/wal-recovery.md
+#
+# Single-line comment syntaxes recognised: `// KB:` (Java/JS/TS/Go/Rust/C/C++),
+# `# KB:` (Python/Bash/Ruby/Perl), `<!-- KB: ... -->` (HTML/XML/Markdown).
+# Multiple citations may appear comma-separated on one line, OR on separate
+# `KB:` lines.
+#
+# When the hook fires (warn-only, never blocks):
+#
+#   1. Citation present but path missing — `.kb/foo/bar.md` doesn't exist.
+#      The most common bit-rot: rename a KB entry, code citation goes stale.
+#
+#   2. Citation present but `applies_to` doesn't include this file path —
+#      likely a copy-paste citation. The cited entry's applies_to globs
+#      do not match the file being written.
+#
+#   3. No citation AND there exist KB entries whose `applies_to` matches the
+#      file path. Suggest those entries by path; the writer can ignore or
+#      pick one.
+#
+# Auto-disable. If `.kb/` doesn't exist, contains only `_refs/`, or contains
+# no entries with `applies_to` set, the hook exits silently — projects that
+# don't use the KB for code-relevant research aren't nagged.
+#
+# Output. JSON `{"systemMessage": "..."}` to stdout when there's something
+# to surface; nothing otherwise. Always exits 0 — hook is advisory.
+#
+# Stdin. Standard PostToolUse JSON: `{"tool_input": {"file_path": "..."}}`
+# or `{"tool_response": {"filePath": "..."}}`. Tolerates both shapes.
+
+set -euo pipefail
+shopt -s globstar nullglob
+
+# ── Read the tool result ─────────────────────────────────────────────────────
+
+INPUT="$(cat 2>/dev/null || true)"
+[[ -z "$INPUT" ]] && exit 0
+
+FILE_PATH="$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    p = ((d.get("tool_input") or {}).get("file_path")
+         or (d.get("tool_response") or {}).get("filePath")
+         or "")
+    print(p)
+except Exception:
+    pass
+' 2>/dev/null || true)"
+
+[[ -z "$FILE_PATH" ]] && exit 0
+[[ ! -f "$FILE_PATH" ]] && exit 0
+
+# Resolve to project-relative for cleaner paths in messages and matching.
+PROJECT_ROOT="$(pwd -P)"
+case "$FILE_PATH" in
+  /*) REL_PATH="${FILE_PATH#"$PROJECT_ROOT/"}" ;;
+  *)  REL_PATH="$FILE_PATH" ;;
+esac
+
+# ── Filter: skip vallorcine internals and known non-source ──────────────────
+
+case "$REL_PATH" in
+  .kb/*|.spec/*|.work/*|.feature/*|.curate/*|.decisions/*|.claude/*|.git/*) exit 0 ;;
+  WIP.md|CONTEXT.md|SETTLED.md|CHANGELOG.md|README.md|VERSION) exit 0 ;;
+esac
+
+EXT="${REL_PATH##*.}"
+case "$EXT" in
+  md|json|yaml|yml|toml|lock|txt|gitignore|env|properties) exit 0 ;;
+esac
+
+# ── Auto-disable: no meaningful KB ─────────────────────────────────────────
+
+if [[ ! -d ".kb" ]]; then exit 0; fi
+
+# Count KB entries (excluding indexes, refs, archive). Bail if zero.
+KB_ENTRY_COUNT=0
+for f in .kb/**/*.md; do
+  case "$f" in
+    .kb/CLAUDE.md|.kb/_refs/*|.kb/_archive*|*/CLAUDE.md) continue ;;
+  esac
+  [[ -f "$f" ]] && KB_ENTRY_COUNT=$((KB_ENTRY_COUNT + 1))
+done
+[[ "$KB_ENTRY_COUNT" -eq 0 ]] && exit 0
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Extract every cited KB path from the source file. Looks for KB: <path>
+# in line- or HTML-comment form, supports comma-separated multi-citation.
+# Echoes one path per line.
+extract_citations() {
+  local file="$1"
+  # Patterns:
+  #   //  KB: <paths>
+  #   #   KB: <paths>
+  #   <!-- KB: <paths> -->
+  # Strip optional `-->` suffix and split on commas.
+  grep -E '^[[:space:]]*(//|#|<!--)[[:space:]]*KB:' "$file" 2>/dev/null \
+    | sed -E 's~^[[:space:]]*(//|#|<!--)[[:space:]]*KB:[[:space:]]*~~' \
+    | sed -E 's~[[:space:]]*-->[[:space:]]*$~~' \
+    | tr ',' '\n' \
+    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | grep -v '^$' || true
+}
+
+# Extract applies_to entries from a KB entry's frontmatter. Echoes one
+# pattern per line. Tolerates the inline (`applies_to: ["a", "b"]`) and
+# block (`applies_to:\n  - a\n  - b`) YAML forms.
+extract_applies_to() {
+  local kb_file="$1"
+  awk '
+    BEGIN { in_fm = 0; in_at = 0 }
+    /^---[[:space:]]*$/ { in_fm = !in_fm; next }
+    in_fm && /^applies_to:[[:space:]]*\[/ {
+      # Inline list — strip key, brackets, quotes; print each comma-separated entry.
+      sub(/^applies_to:[[:space:]]*\[[[:space:]]*/, "")
+      sub(/[[:space:]]*\][[:space:]]*$/, "")
+      gsub(/"/, "")
+      gsub(/'\''/, "")
+      n = split($0, parts, /[[:space:]]*,[[:space:]]*/)
+      for (i = 1; i <= n; i++) if (parts[i] != "") print parts[i]
+      next
+    }
+    in_fm && /^applies_to:[[:space:]]*$/ { in_at = 1; next }
+    in_fm && in_at && /^[[:space:]]*-[[:space:]]+/ {
+      sub(/^[[:space:]]*-[[:space:]]+/, "")
+      gsub(/"/, "")
+      gsub(/'\''/, "")
+      print
+      next
+    }
+    in_fm && in_at && /^[^[:space:]-]/ { in_at = 0 }
+  ' "$kb_file" 2>/dev/null
+}
+
+# Match a glob pattern against a path. Supports **, *, ?, [...]. Uses
+# bash globstar for ** semantics (any number of intermediate dirs).
+match_pattern() {
+  local pattern="$1" path="$2"
+  # shellcheck disable=SC2053
+  [[ "$path" == $pattern ]]
+}
+
+# Returns 0 if any pattern in the entry's applies_to matches the path.
+entry_applies_to_path() {
+  local kb_file="$1" path="$2" pat
+  while IFS= read -r pat; do
+    [[ -z "$pat" ]] && continue
+    if match_pattern "$pat" "$path"; then return 0; fi
+  done < <(extract_applies_to "$kb_file")
+  return 1
+}
+
+# Find KB entries whose applies_to covers $REL_PATH. Echoes paths.
+suggest_entries() {
+  local f
+  for f in .kb/**/*.md; do
+    case "$f" in
+      .kb/CLAUDE.md|.kb/_refs/*|.kb/_archive*|*/CLAUDE.md) continue ;;
+    esac
+    [[ -f "$f" ]] || continue
+    if entry_applies_to_path "$f" "$REL_PATH"; then
+      printf '%s\n' "$f"
+    fi
+  done
+}
+
+# Emit a systemMessage. Properly JSON-escapes the body.
+emit() {
+  local msg="$1"
+  python3 -c 'import json, sys; print(json.dumps({"systemMessage": sys.argv[1]}))' "$msg"
+}
+
+# ── Run the checks ───────────────────────────────────────────────────────────
+
+mapfile -t CITATIONS < <(extract_citations "$FILE_PATH")
+
+PROBLEMS=()
+
+if [[ "${#CITATIONS[@]}" -gt 0 ]]; then
+  # Validate each citation.
+  for cited in "${CITATIONS[@]}"; do
+    # Normalise — accept both `.kb/foo.md` and `kb/foo.md`.
+    local_path="$cited"
+    case "$local_path" in
+      .kb/*) ;;
+      kb/*)  local_path=".$local_path" ;;
+      *)     local_path=".kb/$local_path" ;;
+    esac
+
+    if [[ ! -f "$local_path" ]]; then
+      PROBLEMS+=("citation points at missing entry: $cited")
+      continue
+    fi
+
+    # Empty applies_to is acceptable (general research). Only flag a
+    # mismatch when applies_to has entries AND none of them match.
+    AT_COUNT=$(extract_applies_to "$local_path" | grep -c . 2>/dev/null || echo 0)
+    if [[ "$AT_COUNT" -gt 0 ]]; then
+      if ! entry_applies_to_path "$local_path" "$REL_PATH"; then
+        PROBLEMS+=("$cited: applies_to does not include $REL_PATH (likely wrong citation)")
+      fi
+    fi
+  done
+else
+  # No citation — see if anything in the KB applies to this file.
+  mapfile -t SUGGESTIONS < <(suggest_entries)
+  if [[ "${#SUGGESTIONS[@]}" -gt 0 ]]; then
+    msg="${REL_PATH}: no KB citation, but matching entries exist:"
+    for s in "${SUGGESTIONS[@]}"; do
+      msg+=$'\n  '"// KB: $s"
+    done
+    msg+=$'\n''(add a `// KB: <path>` comment near the top of the file, or document why no KB applies.)'
+    emit "$msg"
+  fi
+  # If no citations and nothing matches, stay silent — no nagging projects
+  # whose KB hasn't grown into a given area yet.
+  exit 0
+fi
+
+if [[ "${#PROBLEMS[@]}" -gt 0 ]]; then
+  msg="${REL_PATH}: KB citation issues:"
+  for p in "${PROBLEMS[@]}"; do
+    msg+=$'\n  · '"$p"
+  done
+  emit "$msg"
+fi
+
+exit 0

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -2071,6 +2071,97 @@ if [[ -d ".kb" ]]; then
     done
 fi
 
+# ── Analysis 26: KB-citation drift in source code ──────────────────────────
+# The check-kb-ref.sh hook fires at write time and warns about missing /
+# wrong KB citations. This analysis closes the loop after the fact:
+# scans source files that changed in the window for `// KB:` / `# KB:` /
+# `<!-- KB:` citations and validates each against the KB. Catches drift
+# the hook missed (kit installed mid-stream, citation predates the
+# entry rename, etc.).
+#
+# Scope: changed source files only — the existing $TMPDIR_SCAN/changed-source.txt
+# is the bounded set. Full-tree scan would be too expensive; recent
+# drift is the actionable signal.
+#
+# Output: KB_CITATION_DRIFT|<source-file>|<cited-kb-entry>|<reason>
+
+> "$TMPDIR_SCAN/kb-citation-drift.txt"
+if [[ -s "$TMPDIR_SCAN/changed-source.txt" ]] && [[ -d ".kb" ]]; then
+    while IFS= read -r src_file; do
+        [[ -f "$src_file" ]] || continue
+        # Skip vallorcine internals and non-source.
+        case "$src_file" in
+            .kb/*|.spec/*|.work/*|.feature/*|.curate/*|.decisions/*|.claude/*) continue ;;
+        esac
+        ext="${src_file##*.}"
+        case "$ext" in
+            md|json|yaml|yml|toml|lock|txt|gitignore|env|properties) continue ;;
+        esac
+
+        # Extract citations using the same recogniser the hook uses.
+        citations="$(grep -E '^[[:space:]]*(//|#|<!--)[[:space:]]*KB:' "$src_file" 2>/dev/null \
+            | sed -E 's~^[[:space:]]*(//|#|<!--)[[:space:]]*KB:[[:space:]]*~~' \
+            | sed -E 's~[[:space:]]*-->[[:space:]]*$~~' \
+            | tr ',' '\n' \
+            | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+            | grep -v '^$' || true)"
+        [[ -z "$citations" ]] && continue
+
+        while IFS= read -r cited; do
+            # Normalise to .kb/-prefixed path.
+            local_path="$cited"
+            case "$local_path" in
+                .kb/*) ;;
+                kb/*)  local_path=".$local_path" ;;
+                *)     local_path=".kb/$local_path" ;;
+            esac
+
+            if [[ ! -f "$local_path" ]]; then
+                echo "KB_CITATION_DRIFT|$src_file|$cited|missing-entry" \
+                    >> "$TMPDIR_SCAN/kb-citation-drift.txt"
+                continue
+            fi
+
+            # Check applies_to. Empty applies_to (general research) is OK;
+            # only flag when applies_to has entries AND none cover the file.
+            applies_to_lines="$(awk '
+                BEGIN { in_fm = 0; in_at = 0 }
+                /^---[[:space:]]*$/ { in_fm = !in_fm; next }
+                in_fm && /^applies_to:[[:space:]]*\[/ {
+                    sub(/^applies_to:[[:space:]]*\[[[:space:]]*/, "")
+                    sub(/[[:space:]]*\][[:space:]]*$/, "")
+                    gsub(/"/, "")
+                    n = split($0, parts, /[[:space:]]*,[[:space:]]*/)
+                    for (i = 1; i <= n; i++) if (parts[i] != "") print parts[i]
+                    next
+                }
+                in_fm && /^applies_to:[[:space:]]*$/ { in_at = 1; next }
+                in_fm && in_at && /^[[:space:]]*-[[:space:]]+/ {
+                    sub(/^[[:space:]]*-[[:space:]]+/, "")
+                    gsub(/"/, "")
+                    print
+                    next
+                }
+                in_fm && in_at && /^[^[:space:]-]/ { in_at = 0 }
+            ' "$local_path" 2>/dev/null)"
+
+            [[ -z "$applies_to_lines" ]] && continue   # general research
+
+            matched=0
+            while IFS= read -r pat; do
+                [[ -z "$pat" ]] && continue
+                # shellcheck disable=SC2053
+                if [[ "$src_file" == $pat ]]; then matched=1; break; fi
+            done <<< "$applies_to_lines"
+
+            if [[ "$matched" -eq 0 ]]; then
+                echo "KB_CITATION_DRIFT|$src_file|$cited|applies_to-mismatch" \
+                    >> "$TMPDIR_SCAN/kb-citation-drift.txt"
+            fi
+        done <<< "$citations"
+    done < "$TMPDIR_SCAN/changed-source.txt"
+fi
+
 # ── Write summary file ──────────────────────────────────────────────────────
 
 SCAN_DATE="$(date +%Y-%m-%d)"
@@ -2621,6 +2712,24 @@ if [[ -s "$TMPDIR_SCAN/kb-location-mismatch.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# KB citation drift in source code (Analysis 26)
+if [[ -s "$TMPDIR_SCAN/kb-citation-drift.txt" ]]; then
+    echo "## KB Citation Drift in Source" >> "$SUMMARY_FILE"
+    echo "Source files that changed in the scan window cite KB entries that" >> "$SUMMARY_FILE"
+    echo "either no longer exist (\`missing-entry\`) or whose \`applies_to\`" >> "$SUMMARY_FILE"
+    echo "doesn't include the source file (\`applies_to-mismatch\`). Two" >> "$SUMMARY_FILE"
+    echo "fixes per row: update the citation to the right path, or extend" >> "$SUMMARY_FILE"
+    echo "the entry's \`applies_to\` if the citation is correct but the" >> "$SUMMARY_FILE"
+    echo "entry's stated scope is incomplete." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Source File | Cited Entry | Reason |" >> "$SUMMARY_FILE"
+    echo "|-------------|-------------|--------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ src_file cited reason; do
+        echo "| $src_file | $cited | $reason |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/kb-citation-drift.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # Falsification lens staleness (Analysis 22)
 if [[ -s "$TMPDIR_SCAN/falsification-stale.txt" ]]; then
     echo "## Falsification Lens Staleness" >> "$SUMMARY_FILE"
@@ -2678,6 +2787,7 @@ echo "  Falsification staleness: $(wc -l < "$TMPDIR_SCAN/falsification-stale.txt
 echo "  KB filename collisions: $(wc -l < "$TMPDIR_SCAN/kb-collisions.txt" 2>/dev/null || echo 0)"
 echo "  KB schema drift: $(wc -l < "$TMPDIR_SCAN/kb-schema-drift.txt" 2>/dev/null || echo 0)"
 echo "  KB type/location mismatch: $(wc -l < "$TMPDIR_SCAN/kb-location-mismatch.txt" 2>/dev/null || echo 0)"
+echo "  KB citation drift in source: $(wc -l < "$TMPDIR_SCAN/kb-citation-drift.txt" 2>/dev/null || echo 0)"
 
 # ── Update curation state ─────────────────────────────────────────────────
 

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -28,6 +28,7 @@ couldn't see because they each had a narrower scope.
 16. KB filename collisions — entries sharing a filename across folders (silently fragments search and pattern-recurrence evidence)
 17. KB schema drift — frontmatter that does not match `.kb/_refs/frontmatter.md` (missing/bad-enum fields, confidence overclaim, path/frontmatter mismatch)
 18. KB type/location mismatch — adversarial findings outside `patterns/<concern>/` or feature-footprints outside `architecture/feature-footprints/`
+19. KB citation drift in source — `// KB:` / `# KB:` citations in changed source files that point at missing entries or whose entry's `applies_to` doesn't include the source file (closes the loop with the `check-kb-ref.sh` PostToolUse hook)
 
 **Flags:**
 - `--init` — first-time scan (ignores last-scanned SHA, good for new installs)
@@ -729,6 +730,50 @@ the writer must still pick the appropriate concern (`validation`,
 `/curate` infers the concern from the entry's `domain:` field (for
 adversarial-findings) or asks the user.
 
+### 2s — KB citation drift in source
+
+**Guard:** Only run this step if the "KB Citation Drift in Source" section
+exists in the scan summary. If absent, skip entirely.
+
+This analysis closes the loop with the `check-kb-ref.sh` PostToolUse hook:
+the hook fires at write-time, this analysis catches the cases the hook
+missed (kit installed mid-stream, file edited before the hook landed,
+citation predates an entry rename). Every row is a `// KB:` / `# KB:` /
+`<!-- KB: -->` citation in a source file that doesn't reconcile with the
+KB.
+
+Two reason codes:
+
+- `missing-entry` — the cited path doesn't resolve. The KB entry was
+  renamed, deleted, or never existed. The citation is rotted.
+- `applies_to-mismatch` — the cited entry exists, but its `applies_to`
+  doesn't include the source file. Either the citation is wrong (likely
+  copy-paste from another file) or the entry's `applies_to` is too
+  narrow.
+
+For each row, use AskUserQuestion with options:
+
+- **"Update the citation"** (description: "The citation is wrong. Edit
+  the source file to point at the correct KB entry, or remove the
+  citation if no KB applies. /curate proposes the right entry from
+  `applies_to` matches when possible.")
+- **"Extend the entry's applies_to"** (description: "The citation is
+  correct but the cited entry's `applies_to` is too narrow. Add the
+  source file (or a glob covering it) to the entry's `applies_to:`
+  frontmatter list. Stage the change with `git add`; user commits.")
+- **"Dismiss as intentional"** (description: "Rare; e.g., the citation
+  is to a parent-domain entry that the writer wanted to reference even
+  though `applies_to` is more specific. Record in review log.")
+- **"Skip"** (description: "Defer to next /curate pass")
+
+For `missing-entry`: only "Update the citation" / "Dismiss" / "Skip" make
+sense (you can't extend an entry that doesn't exist).
+
+For `applies_to-mismatch`: when the user picks "Extend", `/curate`
+proposes a glob — usually the broadest folder under which the source
+file lives (e.g. `modules/auth/**` rather than the exact file path).
+Confirm with the user before staging.
+
 ---
 
 ## Step 2.5 — Merge in unresolved prior items
@@ -882,6 +927,9 @@ I scanned <N> commits since last review and found <N> items:
 
  22. <N> KB type/location mismatches — adversarial-findings outside `patterns/` or footprints outside `architecture/feature-footprints/`
      → I'll propose a relocation or type reclassification per entry
+
+ 23. <N> KB citation drift rows in changed source files — `// KB:` lines pointing at missing entries or whose entry's `applies_to` doesn't include the source file
+     → I'll propose either a citation update or an `applies_to` extension per row
 
 Items you don't address are saved automatically — run /curate anytime to pick them up.
 ```
@@ -1421,6 +1469,7 @@ across runs. Use these conventions:
 | KB filename collision | `kb-collision:<basename>` |
 | KB schema drift | `kb-schema:<path>:<issue-code>` |
 | KB type/location mismatch | `kb-location:<path>` |
+| KB citation drift | `kb-citation:<source-file>:<cited-entry>` |
 
 The append helper is duplicate-safe — re-appending an identical row is a
 no-op, so resuming a previous /curate session does not duplicate entries.

--- a/tests/scenario-check-kb-ref.sh
+++ b/tests/scenario-check-kb-ref.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Scenario: PostToolUse hook check-kb-ref.sh validates KB citations in code.
+#
+# Layered cover:
+#
+#   1. Auto-disable when .kb/ is absent.
+#   2. Auto-disable when .kb/ only has _refs/ (no entries).
+#   3. Skip files inside vallorcine internal dirs (.kb/, .spec/, etc.).
+#   4. Skip non-source extensions (md, json, yaml, etc.).
+#   5. Suggest matching KB entries when a source file has no citation
+#      but applies_to globs cover its path.
+#   6. Silent when there is no citation AND no entry's applies_to matches.
+#   7. Warn when a citation points at a missing KB entry (rotted link).
+#   8. Warn when a citation's applies_to does not include the file (wrong citation).
+#   9. Accept comma-separated multi-citation on one line.
+#  10. Accept // KB:, # KB:, and <!-- KB: ... --> comment forms.
+#  11. Hook always exits 0 (advisory only, never blocks the tool use).
+#  12. Empty applies_to in the cited entry passes validation (general research).
+#
+# Run from repo root: bash tests/scenario-check-kb-ref.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+HOOK="$REPO_ROOT/scripts/check-kb-ref.sh"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+# Drives the hook with a synthetic PostToolUse JSON. Captures stdout (the
+# systemMessage JSON or empty), stderr, and exit code.
+#
+#   run_hook <project-root> <file-path>  → echoes stdout
+run_hook() {
+  local proj="$1" path="$2"
+  ( cd "$proj" && \
+    printf '{"tool_input":{"file_path":"%s"}}' "$path" \
+      | bash "$HOOK" 2>/dev/null )
+}
+
+echo ""
+echo "scenario: check-kb-ref.sh hook"
+echo "────────────────────────────────────────────────"
+
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine/check-kb-ref.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# ── 1. Project with no .kb/ at all ───────────────────────────────────────────
+
+P1="$TMPDIR_TEST/no-kb"
+mkdir -p "$P1/src/main"
+cat > "$P1/src/main/Foo.java" << 'EOF'
+public class Foo {}
+EOF
+
+OUT="$(run_hook "$P1" "src/main/Foo.java")"
+if [[ -z "$OUT" ]]; then
+  pass "auto-disable when .kb/ is absent"
+else
+  fail "auto-disable when .kb/ is absent" "got: $OUT"
+fi
+
+# Always exit 0 — advisory only.
+( cd "$P1" && printf '{"tool_input":{"file_path":"src/main/Foo.java"}}' | bash "$HOOK" >/dev/null 2>&1 )
+if [[ "$?" -eq 0 ]]; then
+  pass "hook exits 0 on no-kb project"
+else
+  fail "hook exits 0 on no-kb project"
+fi
+
+# ── 2. Project with only _refs/ (no entries) ────────────────────────────────
+
+P2="$TMPDIR_TEST/refs-only"
+mkdir -p "$P2/.kb/_refs" "$P2/src/main"
+echo "stub" > "$P2/.kb/_refs/frontmatter.md"
+cat > "$P2/.kb/CLAUDE.md" << 'EOF'
+# KB
+EOF
+cat > "$P2/src/main/Bar.java" << 'EOF'
+public class Bar {}
+EOF
+
+OUT="$(run_hook "$P2" "src/main/Bar.java")"
+if [[ -z "$OUT" ]]; then
+  pass "auto-disable when .kb/ only has _refs/"
+else
+  fail "auto-disable when .kb/ only has _refs/" "got: $OUT"
+fi
+
+# ── Build a richer fixture for the rest ─────────────────────────────────────
+
+P3="$TMPDIR_TEST/proj"
+mkdir -p "$P3/.kb/algorithms/encryption" \
+         "$P3/.kb/patterns/validation" \
+         "$P3/.kb/_refs" \
+         "$P3/.spec" \
+         "$P3/src/main/auth" \
+         "$P3/src/main/billing" \
+         "$P3/docs"
+
+cat > "$P3/.kb/CLAUDE.md" << 'EOF'
+# KB
+EOF
+echo "stub" > "$P3/.kb/_refs/frontmatter.md"
+
+cat > "$P3/.kb/algorithms/encryption/three-level-keys.md" << 'EOF'
+---
+title: "Three-level key hierarchy"
+type: research
+applies_to:
+  - "src/main/auth/**"
+  - "src/main/auth/KeyStore.java"
+last_researched: "2026-05-09"
+research_status: stable
+---
+# entry
+EOF
+
+cat > "$P3/.kb/patterns/validation/silent-fallthrough.md" << 'EOF'
+---
+title: "Silent fallthrough"
+type: adversarial-finding
+domain: validation
+severity: confirmed
+applies_to:
+  - "src/main/auth/**"
+last_researched: "2026-05-09"
+research_status: stable
+---
+# entry
+EOF
+
+cat > "$P3/.kb/algorithms/encryption/no-applies.md" << 'EOF'
+---
+title: "General encryption research (no applies_to)"
+type: research
+applies_to: []
+last_researched: "2026-05-09"
+research_status: stable
+---
+# entry
+EOF
+
+# ── 3. Skip vallorcine internals ─────────────────────────────────────────────
+
+OUT="$(run_hook "$P3" ".kb/algorithms/encryption/three-level-keys.md")"
+if [[ -z "$OUT" ]]; then
+  pass "skip files inside .kb/"
+else
+  fail "skip files inside .kb/" "got: $OUT"
+fi
+
+OUT="$(run_hook "$P3" ".spec/foo.md")"
+if [[ -z "$OUT" ]]; then
+  pass "skip files inside .spec/"
+else
+  fail "skip files inside .spec/" "got: $OUT"
+fi
+
+# ── 4. Skip non-source extensions ───────────────────────────────────────────
+
+cat > "$P3/docs/notes.md" << 'EOF'
+some markdown
+EOF
+OUT="$(run_hook "$P3" "docs/notes.md")"
+if [[ -z "$OUT" ]]; then
+  pass "skip .md files"
+else
+  fail "skip .md files" "got: $OUT"
+fi
+
+cat > "$P3/src/main/auth/config.yaml" << 'EOF'
+key: value
+EOF
+OUT="$(run_hook "$P3" "src/main/auth/config.yaml")"
+if [[ -z "$OUT" ]]; then
+  pass "skip .yaml files"
+else
+  fail "skip .yaml files" "got: $OUT"
+fi
+
+# ── 5. Suggest matching entries when no citation ────────────────────────────
+
+cat > "$P3/src/main/auth/KeyStore.java" << 'EOF'
+public class KeyStore {
+    // some implementation
+}
+EOF
+OUT="$(run_hook "$P3" "src/main/auth/KeyStore.java")"
+if echo "$OUT" | grep -q 'three-level-keys'; then
+  pass "suggest: matching entry surfaced when no citation present"
+else
+  fail "suggest: matching entry surfaced when no citation present" "got: $OUT"
+fi
+if echo "$OUT" | grep -q 'silent-fallthrough'; then
+  pass "suggest: second matching entry also surfaced"
+else
+  fail "suggest: second matching entry also surfaced" "got: $OUT"
+fi
+
+# ── 6. Silent when no citation AND no entry matches ─────────────────────────
+
+cat > "$P3/src/main/billing/Invoice.java" << 'EOF'
+public class Invoice {}
+EOF
+OUT="$(run_hook "$P3" "src/main/billing/Invoice.java")"
+if [[ -z "$OUT" ]]; then
+  pass "silent when no citation and no applies_to matches"
+else
+  fail "silent when no citation and no applies_to matches" "got: $OUT"
+fi
+
+# ── 7. Warn when citation points at missing entry ───────────────────────────
+
+cat > "$P3/src/main/auth/Login.java" << 'EOF'
+// KB: .kb/algorithms/encryption/this-was-renamed.md
+public class Login {}
+EOF
+OUT="$(run_hook "$P3" "src/main/auth/Login.java")"
+if echo "$OUT" | grep -q 'missing entry'; then
+  pass "warn: citation points at missing entry"
+else
+  fail "warn: citation points at missing entry" "got: $OUT"
+fi
+
+# ── 8. Warn when applies_to does not include the file ───────────────────────
+
+cat > "$P3/src/main/billing/Charge.java" << 'EOF'
+// KB: .kb/algorithms/encryption/three-level-keys.md
+public class Charge {}
+EOF
+OUT="$(run_hook "$P3" "src/main/billing/Charge.java")"
+if echo "$OUT" | grep -q 'applies_to does not include'; then
+  pass "warn: applies_to mismatch flagged"
+else
+  fail "warn: applies_to mismatch flagged" "got: $OUT"
+fi
+
+# ── 9. Multi-citation parsing (comma-separated) ─────────────────────────────
+
+cat > "$P3/src/main/auth/Multi.java" << 'EOF'
+// KB: .kb/algorithms/encryption/three-level-keys.md, .kb/algorithms/encryption/missing.md
+public class Multi {}
+EOF
+OUT="$(run_hook "$P3" "src/main/auth/Multi.java")"
+if echo "$OUT" | grep -q 'missing.md'; then
+  pass "multi-citation: missing entry in second slot is flagged"
+else
+  fail "multi-citation: missing entry in second slot is flagged" "got: $OUT"
+fi
+# The valid first citation should not be flagged.
+if ! echo "$OUT" | grep -q 'three-level-keys.md.*missing entry'; then
+  pass "multi-citation: valid entry in first slot is NOT flagged"
+else
+  fail "multi-citation: valid entry in first slot is NOT flagged" "got: $OUT"
+fi
+
+# ── 10. All comment syntaxes recognised ─────────────────────────────────────
+
+cat > "$P3/src/main/auth/hash.py" << 'EOF'
+# KB: .kb/algorithms/encryption/three-level-keys.md
+def hash_key(): pass
+EOF
+OUT="$(run_hook "$P3" "src/main/auth/hash.py")"
+# No suggestion message because citation is present and valid.
+if [[ -z "$OUT" ]] || ! echo "$OUT" | grep -q 'no KB citation'; then
+  pass "comment syntax: # KB: recognised (no suggestion fired)"
+else
+  fail "comment syntax: # KB: recognised (no suggestion fired)" "got: $OUT"
+fi
+
+cat > "$P3/src/main/auth/page.html" << 'EOF'
+<!-- KB: .kb/algorithms/encryption/three-level-keys.md -->
+<html></html>
+EOF
+OUT="$(run_hook "$P3" "src/main/auth/page.html")"
+if [[ -z "$OUT" ]] || ! echo "$OUT" | grep -q 'no KB citation'; then
+  pass "comment syntax: <!-- KB: --> recognised"
+else
+  fail "comment syntax: <!-- KB: --> recognised" "got: $OUT"
+fi
+
+# ── 11. Hook always exits 0 ─────────────────────────────────────────────────
+
+EXIT_CODE=0
+( cd "$P3" && printf '{"tool_input":{"file_path":"src/main/auth/Login.java"}}' \
+    | bash "$HOOK" >/dev/null 2>&1 ) || EXIT_CODE=$?
+if [[ "$EXIT_CODE" -eq 0 ]]; then
+  pass "exit 0 even when warnings are emitted"
+else
+  fail "exit 0 even when warnings are emitted" "exit=$EXIT_CODE"
+fi
+
+# ── 12. Empty applies_to entry passes validation (general research) ─────────
+
+cat > "$P3/src/main/auth/General.java" << 'EOF'
+// KB: .kb/algorithms/encryption/no-applies.md
+public class General {}
+EOF
+OUT="$(run_hook "$P3" "src/main/auth/General.java")"
+if ! echo "$OUT" | grep -q 'applies_to does not include'; then
+  pass "empty applies_to entry passes validation (general research)"
+else
+  fail "empty applies_to entry passes validation (general research)" "got: $OUT"
+fi
+
+# ── Final report ────────────────────────────────────────────────────────────
+
+echo ""
+echo "── Summary ──"
+echo "  Passed: $passed/$total"
+echo "  Failed: $failed/$total"
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1

--- a/tests/scenario-curate-kb-citation-drift.sh
+++ b/tests/scenario-curate-kb-citation-drift.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# Scenario: /curate KB citation drift detector (Analysis 26).
+#
+# Validates curate-scan.sh's detection of `// KB:` / `# KB:` / `<!-- KB: -->`
+# citations in changed source files that don't reconcile with the KB:
+#
+#   * `missing-entry` — citation points at a deleted/renamed KB path.
+#   * `applies_to-mismatch` — citation is to an existing entry, but the
+#     entry's `applies_to` doesn't include the source file.
+#
+# Layered cover:
+#
+#   1. Citation in a changed source file with missing target → flagged.
+#   2. Citation to existing entry with applies_to NOT covering the file → flagged.
+#   3. Citation to existing entry whose applies_to DOES cover the file → NOT flagged.
+#   4. Citation to existing entry with EMPTY applies_to (general research) → NOT flagged.
+#   5. Source file with no citation → NOT flagged (analysis is for citations only).
+#   6. UNCHANGED source files (not in changed-source.txt) are NOT scanned —
+#      analysis is bounded to recent activity.
+#   7. Files in vallorcine internals (.kb/, .spec/) are skipped.
+#   8. Multi-citation: the analysis flags only the bad slot, not the good one.
+#   9. All three comment syntaxes are recognised (// , #, <!-- -->).
+#
+# Run from repo root: bash tests/scenario-curate-kb-citation-drift.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() {
+  ((failed++)) || true; ((total++)) || true
+  echo "  FAIL  $1"
+  [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+assert_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$desc"
+  else
+    fail "$desc" "pattern not found: $pattern"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$desc"
+  else
+    fail "$desc" "pattern unexpectedly found: $pattern"
+  fi
+}
+
+# Extract just the KB Citation Drift section so assertions don't collide with
+# generic git analyses (Churn Hotspots, Test-Source Drift, etc.) that
+# legitimately list every changed file by name.
+citation_drift_section() {
+  awk '
+    /^## KB Citation Drift in Source/ { in_section = 1; next }
+    /^## / && in_section { in_section = 0 }
+    in_section { print }
+  ' "$1"
+}
+
+assert_drift_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if citation_drift_section "$file" | grep -qE "$pattern" 2>/dev/null; then
+    pass "$desc"
+  else
+    fail "$desc" "pattern not found in KB Citation Drift section: $pattern"
+  fi
+}
+
+assert_drift_not_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if ! citation_drift_section "$file" | grep -qE "$pattern" 2>/dev/null; then
+    pass "$desc"
+  else
+    fail "$desc" "pattern unexpectedly found in KB Citation Drift section: $pattern"
+  fi
+}
+
+echo ""
+echo "scenario: /curate KB citation drift (Analysis 26)"
+echo "────────────────────────────────────────────────"
+
+TMPDIR_TEST="$(mktemp -d /tmp/vallorcine/curate-kb-citation.XXXXXX)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PROJ="$TMPDIR_TEST/proj"
+mkdir -p "$PROJ/.kb/algorithms/encryption" \
+         "$PROJ/.kb/_refs" \
+         "$PROJ/.curate" \
+         "$PROJ/src/main/auth" \
+         "$PROJ/src/main/billing" \
+         "$PROJ/src/main/util" \
+         "$PROJ/.spec"
+cd "$PROJ"
+
+git init -q
+git config user.email test@example.com
+git config user.name "Test"
+
+# Seed KB
+cat > .kb/CLAUDE.md << 'EOF'
+# KB
+## Topic Map
+EOF
+echo "stub" > .kb/_refs/frontmatter.md
+
+cat > .kb/algorithms/encryption/three-level-keys.md << 'EOF'
+---
+title: "Three-level keys"
+type: research
+applies_to:
+  - "src/main/auth/**"
+last_researched: "2026-04-01"
+research_status: stable
+---
+# entry
+EOF
+
+cat > .kb/algorithms/encryption/general-encryption.md << 'EOF'
+---
+title: "General encryption (no applies_to — applies to anything)"
+type: research
+applies_to: []
+last_researched: "2026-04-01"
+research_status: stable
+---
+# entry
+EOF
+
+# Source files
+
+# 1. Citation to missing entry (will be flagged).
+cat > src/main/auth/Login.java << 'EOF'
+// KB: .kb/algorithms/encryption/this-was-renamed.md
+public class Login {}
+EOF
+
+# 2. Citation to existing entry whose applies_to does NOT include this file
+#    (Charge.java is in src/main/billing, but the entry only covers src/main/auth/**).
+cat > src/main/billing/Charge.java << 'EOF'
+// KB: .kb/algorithms/encryption/three-level-keys.md
+public class Charge {}
+EOF
+
+# 3. Citation to existing entry whose applies_to DOES cover this file
+#    (KeyStore.java in src/main/auth/, entry's applies_to is src/main/auth/**).
+cat > src/main/auth/KeyStore.java << 'EOF'
+// KB: .kb/algorithms/encryption/three-level-keys.md
+public class KeyStore {}
+EOF
+
+# 4. Citation to entry with empty applies_to (general research) — never flagged.
+cat > src/main/util/Hex.java << 'EOF'
+// KB: .kb/algorithms/encryption/general-encryption.md
+public class Hex {}
+EOF
+
+# 5. Source file with no citation at all — not flagged by Analysis 26 (it is
+#    the hook's job at write-time, and Analysis 26 scopes to citations).
+cat > src/main/auth/Plain.java << 'EOF'
+public class Plain {}
+EOF
+
+# 8. Multi-citation: one slot good, one slot bad.
+cat > src/main/auth/Multi.java << 'EOF'
+// KB: .kb/algorithms/encryption/three-level-keys.md, .kb/algorithms/encryption/missing.md
+public class Multi {}
+EOF
+
+# 9. Comment-syntax variants — all valid citations to entries that cover them.
+cat > src/main/auth/hash.py << 'EOF'
+# KB: .kb/algorithms/encryption/three-level-keys.md
+def hash(): pass
+EOF
+
+cat > src/main/auth/page.html << 'EOF'
+<!-- KB: .kb/algorithms/encryption/three-level-keys.md -->
+<html></html>
+EOF
+
+# Initial commit so changed-source.txt is non-empty during scan window.
+git add -A
+git commit -q --date='2026-05-01T00:00:00Z' -m "initial source"
+
+# Run scan with link-rot disabled.
+MAX_LINK_ROT_URLS=0 bash "$REPO_ROOT/scripts/curate-scan.sh" --init >/dev/null 2>&1 || true
+
+SUMMARY="$PROJ/.curate/scan-summary.md"
+
+if [[ ! -s "$SUMMARY" ]]; then
+  fail "scan-summary.md was created and non-empty"
+  echo ""
+  echo "── Summary ──"
+  echo "  Passed: $passed/$total"
+  echo "  Failed: $failed/$total"
+  exit 1
+fi
+
+# ── Section presence ─────────────────────────────────────────────────────
+
+assert_contains "$SUMMARY" "## KB Citation Drift in Source" \
+    "section: KB Citation Drift in Source present"
+
+# ── 1. missing-entry detection ───────────────────────────────────────────
+
+assert_drift_contains "$SUMMARY" "Login.java.*this-was-renamed.md.*missing-entry" \
+    "drift: missing-entry on Login.java flagged"
+
+# ── 2. applies_to-mismatch detection ─────────────────────────────────────
+
+assert_drift_contains "$SUMMARY" "Charge.java.*three-level-keys.md.*applies_to-mismatch" \
+    "drift: applies_to-mismatch on Charge.java flagged"
+
+# ── 3. Valid citation NOT flagged ────────────────────────────────────────
+
+assert_drift_not_contains "$SUMMARY" "KeyStore.java" \
+    "exempt: KeyStore.java (valid citation, applies_to covers it) not flagged"
+
+# ── 4. Empty applies_to entry NOT flagged ────────────────────────────────
+
+assert_drift_not_contains "$SUMMARY" "Hex.java" \
+    "exempt: Hex.java (empty applies_to) not flagged for mismatch"
+
+# ── 5. No-citation file NOT flagged ──────────────────────────────────────
+
+assert_drift_not_contains "$SUMMARY" "Plain.java" \
+    "exempt: Plain.java (no citation) not flagged"
+
+# ── 8. Multi-citation: only the bad slot is flagged ──────────────────────
+
+assert_drift_contains "$SUMMARY" "Multi.java.*missing.md.*missing-entry" \
+    "multi-citation: bad slot flagged"
+
+# Multi.java's GOOD slot is three-level-keys.md, applies_to: src/main/auth/**.
+# Multi.java is in src/main/auth/, so this slot is valid — should NOT flag
+# applies_to-mismatch on the good slot.
+multi_mismatches=$(citation_drift_section "$SUMMARY" \
+    | grep -E "Multi.java.*three-level-keys.md.*applies_to-mismatch" | wc -l || true)
+if [[ "$multi_mismatches" -eq 0 ]]; then
+  pass "multi-citation: good slot NOT flagged"
+else
+  fail "multi-citation: good slot NOT flagged" "found $multi_mismatches mismatch row(s)"
+fi
+
+# ── 9. Comment-syntax variants ───────────────────────────────────────────
+
+assert_drift_not_contains "$SUMMARY" "hash.py" \
+    "comment syntax: # KB: parsed and validated (no drift)"
+
+assert_drift_not_contains "$SUMMARY" "page.html" \
+    "comment syntax: <!-- KB: --> parsed and validated (no drift)"
+
+# ── 7. Vallorcine internals not scanned ──────────────────────────────────
+
+# Drop a fake citation inside .spec/ — it should never appear in drift output
+# because of the .spec/ filter.
+mkdir -p .spec/domains
+cat > .spec/domains/fake.md << 'EOF'
+// KB: .kb/algorithms/encryption/this-also-missing.md
+EOF
+git add -A
+git commit -q --date='2026-05-02T00:00:00Z' -m "add .spec citation"
+
+MAX_LINK_ROT_URLS=0 bash "$REPO_ROOT/scripts/curate-scan.sh" --init >/dev/null 2>&1 || true
+
+assert_drift_not_contains "$SUMMARY" "this-also-missing.md" \
+    "exempt: citation inside .spec/ not scanned"
+
+# ── Final report ─────────────────────────────────────────────────────────
+
+echo ""
+echo "── Summary ──"
+echo "  Passed: $passed/$total"
+echo "  Failed: $failed/$total"
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Pairs v0.17.0's schema work with write-time enforcement and a scan-time
backstop for KB→code linking. Source files SHOULD declare which KB articles
informed them (`// KB:`, `# KB:`, or `<!-- KB: -->` comment); the kit catches
drift two ways.

### What's new

- **`scripts/check-kb-ref.sh`** — PostToolUse hook on Write/Edit/MultiEdit.
  Validates citations, suggests matching entries when none are present, flags
  rotted/wrong citations. Auto-disables when `.kb/` is empty so non-KB
  projects aren't nagged.
- **`/curate` Analysis 26 — KB citation drift in source.** Scans changed
  source files for `KB:` citations and flags `missing-entry` /
  `applies_to-mismatch` cases the hook missed.
- **Convention doc** in `rules/kb-protocol.md`.

Inspired by faas-rippling's `check-kb-ref.sh`; vallorcine's version adds path
validation, applies_to cross-checking, citation suggestions, multi-citation
parsing, three comment syntaxes, and the auto-disable so the kit-default is
safe for every project.

## Test plan

- [x] `scenario-check-kb-ref.sh` — 18/18 covering all enhancement paths
- [x] `scenario-curate-kb-citation-drift.sh` — 11/11 with section-scoped
      assertions
- [x] `test-install.sh` — 72/72 (no new assertions needed; MANIFEST loop
      covers the new script)
- [x] All other `scenario-curate-*.sh` continue to pass

## Self-review

Two bugs caught during review:
- Backticks in a double-quoted warning string were interpreted as command
  substitution. Switched to single-quoted concat.
- `sed`'s `|` delimiter collided with `|` alternation inside the regex
  pattern (sed saw `s|^[[:space:]]*(//|...` as `s|<pattern>|<replacement>|`).
  Switched the sed delimiter to `~`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)