### PR TITLE
feat(spec-backfill, dispatch): generic dispatch-marker + corpus-mode subagent dispatch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -138,6 +138,7 @@
 .claude/scripts/work-context.sh
 .claude/scripts/work-finalize.sh
 .claude/scripts/work-dispatch.sh
+.claude/scripts/dispatch-marker.sh
 .claude/scripts/work-index.sh
 .claude/scripts/check-kb-ref.sh
 .claude/scripts/kb-index.sh

--- a/install.sh
+++ b/install.sh
@@ -314,6 +314,7 @@ install_file "$SCRIPT_DIR/scripts/work-validate.sh" "$TARGET/.claude/scripts/wor
 install_file "$SCRIPT_DIR/scripts/work-context.sh" "$TARGET/.claude/scripts/work-context.sh"
 install_file "$SCRIPT_DIR/scripts/work-finalize.sh" "$TARGET/.claude/scripts/work-finalize.sh"
 install_file "$SCRIPT_DIR/scripts/work-dispatch.sh" "$TARGET/.claude/scripts/work-dispatch.sh"
+install_file "$SCRIPT_DIR/scripts/dispatch-marker.sh" "$TARGET/.claude/scripts/dispatch-marker.sh"
 install_file "$SCRIPT_DIR/scripts/work-index.sh" "$TARGET/.claude/scripts/work-index.sh"
 install_file "$SCRIPT_DIR/scripts/check-kb-ref.sh" "$TARGET/.claude/scripts/check-kb-ref.sh"
 install_file "$SCRIPT_DIR/scripts/kb-index.sh" "$TARGET/.claude/scripts/kb-index.sh"
@@ -351,6 +352,7 @@ chmod +x "$TARGET/.claude/scripts/work-validate.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-context.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-finalize.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-dispatch.sh" 2>/dev/null || true
+chmod +x "$TARGET/.claude/scripts/dispatch-marker.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/work-index.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/check-kb-ref.sh" 2>/dev/null || true
 chmod +x "$TARGET/.claude/scripts/kb-index.sh" 2>/dev/null || true
@@ -444,6 +446,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
       "Bash(bash .claude/scripts/work-dispatch.sh:*)",
+      "Bash(bash .claude/scripts/dispatch-marker.sh:*)",
       "Bash(bash .claude/scripts/work-index.sh:*)",
       "Bash(bash .claude/scripts/check-kb-ref.sh:*)",
       "Bash(bash .claude/scripts/kb-index.sh:*)",
@@ -596,6 +599,7 @@ HOOKJSON
       "Bash(bash .claude/scripts/work-context.sh:*)",
       "Bash(bash .claude/scripts/work-finalize.sh:*)",
       "Bash(bash .claude/scripts/work-dispatch.sh:*)",
+      "Bash(bash .claude/scripts/dispatch-marker.sh:*)",
       "Bash(bash .claude/scripts/work-index.sh:*)",
       "Bash(bash .claude/scripts/feature-state-reconcile.sh:*)"
         ] | unique)' "$SETTINGS_FILE" > "$SETTINGS_FILE.tmp" && mv "$SETTINGS_FILE.tmp" "$SETTINGS_FILE"
@@ -626,6 +630,7 @@ IGNORE_MARKER="# vallorcine runtime files"
 NEW_GITIGNORE_ENTRIES=(
     ".spec/.split-log/"
     ".spec/.split-plan.json"
+    ".spec/_backfill-dispatches/"
     ".work/*/_readiness.json"
     ".work/*/_decompose-progress.md"
     ".work/*/.work-resolve.lock"
@@ -646,6 +651,7 @@ if [[ "$DIFF_MODE" != "1" ]]; then
 .curate/
 .spec/.split-log/
 .spec/.split-plan.json
+.spec/_backfill-dispatches/
 .work/*/_readiness.json
 .work/*/_decompose-progress.md
 .work/*/.work-resolve.lock

--- a/scripts/dispatch-marker.sh
+++ b/scripts/dispatch-marker.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# dispatch-marker.sh — generic per-dispatch marker tracker.
+#
+# Background. Several vallorcine skills dispatch subagents via the Agent
+# tool to keep coordinator context bounded. The Agent call blocks until
+# the child emits its final assistant message, then the coordinator
+# parses that message into a structured return. Two failure modes break
+# that contract without touching downstream state:
+#
+#   1. Tool error: Agent returns "[Tool result missing due to internal
+#      error]". The payload is gone. The coordinator has no return-line
+#      to parse and no signal of whether the sub-agent ran, partially
+#      ran, or never started.
+#
+#   2. User stop: Agent returns "The user doesn't want to proceed with
+#      this tool use. ..." (e.g. user pressed ESC during the dispatch).
+#      Sub-agent never started.
+#
+# In both cases the coordinator's view sits in an undefined state and
+# recovery requires manual filesystem inspection.
+#
+# This is the generic counterpart to scripts/work-dispatch.sh — the
+# work-layer version operates inside `.work/<group>/` and is coupled
+# to the work-lib helpers. The generic version takes a marker root
+# directory as its first argument so any skill (`/curate`,
+# `/spec-backfill`, future skills) can drop markers into its own state
+# directory without duplicating this script.
+#
+# Schema (current: schema_version 1):
+#   {
+#     "schema_version": 1,
+#     "id": "<dispatch-id>",
+#     "dispatched_at": "2026-05-10T18:30:00Z",
+#     "ack": false,
+#     "result": null,
+#     "failure_reason": null,
+#     "acknowledged_at": null
+#   }
+#
+# Subcommands:
+#   begin   <root> <id>
+#   ack     <root> <id> <result-line>
+#   fail    <root> <id> <reason>
+#   status  <root> <id>          (exit 1 + no output if marker absent)
+#   stuck   <root>               (one line per unacked marker)
+#   clear   <root> <id>          (idempotent — exit 0 even if absent)
+#
+# <root> is the absolute or repo-relative directory that holds the
+# `_dispatch-<id>.json` files. The directory is created on `begin` if
+# missing. Caller is responsible for choosing a stable location
+# (.curate/_dispatches/, .spec/_backfill-dispatches/, etc.).
+#
+# Atomic writes: every write goes through .tmp.$$ + rename to prevent
+# torn reads when concurrent readers (e.g. recovery scans) read the
+# marker while a dispatcher writes it.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage:
+  dispatch-marker.sh begin   <root> <id>
+  dispatch-marker.sh ack     <root> <id> <result-line>
+  dispatch-marker.sh fail    <root> <id> <reason>
+  dispatch-marker.sh status  <root> <id>
+  dispatch-marker.sh stuck   <root>
+  dispatch-marker.sh clear   <root> <id>
+
+See the comment at the top of this file for details.
+EOF
+  exit 2
+}
+
+# Strip control bytes that would break JSON. Mirrors work-dispatch.sh
+# and work-resolve.sh — input strings may contain anything from a
+# subagent's final line, including stray bytes from log capture.
+json_escape() {
+  local s="$1"
+  s="${s//$'\x00'/}"
+  s="${s//$'\x01'/}"
+  s="${s//$'\x02'/}"
+  s="${s//$'\x03'/}"
+  s="${s//$'\x04'/}"
+  s="${s//$'\x05'/}"
+  s="${s//$'\x06'/}"
+  s="${s//$'\x07'/}"
+  s="${s//$'\x08'/}"
+  s="${s//$'\x0B'/}"
+  s="${s//$'\x0C'/}"
+  s="${s//$'\x0E'/}"
+  s="${s//$'\x0F'/}"
+  s="${s//$'\x10'/}"
+  s="${s//$'\x11'/}"
+  s="${s//$'\x12'/}"
+  s="${s//$'\x13'/}"
+  s="${s//$'\x14'/}"
+  s="${s//$'\x15'/}"
+  s="${s//$'\x16'/}"
+  s="${s//$'\x17'/}"
+  s="${s//$'\x18'/}"
+  s="${s//$'\x19'/}"
+  s="${s//$'\x1A'/}"
+  s="${s//$'\x1B'/}"
+  s="${s//$'\x1C'/}"
+  s="${s//$'\x1D'/}"
+  s="${s//$'\x1E'/}"
+  s="${s//$'\x1F'/}"
+  s="${s//\\/\\\\}"   # backslash first
+  s="${s//\"/\\\"}"   # double-quote
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+now_utc() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# Slugify an arbitrary id into a filesystem-safe filename token. Replaces
+# anything other than [A-Za-z0-9._-] with `_`. Long IDs (>120 chars) get
+# truncated; the original ID is preserved in-marker via the `id` field.
+slug_id() {
+  local raw="$1"
+  local slug
+  slug=$(printf '%s' "$raw" | tr -c 'A-Za-z0-9._-' '_')
+  if (( ${#slug} > 120 )); then
+    slug="${slug:0:120}"
+  fi
+  printf '%s' "$slug"
+}
+
+marker_path() {
+  local root="$1" id="$2"
+  printf '%s/_dispatch-%s.json' "$root" "$(slug_id "$id")"
+}
+
+ensure_root() {
+  local root="$1"
+  if [[ ! -d "$root" ]]; then
+    mkdir -p "$root" || {
+      echo "ERROR: cannot create marker root: $root" >&2
+      exit 2
+    }
+  fi
+}
+
+write_marker() {
+  local path="$1" content="$2"
+  local tmp="${path}.tmp.$$"
+  printf '%s' "$content" > "$tmp"
+  mv "$tmp" "$path"
+}
+
+read_field() {
+  local path="$1" field="$2"
+  [[ -f "$path" ]] || return 0
+  grep -oE "\"$field\":[[:space:]]*\"[^\"]*\"" "$path" 2>/dev/null \
+    | head -1 \
+    | sed -E "s/^\"$field\":[[:space:]]*\"([^\"]*)\"$/\1/" \
+    | head -1 || true
+}
+
+read_bool_field() {
+  local path="$1" field="$2"
+  [[ -f "$path" ]] || return 0
+  grep -oE "\"$field\":[[:space:]]*(true|false)" "$path" 2>/dev/null \
+    | head -1 \
+    | sed -E "s/^\"$field\":[[:space:]]*(true|false)$/\1/" \
+    | head -1 || true
+}
+
+cmd_begin() {
+  local root="$1" id="$2"
+  ensure_root "$root"
+  local marker now content
+  marker="$(marker_path "$root" "$id")"
+  now="$(now_utc)"
+  content=$(cat <<EOF
+{"schema_version":1,"id":"$(json_escape "$id")","dispatched_at":"$now","ack":false,"result":null,"failure_reason":null,"acknowledged_at":null}
+EOF
+)
+  write_marker "$marker" "$content"
+  echo "[dispatch] begin $id at $now"
+}
+
+cmd_ack() {
+  local root="$1" id="$2" result_line="${3:-}"
+  ensure_root "$root"
+  local marker now dispatched_at content
+  marker="$(marker_path "$root" "$id")"
+
+  if [[ ! -f "$marker" ]]; then
+    now="$(now_utc)"
+    dispatched_at="$now"
+  else
+    dispatched_at="$(read_field "$marker" "dispatched_at")"
+    [[ -z "$dispatched_at" ]] && dispatched_at="$(now_utc)"
+    now="$(now_utc)"
+  fi
+
+  content=$(cat <<EOF
+{"schema_version":1,"id":"$(json_escape "$id")","dispatched_at":"$dispatched_at","ack":true,"result":"$(json_escape "$result_line")","failure_reason":null,"acknowledged_at":"$now"}
+EOF
+)
+  write_marker "$marker" "$content"
+  echo "[dispatch] ack $id"
+}
+
+cmd_fail() {
+  local root="$1" id="$2" reason="${3:-unspecified}"
+  ensure_root "$root"
+  local marker now dispatched_at content
+  marker="$(marker_path "$root" "$id")"
+
+  if [[ ! -f "$marker" ]]; then
+    dispatched_at="$(now_utc)"
+    now="$dispatched_at"
+  else
+    dispatched_at="$(read_field "$marker" "dispatched_at")"
+    [[ -z "$dispatched_at" ]] && dispatched_at="$(now_utc)"
+    now="$(now_utc)"
+  fi
+
+  content=$(cat <<EOF
+{"schema_version":1,"id":"$(json_escape "$id")","dispatched_at":"$dispatched_at","ack":true,"result":null,"failure_reason":"$(json_escape "$reason")","acknowledged_at":"$now"}
+EOF
+)
+  write_marker "$marker" "$content"
+  echo "[dispatch] fail $id ($reason)"
+}
+
+cmd_status() {
+  local root="$1" id="$2"
+  local marker
+  marker="$(marker_path "$root" "$id")"
+  if [[ ! -f "$marker" ]]; then
+    exit 1
+  fi
+  cat "$marker"
+}
+
+cmd_stuck() {
+  local root="$1"
+  [[ -d "$root" ]] || return 0
+
+  shopt -s nullglob
+  local marker
+  for marker in "$root"/_dispatch-*.json; do
+    local ack id dispatched_at result failure has_result
+    ack="$(read_bool_field "$marker" "ack")"
+    if [[ "$ack" != "true" ]]; then
+      id="$(read_field "$marker" "id")"
+      dispatched_at="$(read_field "$marker" "dispatched_at")"
+      result="$(read_field "$marker" "result")"
+      failure="$(read_field "$marker" "failure_reason")"
+      if [[ -n "$result" ]]; then
+        has_result="true"
+      else
+        has_result="false"
+      fi
+      printf '%s|%s|%s|%s\n' "$id" "$dispatched_at" "$has_result" "$failure"
+    fi
+  done
+  shopt -u nullglob
+}
+
+cmd_clear() {
+  local root="$1" id="$2"
+  local marker
+  marker="$(marker_path "$root" "$id")"
+  if [[ -f "$marker" ]]; then
+    rm -f "$marker"
+    echo "[dispatch] cleared $id"
+  fi
+  exit 0
+}
+
+[[ $# -ge 1 ]] || usage
+
+case "$1" in
+  begin)
+    [[ $# -eq 3 ]] || usage
+    cmd_begin "$2" "$3" ;;
+  ack)
+    [[ $# -ge 3 ]] || usage
+    cmd_ack "$2" "$3" "${4:-}" ;;
+  fail)
+    [[ $# -ge 3 ]] || usage
+    cmd_fail "$2" "$3" "${4:-unspecified}" ;;
+  status)
+    [[ $# -eq 3 ]] || usage
+    cmd_status "$2" "$3" ;;
+  stuck)
+    [[ $# -eq 2 ]] || usage
+    cmd_stuck "$2" ;;
+  clear)
+    [[ $# -eq 3 ]] || usage
+    cmd_clear "$2" "$3" ;;
+  -h|--help|help)
+    usage ;;
+  *)
+    echo "ERROR: unknown subcommand: $1" >&2
+    usage ;;
+esac

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -211,9 +211,53 @@ If `skipped` count > 0, tell the user how to resume:
 ## Corpus mode (`--all`)
 
 When invoked with `--all`, iterate every APPROVED spec in the manifest
-and run the per-spec walk against each. Pre-flight runs once; the
-backfill log is the same `.spec/backfill-log.md` so progress and prior
-decisions persist across the whole corpus.
+and run the per-spec walk against each via the **subagent dispatch
+pattern** — each spec is processed by a dedicated sub-agent that owns
+all file reads, the candidate-finding subprocess, and edit application.
+The coordinator (this skill, in the user's conversation) only holds
+per-spec one-line summaries, keeping its context bounded as the corpus
+grows. Pre-flight runs once; the backfill log is the same
+`.spec/backfill-log.md` so progress and prior decisions persist across
+the whole corpus.
+
+### Why dispatch instead of inline iteration
+
+Inline iteration accumulates context linearly: spec 1's candidates +
+requirement text + edit application stay in the coordinator's window
+while spec 2 begins, and so on. By spec 12 a coordinator running
+inline holds 12 × (5–30 KB) of read state. Dispatching each spec as a
+sub-agent gives that spec a fresh context window; the coordinator
+absorbs only the return summary (~80 bytes per spec). 12 specs ≈ 1 KB
+of accumulated summaries — bounded forever.
+
+The dispatch boundary lines up with per-spec independence: backfill
+decisions for spec A do not affect spec B's candidate scoring or
+requirement text. Cross-spec resumption is already handled by the
+append-only `backfill-log.md` — already-decided (spec, R-id) pairs
+auto-skip on subsequent runs regardless of which run made the decision.
+
+### C0. Pre-flight: surface stuck dispatches from prior runs
+
+Before enumerating, check for unacknowledged dispatch markers under
+`.spec/_backfill-dispatches/`:
+
+```bash
+bash .claude/scripts/dispatch-marker.sh stuck .spec/_backfill-dispatches
+```
+
+If output is non-empty, surface each stuck spec to the user via
+AskUserQuestion BEFORE starting the corpus walk:
+
+- **"Re-dispatch <spec-id>"** — clear the marker and include the spec
+  in the run.
+- **"Skip <spec-id> for now"** — leave the marker; spec will be
+  surfaced again next run.
+- **"Investigate manually"** — print the marker contents
+  (`dispatch-marker.sh status …`) and stop the run.
+
+This mirrors `/work-resume rule 0` (PR #79) — any unacknowledged marker
+pre-empts the normal flow because it represents a previous run whose
+result the coordinator never saw.
 
 ### C1. Discover the candidate set
 
@@ -235,59 +279,133 @@ dual-schema pattern `spec-lib.sh` uses.
 
 For each ID, run `bash .claude/scripts/spec-trace.sh --uncovered <id>`
 and capture only the count of uncovered R-ids. Skip specs that return
-zero uncovered (already fully annotated).
+zero uncovered (already fully annotated). The pre-flight scan is the
+ONLY place the coordinator reads spec-trace output for the corpus —
+per-spec depth lives inside each dispatched sub-agent.
 
 Tell the user the corpus picture in one paragraph:
 
 ```
 Corpus has <N> APPROVED specs. <K> already fully annotated — skipping.
 <M> have at least one uncovered requirement, totalling <U> uncovered
-R-ids across the corpus. Walking specs in manifest order; you can
-break out at any time and rerun /spec-backfill --all to resume.
+R-ids across the corpus. Dispatching one sub-agent per spec to keep
+this conversation's context bounded. Break out at any time and rerun
+/spec-backfill --all to resume.
 ```
 
-### C2. Per-spec walk
+Use AskUserQuestion to confirm before starting if `<U>` exceeds 50:
+- **"Run all"** (Recommended)
+- **"Cap at 10 specs"** (or another cap)
+- **"Cancel"**
 
-For each spec with uncovered R-ids, run **Phase 1 → Phase 2 → Phase 3**
-verbatim from the per-spec mode above. Between specs, surface a brief
-transition line so the user knows where they are:
+### C2. Per-spec dispatch loop
+
+For each spec with uncovered R-ids, in manifest order, run this loop
+until the dispatched count reaches the cap (if set) or the eligible
+set is empty:
+
+**C2a. Write the dispatch marker.**
+
+```bash
+bash .claude/scripts/dispatch-marker.sh begin .spec/_backfill-dispatches <spec-id>
+```
+
+This creates `.spec/_backfill-dispatches/_dispatch-<spec-id>.json` with
+`ack: false`. The marker is gitignored. Flipped to `ack: true` once the
+sub-agent returns and the coordinator parses its result.
+
+**C2b. Dispatch the sub-agent.** Invoke the Agent tool with this prompt
+verbatim (substitute `<spec-id>`):
 
 ```
-─────────────────────────────────────────
-Spec 4 of 12 — auth.token-validation
-6 uncovered, 2 already decided in log
-─────────────────────────────────────────
+You are the per-spec backfill runner for <spec-id>.
+
+Invoke /spec-backfill <spec-id>. The single-spec flow handles Phase 1
+(discover uncovered R-ids), Phase 2 (per-R-id candidate walk with user
+decisions), and Phase 3 (re-trace + summarize). AskUserQuestion in
+Phase 2 surfaces to the actual user — you do not auto-answer it. The
+user IS available across the dispatch boundary; do not assume
+autonomy.
+
+When the per-spec flow completes, return EXACTLY ONE LINE on stdout
+matching this shape:
+
+  COMPLETE <spec-id> annotated=<N> skipped=<K> waived=<W> uncovered_after=<U>
+
+If the user breaks out mid-walk (any non-resume exit), return:
+
+  STOPPED <spec-id> annotated=<N> skipped=<K> waived=<W> remaining=<R>
+
+If the spec turns out to have zero uncovered R-ids after the log query
+(prior runs covered everything), return:
+
+  EMPTY <spec-id>
+
+Any other return is treated as a parse failure.
 ```
+
+**C2c. Wait for the return.** The Agent tool blocks until the sub-agent
+emits its final assistant message.
+
+**C2d. Classify and ack.** Parse the return into one of four shapes:
+
+- **COMPLETE** / **STOPPED** / **EMPTY** — ack the marker with the
+  exact return line:
+  ```bash
+  bash .claude/scripts/dispatch-marker.sh ack .spec/_backfill-dispatches <spec-id> "<return-line>"
+  ```
+  Print a one-line summary to the user: `<spec-id> — <return-line>`.
+  Continue to next spec.
+
+- **Payload lost** — Agent return literally equals
+  `[Tool result missing due to internal error]`. Mark the marker as
+  failed:
+  ```bash
+  bash .claude/scripts/dispatch-marker.sh fail .spec/_backfill-dispatches <spec-id> "payload-lost"
+  ```
+  Surface via AskUserQuestion: "Pause for investigation" /
+  "Re-dispatch <spec-id>" / "Skip and continue".
+
+- **User stopped** — Agent return contains
+  `The user doesn't want to proceed with this tool use`. Mark as
+  failed with reason `user-stopped`. Surface AskUserQuestion:
+  "Re-dispatch <spec-id>" / "Continue with next spec" / "Stop the run".
+
+- **Parse failed** — return present but does not match any expected
+  shape. Mark as failed with reason `parse-failed: <first-80-chars>`.
+  Print the raw return to the user and offer the same recovery options
+  as user-stopped.
+
+**C2e. Honor the cap.** If a cap was set in C1 and the dispatched
+count has reached it, exit the loop after acking the current spec.
 
 ### C3. Corpus summary
 
-After the last spec, emit a final aggregate report:
+After the loop exits, emit a final aggregate report:
 
-- Total specs walked / skipped (already covered) / partially covered after run
-- Total annotations applied this session
+- Total specs dispatched / completed / stopped / empty / failed
+- Total annotations applied this session (sum from return lines)
 - Total R-ids skipped (will resurface) / waived
+- Any remaining stuck markers (re-run pre-flight count)
 - Pointer to `.spec/backfill-log.md` for the canonical record
 
-If any spec still has skipped or undecided R-ids, tell the user how to
-resume:
+If any spec returned STOPPED or any marker is still failed, tell the
+user how to resume:
 
 ```
-<X> requirement(s) across <Y> spec(s) were skipped this run. Rerun
-/spec-backfill --all to resume — already-decided R-ids will be skipped
-automatically.
+<X> spec(s) left work undone this run. Rerun /spec-backfill --all
+to resume — already-decided R-ids will be skipped automatically, and
+the pre-flight will offer to re-dispatch any stuck markers.
 ```
 
 ### C4. Cost awareness
 
-Whole-corpus runs can be long. Surface a one-line cost note before
-starting if the corpus has > 50 uncovered R-ids in total:
-
-```
-Heads up: <U> uncovered R-ids across the corpus. Each requires at
-least one decision (annotate / skip / waive). Plan to break this
-into multiple sessions if needed — progress persists in
-.spec/backfill-log.md.
-```
+Even with dispatch, whole-corpus runs are still long because each
+sub-agent does real work — the win is coordinator context economy,
+not wall-clock. The C1 confirmation step surfaces the cost note when
+the uncovered count exceeds 50, but a corpus with 50+ specs may still
+benefit from a `Cap at 10` first pass to validate the dispatch is
+behaving as expected.
 
 ---
 

--- a/tests/scenario-dispatch-marker.sh
+++ b/tests/scenario-dispatch-marker.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Scenario: generic dispatch-marker.sh primitive
+#
+# Validates the dispatch marker contract reused by /spec-backfill --all
+# (and future /curate dispatch). The script is a generic counterpart to
+# work-dispatch.sh — same begin / ack / fail / status / stuck / clear
+# subcommands, but with a marker root passed in as the first argument so
+# any skill can drop markers into its own state directory.
+#
+# Run from repo root: bash tests/scenario-dispatch-marker.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-dispatch-marker"
+DM="$REPO_ROOT/scripts/dispatch-marker.sh"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+cleanup() { rm -rf "$TEST_BASE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+cleanup
+mkdir -p "$TEST_BASE"
+ROOT="$TEST_BASE/markers"
+
+echo ""
+echo "scenario: dispatch-marker.sh"
+echo "────────────────────────────────────────────────"
+
+# ── Test 1: begin creates a marker with ack=false ────────────────────────────
+
+echo ""
+echo "── Test 1: begin writes a fresh marker"
+
+bash "$DM" begin "$ROOT" "spec-A" >/dev/null
+marker="$ROOT/_dispatch-spec-A.json"
+if [[ -f "$marker" ]]; then
+    pass "marker file written at expected path"
+else
+    fail "marker not written"
+fi
+
+if grep -q '"ack":false' "$marker"; then
+    pass "fresh marker has ack=false"
+else
+    fail "fresh marker missing ack=false"
+fi
+
+if grep -q '"id":"spec-A"' "$marker"; then
+    pass "marker carries the id field"
+else
+    fail "marker missing id field"
+fi
+
+# ── Test 2: stuck reports unacked markers ────────────────────────────────────
+
+echo ""
+echo "── Test 2: stuck lists unacked markers, exits 0 with content"
+
+out="$(bash "$DM" stuck "$ROOT")"
+if [[ -n "$out" ]] && echo "$out" | grep -q "^spec-A|"; then
+    pass "stuck shows the unacked spec-A row"
+else
+    fail "stuck did not surface spec-A" "got: $out"
+fi
+
+# ── Test 3: ack flips the marker + removes it from stuck ─────────────────────
+
+echo ""
+echo "── Test 3: ack updates marker and clears it from stuck list"
+
+bash "$DM" ack "$ROOT" "spec-A" "COMPLETE spec-A annotated=3 skipped=0 waived=0 uncovered_after=0" >/dev/null
+
+if grep -q '"ack":true' "$marker"; then
+    pass "ack flipped marker to ack=true"
+else
+    fail "ack did not update ack flag"
+fi
+
+if grep -q 'annotated=3' "$marker"; then
+    pass "ack preserved the result line in marker"
+else
+    fail "ack did not preserve result line"
+fi
+
+stuck_out="$(bash "$DM" stuck "$ROOT" || true)"
+if [[ -z "$stuck_out" ]]; then
+    pass "acked marker no longer appears in stuck"
+else
+    fail "acked marker still in stuck list" "got: $stuck_out"
+fi
+
+# ── Test 4: fail records failure_reason, still ack=true ──────────────────────
+
+echo ""
+echo "── Test 4: fail acks marker with failure_reason"
+
+bash "$DM" begin "$ROOT" "spec-B" >/dev/null
+bash "$DM" fail "$ROOT" "spec-B" "payload-lost" >/dev/null
+
+marker_b="$ROOT/_dispatch-spec-B.json"
+if grep -q '"ack":true' "$marker_b" && grep -q '"failure_reason":"payload-lost"' "$marker_b"; then
+    pass "fail sets ack=true + records failure_reason"
+else
+    fail "fail did not set ack/failure_reason correctly"
+fi
+
+if ! bash "$DM" stuck "$ROOT" 2>/dev/null | grep -q "spec-B"; then
+    pass "failed marker stays out of stuck list (ack flipped)"
+else
+    fail "failed marker incorrectly appears in stuck"
+fi
+
+# ── Test 5: clear removes the marker, idempotent ─────────────────────────────
+
+echo ""
+echo "── Test 5: clear removes marker, idempotent on repeat"
+
+bash "$DM" clear "$ROOT" "spec-A" >/dev/null
+if [[ ! -f "$marker" ]]; then
+    pass "clear removes the marker file"
+else
+    fail "clear did not remove marker"
+fi
+
+if bash "$DM" clear "$ROOT" "spec-A" >/dev/null 2>&1; then
+    pass "clear is idempotent on already-cleared id"
+else
+    fail "clear failed on already-cleared id"
+fi
+
+# ── Test 6: status returns marker JSON, exits 1 when absent ──────────────────
+
+echo ""
+echo "── Test 6: status emits JSON for present marker, exits 1 if absent"
+
+if bash "$DM" status "$ROOT" "spec-B" 2>/dev/null | grep -q '"schema_version":1'; then
+    pass "status prints marker JSON for present id"
+else
+    fail "status did not print JSON for spec-B"
+fi
+
+if ! bash "$DM" status "$ROOT" "nonexistent-id" >/dev/null 2>&1; then
+    pass "status exits non-zero for absent marker"
+else
+    fail "status did not exit non-zero for absent marker"
+fi
+
+# ── Test 7: id slugification keeps dots/hyphens, replaces unsafe chars ───────
+
+echo ""
+echo "── Test 7: id with dots/hyphens preserved, unsafe chars slugified"
+
+bash "$DM" begin "$ROOT" "engine.handle-lifecycle.state-machine" >/dev/null
+if [[ -f "$ROOT/_dispatch-engine.handle-lifecycle.state-machine.json" ]]; then
+    pass "dotted/hyphenated id preserved in marker filename"
+else
+    fail "dotted id was not preserved in filename"
+fi
+
+# id with slash should be slugified to underscore (slash would create
+# subdirectory, breaking the marker layout)
+bash "$DM" begin "$ROOT" "topic/category/subject" >/dev/null
+if [[ -f "$ROOT/_dispatch-topic_category_subject.json" ]]; then
+    pass "slashes in id slugified to underscores"
+else
+    fail "slash id was not slugified correctly"
+fi
+
+# ── Test 8: marker root auto-created if absent ───────────────────────────────
+
+echo ""
+echo "── Test 8: begin creates the marker root directory if missing"
+
+DEEP_ROOT="$TEST_BASE/deeply/nested/markers"
+bash "$DM" begin "$DEEP_ROOT" "spec-C" >/dev/null
+if [[ -f "$DEEP_ROOT/_dispatch-spec-C.json" ]]; then
+    pass "begin auto-creates deep marker root"
+else
+    fail "begin did not create marker root"
+fi
+
+# ── Test 9: stuck returns empty (exit 0) for an empty marker root ────────────
+
+echo ""
+echo "── Test 9: stuck handles empty marker root gracefully"
+
+EMPTY_ROOT="$TEST_BASE/empty"
+mkdir -p "$EMPTY_ROOT"
+out="$(bash "$DM" stuck "$EMPTY_ROOT" 2>&1)"
+if [[ -z "$out" ]]; then
+    pass "stuck returns empty for an empty root"
+else
+    fail "stuck emitted output for empty root: $out"
+fi
+
+# Nonexistent root: still exits 0 with no output (the script's
+# `[[ -d "$root" ]] || return 0` guard).
+out="$(bash "$DM" stuck "$TEST_BASE/never-existed" 2>&1)"
+if [[ -z "$out" ]]; then
+    pass "stuck returns empty for nonexistent root"
+else
+    fail "stuck emitted output for missing root: $out"
+fi
+
+# ── Test 10: JSON escaping handles control chars + quotes safely ─────────────
+
+echo ""
+echo "── Test 10: ack with quotes + control bytes produces valid JSON"
+
+bash "$DM" begin "$ROOT" "spec-X" >/dev/null
+# Result line containing quotes, newline, and tab
+bash "$DM" ack "$ROOT" "spec-X" $'COMPLETE spec-X "quoted"\nnewline\ttab' >/dev/null
+
+marker_x="$ROOT/_dispatch-spec-X.json"
+if command -v jq >/dev/null 2>&1; then
+    if jq -e . "$marker_x" >/dev/null 2>&1; then
+        pass "marker with quoted+newline result is valid JSON"
+    else
+        fail "marker JSON did not parse via jq"
+    fi
+    # The escaped result should round-trip back through jq
+    val="$(jq -r '.result' "$marker_x")"
+    if [[ "$val" == $'COMPLETE spec-X "quoted"\nnewline\ttab' ]]; then
+        pass "round-trip preserves quotes/newline/tab in result"
+    else
+        fail "round-trip mangled result" "got: $val"
+    fi
+else
+    echo "  SKIP  jq not available for round-trip check"
+fi
+
+# ── Test 11: status uses slugified path for lookup (consistency) ─────────────
+
+echo ""
+echo "── Test 11: status lookup uses same slug as begin"
+
+# Same slash-containing id from Test 7 should resolve via status
+if bash "$DM" status "$ROOT" "topic/category/subject" 2>/dev/null | grep -q '"id":"topic/category/subject"'; then
+    pass "status resolves slugified id and preserves original id in JSON"
+else
+    fail "status could not resolve slugified id"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+if [[ $failed -eq 0 ]]; then
+    echo "ALL PASSED  ($passed/$total)"
+else
+    echo "FAILED  $failed/$total  ($passed passed)"
+fi
+echo ""
+
+exit $failed


### PR DESCRIPTION
## Summary

Generalizes the work-layer dispatch pattern (PR #76 / v0.16.8) into a primitive any skill can reuse, and applies it to `/spec-backfill --all` so corpus-mode runs no longer accumulate per-spec context in the coordinator.

- **NEW `scripts/dispatch-marker.sh`** — generic counterpart to `scripts/work-dispatch.sh`. Same shape (begin / ack / fail / status / stuck / clear), but with marker root passed as the first argument so any state directory works.
- **`/spec-backfill --all` refactored** to a per-spec dispatch loop mirroring `/work-start all`. Coordinator absorbs only ~80-byte one-line summaries per spec; per-spec internals (5–30 KB of candidates + requirement text + edit state) live entirely in each sub-agent's fresh context window.

## Why

After PRs #83 + #84 shipped four new corpus-scale spec/ADR analyses, the natural next concern is whether the commands that walk these analyses scale to long sessions. The investigation (full report at `/tmp/vallorcine/curate-backfill-dispatch-design.md`) found that `/spec-backfill --all` is a textbook case for the work-layer dispatch pattern: per-spec independence, append-only log already handles resumption, AskUserQuestion still surfaces from inside the sub-agent.

## Coordinator context footprint

12-spec corpus, per-spec coordinator load:
- **Today (inline)**: 5–30 KB candidates + requirement text + edit state, retained across iterations → ~360 KB by spec 12
- **This PR (dispatch)**: ~80 byte return summary → ~1 KB by spec 12

## What's NOT in this PR

`/curate` Step 4 adoption deferred to a follow-up PR. The dispatch primitive built here is the foundation; the /curate refactor requires per-finding-type SKILL surgery across ~30 finding types in Step 4's 500-line block, which is enough surface area to deserve its own focused PR. Plan documented in the design doc.

## Adversarial pass

Ten failure modes documented in the design doc + commit message; all covered or explicitly punted with clear rationale. Highlights:
- Malformed sub-agent return → marker.fail(parse-failed) + AskUserQuestion recovery
- User abandon → append-only backfill-log auto-resumes (already true today)
- Stuck markers from prior runs → C0 pre-flight surfaces via AskUserQuestion (mirrors `/work-resume rule 0`)
- Slash-in-id → slugified to underscore in filename, original preserved in marker JSON for round-trip

## Test plan

- [x] `bash tests/scenario-dispatch-marker.sh` — 21/21 (NEW; covers every subcommand + 10 edge cases)
- [x] `bash tests/test-install.sh` — 74/74 (script installed, permission rule added, MANIFEST updated, gitignore extended)
- [x] `bash tests/scenario-curate-scan.sh` — 78/78 (unchanged, no regression)
- [x] Manual smoke test: begin → stuck (shows row) → ack (clears stuck) → status (returns JSON) → clear (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)