### PR TITLE
feat(spec/curate): canonical spec frontmatter schema + 2 corpus drift analyses

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -227,6 +227,7 @@ _install_seed "$SCRIPT_DIR/decisions/CLAUDE.md" "$TARGET/.decisions/CLAUDE.md"
 echo ""
 echo "── Spec seed files ──────────────────────────────"
 _install_seed "$SCRIPT_DIR/spec/CLAUDE.md" "$TARGET/.spec/CLAUDE.md"
+_install_seed "$SCRIPT_DIR/spec/_refs/frontmatter.md" "$TARGET/.spec/_refs/frontmatter.md"
 
 # ── Work seed files (never overwrite — same as KB / Decisions / Spec) ─────
 

--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -2162,6 +2162,74 @@ if [[ -s "$TMPDIR_SCAN/changed-source.txt" ]] && [[ -d ".kb" ]]; then
     done < "$TMPDIR_SCAN/changed-source.txt"
 fi
 
+# ── Analysis 27: Spec DEPRECATED-but-not-INVALIDATED ────────────────────────
+# A spec marked status=DEPRECATED is the author's signal that the spec is
+# obsolete. But until state=INVALIDATED, /spec-resolve still pulls it into
+# bundles. Surface specs in this graduation gap so the user can either
+# (a) finalize displacement (set state=INVALIDATED + displaced_by), or
+# (b) retract the DEPRECATED status if the spec is still authoritative.
+#
+# Output: SPEC_GRADUATION|<id>|<file>|<status>|<state>|<has-displaced-by>
+
+> "$TMPDIR_SCAN/spec-graduation.txt"
+if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
+    MANIFEST=".spec/registry/manifest.json"
+    while IFS= read -r sid; do
+        [[ -z "$sid" ]] && continue
+        sfile=$(spec_file_for_id "$MANIFEST" "$sid")
+        [[ -z "$sfile" || ! -f "$sfile" ]] && continue
+
+        # Read frontmatter via fm() — it understands JSON-in-fences.
+        sstatus=$(fm "$sfile" '.status // ""' 2>/dev/null || echo "")
+        sstate=$(fm  "$sfile" '.state  // ""' 2>/dev/null || echo "")
+        dby_count=$(fm "$sfile" '.displaced_by // [] | length' 2>/dev/null || echo 0)
+
+        if [[ "$sstatus" == "DEPRECATED" && "$sstate" == "APPROVED" ]]; then
+            has_dby="no"
+            [[ "$dby_count" != "0" && "$dby_count" != "null" ]] && has_dby="yes"
+            echo "SPEC_GRADUATION|$sid|$sfile|$sstatus|$sstate|$has_dby" \
+                >> "$TMPDIR_SCAN/spec-graduation.txt"
+        fi
+    done < <(spec_manifest_ids "$MANIFEST")
+fi
+
+# ── Analysis 28: Spec corpus xref drift ──────────────────────────────────────
+# Per-spec spec-validate.sh emits warnings to stderr for unresolvable
+# decision_refs / kb_refs. At corpus scale these warnings are easy to miss
+# (jlsm 2026-05-10: 1 broken kb_ref hidden among 84 distinct refs across
+# 100 specs). Walk every APPROVED/DRAFT spec and aggregate the broken-ref
+# rows into one rollup the curate report surfaces directly.
+#
+# Output: SPEC_XREF|<id>|<ref-type>|<broken-ref>
+
+> "$TMPDIR_SCAN/spec-xref-drift.txt"
+if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
+    MANIFEST=".spec/registry/manifest.json"
+    while IFS= read -r sid; do
+        [[ -z "$sid" ]] && continue
+        sfile=$(spec_file_for_id "$MANIFEST" "$sid")
+        [[ -z "$sfile" || ! -f "$sfile" ]] && continue
+
+        # decision_refs → .decisions/<slug>/adr.md
+        while IFS= read -r dref; do
+            [[ -z "$dref" ]] && continue
+            if [[ ! -f ".decisions/$dref/adr.md" ]]; then
+                echo "SPEC_XREF|$sid|decision_ref|$dref" \
+                    >> "$TMPDIR_SCAN/spec-xref-drift.txt"
+            fi
+        done < <(fm "$sfile" '.decision_refs // [] | .[]' 2>/dev/null)
+
+        # kb_refs → .kb/<path>.md
+        while IFS= read -r kref; do
+            [[ -z "$kref" ]] && continue
+            if [[ ! -f ".kb/$kref.md" ]]; then
+                echo "SPEC_XREF|$sid|kb_ref|$kref" \
+                    >> "$TMPDIR_SCAN/spec-xref-drift.txt"
+            fi
+        done < <(fm "$sfile" '.kb_refs // [] | .[]' 2>/dev/null)
+    done < <(spec_manifest_ids "$MANIFEST")
+fi
+
 # ── Write summary file ──────────────────────────────────────────────────────
 
 SCAN_DATE="$(date +%Y-%m-%d)"
@@ -2730,6 +2798,47 @@ if [[ -s "$TMPDIR_SCAN/kb-citation-drift.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
+# Spec graduation candidates (Analysis 27)
+if [[ -s "$TMPDIR_SCAN/spec-graduation.txt" ]]; then
+    echo "## Spec Graduation Candidates (DEPRECATED but not INVALIDATED)" >> "$SUMMARY_FILE"
+    echo "Specs marked \`status: DEPRECATED\` while still \`state: APPROVED\`." >> "$SUMMARY_FILE"
+    echo "These continue to enter \`/spec-resolve\` bundles despite the author's" >> "$SUMMARY_FILE"
+    echo "intent to retire them. Two ways to resolve each row:" >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "- **Finalize displacement** — set \`state: INVALIDATED\` and populate" >> "$SUMMARY_FILE"
+    echo "  \`displaced_by\` + \`displacement_reason\`. Removes the spec from" >> "$SUMMARY_FILE"
+    echo "  resolved bundles and preserves it for historical inspection." >> "$SUMMARY_FILE"
+    echo "- **Retract status** — if the spec is still authoritative, change" >> "$SUMMARY_FILE"
+    echo "  \`status\` back to \`STABLE\` or \`ACTIVE\`. The DEPRECATED label was" >> "$SUMMARY_FILE"
+    echo "  premature." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Spec | Status | State | Has displaced_by? |" >> "$SUMMARY_FILE"
+    echo "|------|--------|-------|-------------------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ sid _ sstatus sstate has_dby; do
+        echo "| $sid | $sstatus | $sstate | $has_dby |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/spec-graduation.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
+# Spec corpus xref drift (Analysis 28)
+if [[ -s "$TMPDIR_SCAN/spec-xref-drift.txt" ]]; then
+    echo "## Spec Corpus Cross-Reference Drift" >> "$SUMMARY_FILE"
+    echo "Specs whose \`decision_refs\` or \`kb_refs\` no longer resolve to an" >> "$SUMMARY_FILE"
+    echo "ADR or KB entry on disk. \`spec-validate.sh\` emits these as per-spec" >> "$SUMMARY_FILE"
+    echo "stderr warnings; this rollup catches the corpus pattern (one broken" >> "$SUMMARY_FILE"
+    echo "ref hidden across many specs is otherwise easy to miss)." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "Per row: either fix the path (rename / restore the target), or remove" >> "$SUMMARY_FILE"
+    echo "the broken reference from the spec frontmatter." >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "| Spec | Ref Type | Broken Reference |" >> "$SUMMARY_FILE"
+    echo "|------|----------|------------------|" >> "$SUMMARY_FILE"
+    while IFS='|' read -r _ sid rtype bref; do
+        echo "| $sid | $rtype | $bref |" >> "$SUMMARY_FILE"
+    done < "$TMPDIR_SCAN/spec-xref-drift.txt"
+    echo "" >> "$SUMMARY_FILE"
+fi
+
 # Falsification lens staleness (Analysis 22)
 if [[ -s "$TMPDIR_SCAN/falsification-stale.txt" ]]; then
     echo "## Falsification Lens Staleness" >> "$SUMMARY_FILE"
@@ -2788,6 +2897,8 @@ echo "  KB filename collisions: $(wc -l < "$TMPDIR_SCAN/kb-collisions.txt" 2>/de
 echo "  KB schema drift: $(wc -l < "$TMPDIR_SCAN/kb-schema-drift.txt" 2>/dev/null || echo 0)"
 echo "  KB type/location mismatch: $(wc -l < "$TMPDIR_SCAN/kb-location-mismatch.txt" 2>/dev/null || echo 0)"
 echo "  KB citation drift in source: $(wc -l < "$TMPDIR_SCAN/kb-citation-drift.txt" 2>/dev/null || echo 0)"
+echo "  Spec graduation candidates: $(wc -l < "$TMPDIR_SCAN/spec-graduation.txt" 2>/dev/null || echo 0)"
+echo "  Spec xref drift: $(wc -l < "$TMPDIR_SCAN/spec-xref-drift.txt" 2>/dev/null || echo 0)"
 
 # ── Update curation state ─────────────────────────────────────────────────
 

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -29,6 +29,8 @@ couldn't see because they each had a narrower scope.
 17. KB schema drift — frontmatter that does not match `.kb/_refs/frontmatter.md` (missing/bad-enum fields, confidence overclaim, path/frontmatter mismatch)
 18. KB type/location mismatch — adversarial findings outside `patterns/<concern>/` or feature-footprints outside `architecture/feature-footprints/`
 19. KB citation drift in source — `// KB:` / `# KB:` citations in changed source files that point at missing entries or whose entry's `applies_to` doesn't include the source file (closes the loop with the `check-kb-ref.sh` PostToolUse hook)
+20. Spec graduation candidates — specs marked `status: DEPRECATED` that are still `state: APPROVED` (still entering `/spec-resolve` bundles despite the author's intent to retire them — finalize displacement or retract the status)
+21. Spec corpus xref drift — corpus rollup of unresolvable `decision_refs` / `kb_refs` across all specs (per-spec `spec-validate.sh` warnings are easy to miss at scale)
 
 **Flags:**
 - `--init` — first-time scan (ignores last-scanned SHA, good for new installs)
@@ -1470,6 +1472,8 @@ across runs. Use these conventions:
 | KB schema drift | `kb-schema:<path>:<issue-code>` |
 | KB type/location mismatch | `kb-location:<path>` |
 | KB citation drift | `kb-citation:<source-file>:<cited-entry>` |
+| Spec graduation candidate | `spec-graduation:<spec-id>` |
+| Spec xref drift | `spec-xref:<spec-id>:<ref-type>:<broken-ref>` |
 
 The append helper is duplicate-safe — re-appending an identical row is a
 no-op, so resuming a previous /curate session does not duplicate entries.

--- a/skills/spec-write/SKILL.md
+++ b/skills/spec-write/SKILL.md
@@ -13,6 +13,13 @@ a prerequisite stub.
 For authoring hardened specs with adversarial review, use `/spec-author`
 first, then `/spec-write` to register the output.
 
+**Canonical frontmatter schema:** `.spec/_refs/frontmatter.md` is the single
+authoritative reference for what fields a spec carries, what enums each
+field accepts, and how `state` and `status` differ. Read it once at the
+start of any spec authoring session — it is short and exhaustive.
+Validation (`spec-validate.sh`) and corpus drift detection (`/curate`
+analyses 20–21) reconcile against this schema; deviations surface there.
+
 ---
 
 ## Inputs expected in context

--- a/spec/_refs/frontmatter.md
+++ b/spec/_refs/frontmatter.md
@@ -1,0 +1,183 @@
+---
+type: reference-fragment
+title: Spec Frontmatter Schema (Canonical)
+---
+
+# Spec Frontmatter Schema (Canonical)
+
+Every spec under `.spec/domains/` opens with a JSON frontmatter block
+between `---` delimiters. This file is the single authoritative
+schema. The validator (`scripts/spec-validate.sh`) enforces it; the
+writer (`/spec-write`) emits files conforming to it; `/curate`
+analyses (notably the spec corpus drift checks) reconcile against it.
+
+If a `/curate` scan or a `spec-validate.sh` run flagged a schema
+deviation, the patch is to bring the spec into alignment with this
+file — not to extend the schema.
+
+## Why JSON, not YAML
+
+KB entries and ADRs use YAML frontmatter. Specs use JSON inside `---`
+fences. The reason is mechanical: spec frontmatter has structured
+arrays (`requires`, `invalidates`, `decision_refs`, `kb_refs`) and
+nullable fields (`amends`, `parent_spec`, `displaced_by`) that are
+read and written by `jq` from `spec-lib.sh`. JSON gives one parser,
+deterministic round-trip, and no quoting ambiguity for arrays of
+spec-id references that contain dots.
+
+Tooling that reads spec frontmatter MUST use `jq` (or the
+`fm` wrapper in `spec-lib.sh`), never grep-for-`^key:`. Patterns that
+work on KB/ADR YAML will silently miss every spec field.
+
+## Block format
+
+```
+---
+{
+  "id": "<spec-id>",
+  "version": <integer>,
+  "status": "<DRAFT|ACTIVE|STABLE|DEPRECATED>",
+  "state":  "<DRAFT|APPROVED|INVALIDATED>",
+  "domains": ["<domain1>", "<domain2>"],
+  "requires": [],
+  "invalidates": [],
+  "amends": null,
+  "amended_by": null,
+  "decision_refs": [],
+  "kb_refs": []
+}
+---
+```
+
+The closing `---` is followed by a third bare `---` line later in
+the file, marking the human narrative section. Three `---` lines
+total: open frontmatter, close frontmatter, open narrative.
+
+## Required core fields
+
+Every spec MUST have these. `spec-validate.sh` exits non-zero if any
+are missing or malformed.
+
+| Field | Type | Constraint |
+|-------|------|------------|
+| `id` | string | Either `FXX` (legacy) or lowercase `domain.slug[.subdomain...]` |
+| `version` | integer | Increments on each spec rewrite (`/spec-write` v2, v3, …) |
+| `status` | enum | `DRAFT` \| `ACTIVE` \| `STABLE` \| `DEPRECATED` |
+| `state`  | enum | `DRAFT` \| `APPROVED` \| `INVALIDATED` |
+| `domains` | array | Non-empty list of domain folder names |
+
+### `state` vs `status` — they are NOT the same field
+
+The two fields express different concepts. Both are required. Both
+are independently validated.
+
+- **`state`** — the spec's *lifecycle position* in the pipeline.
+  - `DRAFT` — being authored or has unresolved conflict markers.
+  - `APPROVED` — registered, passed validation, entered the
+    resolved-bundle pool.
+  - `INVALIDATED` — superseded by another spec via the displacement
+    chain (`displaced_by`). Excluded from `/spec-resolve` bundles by
+    default.
+- **`status`** — the spec's *implementation/consumption posture*.
+  - `DRAFT` — not yet pursued.
+  - `ACTIVE` — currently the source of truth for ongoing
+    implementation work.
+  - `STABLE` — implementation has settled; spec is reference material.
+  - `DEPRECATED` — author intent to retire, not yet displaced.
+    **`status: DEPRECATED` without a corresponding
+    `state: INVALIDATED` is a graduation candidate** —
+    `/curate` Analysis 27 flags this.
+
+**Common confusion:** marking a spec `DEPRECATED` does NOT remove it
+from `/spec-resolve` bundles. To take a spec out of resolution, set
+`state: INVALIDATED` (which requires a `displaced_by` reference). The
+`status` field is documentation only.
+
+## Optional fields
+
+```json
+{
+  "kind": "interface-contract",
+  "parent_spec": "<parent-id>",
+  "displaced_by": ["<successor-id>"],
+  "displacement_reason": "<free text>",
+  "revives": ["<predecessor-id>"],
+  "revived_by": ["<successor-id>"],
+  "_split_from": "<parent-id>",
+  "open_obligations": []
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `kind` | Currently only `interface-contract` (work-layer interface specs). Omit otherwise. |
+| `parent_spec` | Single parent ID when this spec is a `/spec-split` child. ID prefix MUST match parent + one segment. Acyclic. |
+| `displaced_by` | Specs that supersede this one. Setting non-empty REQUIRES `state: INVALIDATED`. Pipeline-managed, do NOT set by hand. |
+| `displacement_reason` | Free text; required when `displaced_by` is non-empty. |
+| `revives` | Specs whose intent this spec restores. Each target MUST be `state: INVALIDATED`. Pipeline-managed. |
+| `revived_by` | Inverse of `revives`. Pipeline-managed. |
+| `_split_from` | Set by `/spec-split` on the children. Informational. |
+| `open_obligations` | Array of obligation IDs blocking APPROVED state when present. |
+
+## Cross-references
+
+Three reference families resolve against external stores:
+
+- **`requires`** — spec IDs in `requires` MUST appear in
+  `manifest.json`. `spec-validate.sh` Check 6 enforces this.
+- **`decision_refs`** — ADR slugs. Resolution path:
+  `.decisions/<slug>/adr.md`. Missing files surface as warnings;
+  `/curate` Analysis 28 (corpus xref scan) flags broken refs at
+  scale.
+- **`kb_refs`** — KB entry paths (no `.md` extension). Resolution
+  path: `.kb/<path>.md`. Missing files surface as warnings; `/curate`
+  Analysis 28 flags broken refs at scale.
+
+Reference IDs use the same grammar as `id`:
+
+- Spec ID alone: `F01` OR `schema.field-access` OR
+  `encryption.primitives-lifecycle.key-rotation`.
+- Spec requirement ref (in `invalidates`): `F01.R3` OR
+  `schema.field-access.R3`. Letter-suffixed Rs (`R51a`) and
+  multi-dot IDs are supported.
+
+## ID grammar
+
+```
+spec_id_re='^(F[0-9]+|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)$'
+spec_ref_re='^(F[0-9]+|[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+)\.R[0-9]+[a-z]*(-[0-9]+[a-z]*)?$'
+```
+
+(Defined once in `spec-validate.sh`. Never re-implement these
+patterns elsewhere; source them or call `spec-validate.sh`.)
+
+## Validation
+
+Every write path through `/spec-write` calls `spec-validate.sh
+<file>`. The script exits non-zero on any error and prints all
+errors before exiting (no silent partial validation). Warnings are
+emitted to stderr and do not block the write — these include
+unresolvable `decision_refs` / `kb_refs`. Hard errors include
+malformed JSON, missing required fields, invalid enum values,
+unresolvable `requires` / `displaced_by` / `revives`, and
+`state: APPROVED` with `[UNRESOLVED]` or `[CONFLICT]` markers in the
+machine section.
+
+## What `/curate` adds on top
+
+Per-spec validation is necessary but not sufficient. Two `/curate`
+analyses look at the corpus:
+
+- **Analysis 27 — DEPRECATED-without-INVALIDATED**: surfaces specs
+  carrying `status: DEPRECATED` while still `state: APPROVED`,
+  meaning they continue to enter `/spec-resolve` bundles despite the
+  user's intent to retire them. Recommendation routes to displacement
+  finalization or to amending the status.
+- **Analysis 28 — corpus xref drift**: walks every spec's
+  `decision_refs` and `kb_refs`, reports broken paths in one rollup.
+  Catches the case where a single spec's `spec-validate.sh` warning
+  is easy to miss at scale (jlsm 2026-05-10: 1 broken kb_ref hidden
+  among 84 distinct refs).
+
+Run `/curate --init` (or `/curate` after a normal scan) to surface
+both.

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -1507,6 +1507,223 @@ fi
 rm -rf "$COV_DIR" 2>/dev/null || true
 cd "$REPO_ROOT"
 
+# ── Test 34: Spec graduation candidates (Analysis 27) ────────────────────────
+
+echo ""
+echo "── Test 34: Spec graduation candidates (DEPRECATED + APPROVED)"
+
+if command -v jq >/dev/null 2>&1; then
+    GRAD_DIR="$TEST_BASE/grad-project"
+    rm -rf "$GRAD_DIR"; mkdir -p "$GRAD_DIR"
+    cd "$GRAD_DIR"
+    git init --initial-branch=main . >/dev/null 2>&1
+    git config user.email t@t.com; git config user.name t
+    mkdir -p .claude/scripts
+    cp "$REPO_ROOT/scripts/curate-scan.sh" .claude/scripts/
+    cp "$REPO_ROOT/scripts/spec-lib.sh" .claude/scripts/
+    mkdir -p .spec/registry .spec/domains/storage
+
+    # Three specs: one DEPRECATED+APPROVED (the gap), one DEPRECATED+INVALIDATED
+    # (correctly graduated, should NOT surface), one ACTIVE+APPROVED (clean).
+    cat > .spec/registry/manifest.json <<'JSON'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "storage.v1-format", "path": ".spec/domains/storage/v1.md",
+      "state": "APPROVED", "version": 1, "domains": ["storage"], "requires": [],
+      "invalidates": [], "decision_refs": [], "kb_refs": [] },
+    { "id": "storage.v2-format", "path": ".spec/domains/storage/v2.md",
+      "state": "INVALIDATED", "version": 1, "domains": ["storage"], "requires": [],
+      "invalidates": [], "decision_refs": [], "kb_refs": [] },
+    { "id": "storage.v3-format", "path": ".spec/domains/storage/v3.md",
+      "state": "APPROVED", "version": 1, "domains": ["storage"], "requires": [],
+      "invalidates": [], "decision_refs": [], "kb_refs": [] }
+  ]
+}
+JSON
+    # storage.v1-format → DEPRECATED but still APPROVED — should surface.
+    cat > .spec/domains/storage/v1.md <<'SPEC'
+---
+{
+  "id": "storage.v1-format", "version": 1, "status": "DEPRECATED",
+  "state": "APPROVED", "domains": ["storage"], "requires": [],
+  "invalidates": [], "amends": null, "amended_by": null,
+  "decision_refs": [], "kb_refs": []
+}
+---
+
+# storage.v1-format
+
+## Requirements
+R1. Storage uses v1 binary layout.
+
+---
+
+## Design
+v1 format reference.
+SPEC
+    # storage.v2-format → DEPRECATED + INVALIDATED — already graduated,
+    # should NOT surface (Analysis 27 only flags the gap).
+    cat > .spec/domains/storage/v2.md <<'SPEC'
+---
+{
+  "id": "storage.v2-format", "version": 1, "status": "DEPRECATED",
+  "state": "INVALIDATED", "domains": ["storage"], "requires": [],
+  "invalidates": [], "displaced_by": ["storage.v3-format"],
+  "displacement_reason": "v3 supersedes",
+  "decision_refs": [], "kb_refs": []
+}
+---
+
+# storage.v2-format
+
+## Requirements
+R1. Storage uses v2 binary layout.
+
+---
+
+## Design
+v2 format reference (invalidated).
+SPEC
+    # storage.v3-format → ACTIVE + APPROVED — the clean current spec.
+    cat > .spec/domains/storage/v3.md <<'SPEC'
+---
+{
+  "id": "storage.v3-format", "version": 1, "status": "ACTIVE",
+  "state": "APPROVED", "domains": ["storage"], "requires": [],
+  "invalidates": [], "amends": null, "amended_by": null,
+  "decision_refs": [], "kb_refs": []
+}
+---
+
+# storage.v3-format
+
+## Requirements
+R1. Storage uses v3 binary layout.
+
+---
+
+## Design
+v3 format reference.
+SPEC
+    git add -A && git commit -q -m "init"
+
+    bash .claude/scripts/curate-scan.sh --init >/tmp/curate-grad.out 2>&1 || true
+
+    if grep -q "storage.v1-format" .curate/scan-summary.md 2>/dev/null \
+       && grep -A 20 "Spec Graduation Candidates" .curate/scan-summary.md \
+            | grep -q "storage.v1-format"; then
+        pass "storage.v1-format (DEPRECATED + APPROVED) surfaces in graduation candidates"
+    else
+        fail "storage.v1-format graduation candidate did not surface"
+    fi
+
+    if grep -A 20 "Spec Graduation Candidates" .curate/scan-summary.md 2>/dev/null \
+         | grep -q "storage.v2-format"; then
+        fail "storage.v2-format (already INVALIDATED) leaked into graduation candidates"
+    else
+        pass "already-INVALIDATED specs do not surface as graduation candidates"
+    fi
+
+    if grep -A 20 "Spec Graduation Candidates" .curate/scan-summary.md 2>/dev/null \
+         | grep -q "storage.v3-format"; then
+        fail "storage.v3-format (ACTIVE + APPROVED) leaked into graduation candidates"
+    else
+        pass "ACTIVE+APPROVED specs do not surface as graduation candidates"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+cd "$REPO_ROOT"
+
+# ── Test 35: Spec corpus xref drift (Analysis 28) ────────────────────────────
+
+echo ""
+echo "── Test 35: Spec corpus xref drift (broken kb_refs / decision_refs)"
+
+if command -v jq >/dev/null 2>&1; then
+    XREF_DIR="$TEST_BASE/xref-project"
+    rm -rf "$XREF_DIR"; mkdir -p "$XREF_DIR"
+    cd "$XREF_DIR"
+    git init --initial-branch=main . >/dev/null 2>&1
+    git config user.email t@t.com; git config user.name t
+    mkdir -p .claude/scripts
+    cp "$REPO_ROOT/scripts/curate-scan.sh" .claude/scripts/
+    cp "$REPO_ROOT/scripts/spec-lib.sh" .claude/scripts/
+    mkdir -p .spec/registry .spec/domains/api .decisions/real-decision .kb/topic/cat
+    echo "# real adr" > .decisions/real-decision/adr.md
+    echo "# real kb"  > .kb/topic/cat/real-entry.md
+
+    cat > .spec/registry/manifest.json <<'JSON'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "api.endpoint", "path": ".spec/domains/api/endpoint.md",
+      "state": "APPROVED", "version": 1, "domains": ["api"], "requires": [],
+      "invalidates": [], "decision_refs": ["real-decision","missing-decision"],
+      "kb_refs": ["topic/cat/real-entry","topic/cat/missing-entry"] }
+  ]
+}
+JSON
+    cat > .spec/domains/api/endpoint.md <<'SPEC'
+---
+{
+  "id": "api.endpoint", "version": 1, "status": "ACTIVE", "state": "APPROVED",
+  "domains": ["api"], "requires": [], "invalidates": [],
+  "amends": null, "amended_by": null,
+  "decision_refs": ["real-decision","missing-decision"],
+  "kb_refs": ["topic/cat/real-entry","topic/cat/missing-entry"]
+}
+---
+
+# api.endpoint
+
+## Requirements
+R1. The API exposes a versioned endpoint.
+
+---
+
+## Design
+Endpoint contract.
+SPEC
+    git add -A && git commit -q -m "init"
+
+    bash .claude/scripts/curate-scan.sh --init >/tmp/curate-xref.out 2>&1 || true
+
+    if grep -A 20 "Spec Corpus Cross-Reference Drift" .curate/scan-summary.md 2>/dev/null \
+        | grep -q "missing-decision"; then
+        pass "broken decision_ref surfaces in xref drift"
+    else
+        fail "broken decision_ref did not surface"
+    fi
+
+    if grep -A 20 "Spec Corpus Cross-Reference Drift" .curate/scan-summary.md 2>/dev/null \
+        | grep -q "topic/cat/missing-entry"; then
+        pass "broken kb_ref surfaces in xref drift"
+    else
+        fail "broken kb_ref did not surface"
+    fi
+
+    if grep -A 20 "Spec Corpus Cross-Reference Drift" .curate/scan-summary.md 2>/dev/null \
+        | grep -q "real-decision"; then
+        fail "real-decision (resolves) leaked into xref drift"
+    else
+        pass "resolving decision_ref does not appear in xref drift"
+    fi
+
+    if grep -A 20 "Spec Corpus Cross-Reference Drift" .curate/scan-summary.md 2>/dev/null \
+        | grep -q "topic/cat/real-entry"; then
+        fail "real kb_ref (resolves) leaked into xref drift"
+    else
+        pass "resolving kb_ref does not appear in xref drift"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+cd "$REPO_ROOT"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Two interlocking changes driven by an analysis pass on jlsm specs (2026-05-10, 100 specs / 13 domains):

- **`.spec/_refs/frontmatter.md`** — new canonical spec frontmatter schema doc, mirroring `.kb/_refs/frontmatter.md`. Single authoritative reference for the JSON-in-fences format, every required/optional field, ID grammar, cross-reference paths, and the `state` vs `status` distinction. Pre-existing kit guidance was scattered across `spec-write` SKILL Step 9, `spec-validate.sh` enforcement, and `spec-author`.
- **Two new `/curate` analyses** (Analyses 27 and 28) for corpus-scale spec drift:
  - **27 — Spec Graduation Candidates**: flags specs marked `status: DEPRECATED` that are still `state: APPROVED`. These continue entering `/spec-resolve` bundles despite author intent to retire them. Routes to displacement finalization or status retraction.
  - **28 — Spec Corpus Cross-Reference Drift**: aggregates broken `decision_refs` / `kb_refs` across all specs in one pass. Catches the case where a single broken ref hides among many — `spec-validate.sh` already emits per-spec stderr warnings, but at scale they're easy to miss.

## Why now

jlsm analysis surfaced concrete signals that drove each piece:
- Zero specs in `state: INVALIDATED` despite 100 approved specs and a year of evolution. Two specs marked `status: DEPRECATED` with no displacement chain — exactly the gap Analysis 27 is built to detect.
- 84 distinct `kb_refs` across the corpus, 1 broken (`distributed-systems/networking/transport-framing-patterns` referenced by `serialization.remote-serialization`). Per-spec validation would emit a stderr warning but the corpus rollup is what surfaces it as actionable.
- Multiple writers (spec-author, spec-write Step 9, spec-validate.sh) prescribe schema fragments without one canonical file. The `.kb/_refs/frontmatter.md` pattern was already established; specs deserved the same.

## Verification on jlsm

Scripts run against jlsm produce the expected output:
- Analysis 27 surfaces `sstable.format-v2` and `sstable.v3-format-upgrade`. The latter has `sstable.end-to-end-integrity` as a clear successor (already invalidates v3-format-upgrade requirements) — ready for displacement finalization.
- Analysis 28 surfaces the one broken kb_ref (`distributed-systems/networking/transport-framing-patterns`).

Companion jlsm-side cleanup scripts (not in this PR — delivered separately as one-shots) drive the actual repair.

## Test plan

- [x] `bash tests/scenario-curate-scan.sh` — 72/72 pass (7 new tests for the two analyses)
- [x] `bash tests/test-install.sh` — 74/74 pass
- [x] `bash tests/scenario-spec-validate.sh` — 8/8 pass
- [x] Fresh install verifies `.spec/_refs/frontmatter.md` lands at the right path
- [x] Manual run against jlsm surfaces the expected concrete cases (2 graduation candidates, 1 broken kb_ref)
- [x] Bash syntax check on `curate-scan.sh` and the new schema doc

## What is NOT in this PR

Deferred to follow-up (recorded in the analysis at `/tmp/vallorcine/jlsm-spec-analysis/`):

- F5 corpus annotation rollup — small enhancement to existing Analysis 18
- F6 ADRs without spec coverage — separate new analysis
- F2 orphan files in `.spec/domains/` — only 1 actual orphan (`/spec-verify` output dump); not pattern-worthy yet
- F7 frontmatter format unification (YAML vs JSON across layers) — design call, not detector work

🤖 Generated with [Claude Code](https://claude.com/claude-code)