### PR TITLE
feat(curate, spec-backfill): two-phase subagent dispatch + curate adoption

### DIFF
--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -118,6 +118,29 @@ PRIOR_UNRESOLVED=$(bash .claude/scripts/curate-review-log.sh unresolved \
 records. Empty when this is the first run or every prior finding was
 resolved/dismissed.
 
+**Stuck-marker recovery.** Scan `.curate/_dispatches/` for any
+unacknowledged finding-resolution markers from a previous `/curate`
+run that crashed mid-dispatch:
+
+```bash
+STUCK_MARKERS=$(bash .claude/scripts/dispatch-marker.sh stuck \
+  .curate/_dispatches 2>/dev/null || true)
+```
+
+Each row is `<finding-key>|<dispatched-at>|<has-result>|<failure-reason>`.
+
+If non-empty, surface BEFORE Step 1 (the scan run): for each stuck
+marker, use AskUserQuestion with three options —
+**"Re-dispatch"** (clear marker, include in this run),
+**"Skip for now"** (leave marker; next run will resurface it),
+**"Investigate manually"** (print marker JSON via
+`dispatch-marker.sh status .curate/_dispatches <finding-key>` and
+stop the `/curate` run).
+
+This mirrors `/work-resume rule 0` (PR #79) and `/spec-backfill` C0 —
+any unacknowledged marker pre-empts the normal flow because it
+represents a previous dispatch whose result was never reconciled.
+
 Display opening header:
 ```
 ───────────────────────────────────────────────
@@ -995,9 +1018,203 @@ Present numbered list → user picks → execute action → mark resolved →
 re-present remaining items → user picks again → ... → user says "done" → close
 ```
 
-### User picks a number
+### Step 4 dispatch protocol (context-economy on long sessions)
 
-Execute the action for that item:
+When a `/curate` run surfaces 20+ findings, resolving each finding
+inline accumulates file-read context in the coordinator linearly with
+the finding count. For a 30-finding session that resolves a mix of
+ADR/KB/spec findings, the coordinator can carry 200–300 KB of read
+state by the end. The dispatch protocol below isolates that
+read-cost in per-finding sub-agents and keeps the coordinator's
+context bounded.
+
+**Pattern: two-phase dispatch per finding.** Dispatched sub-agents
+follow the codebase convention (`/work-start all`, `/feature-coordinate`)
+of running autonomously — they do NOT call AskUserQuestion mid-flow.
+User interaction happens in the coordinator between the two phases.
+
+**When to use dispatch:** findings whose resolution involves reading
+artifact files (ADR, KB entries, spec frontmatter, source files).
+The list is recorded in the **Dispatchable types** table below. When
+the user picks a finding NOT in that table (index rebuild, log
+appends, trivial bookkeeping), handle inline as today.
+
+**Dispatchable types** (heavy file reads in resolution):
+
+| Type | Why it qualifies |
+|------|------------------|
+| ADR pressure / gravity / drift | Reads full ADR file + constrained file list |
+| KB stale | Reads KB entry full text + related entries |
+| Spec coverage / spec-code drift | Reads spec frontmatter + manifest + source matches |
+| Spec annotation drift (Analysis 18b drift bucket) | Reads spec file + spec-trace output |
+| Spec graduation candidate (Analysis 27) | Reads spec frontmatter + invalidates-references |
+| Spec corpus xref drift (Analysis 28) | Reads spec frontmatter + ADR/KB resolution |
+| ADRs without spec (Analysis 29) | Reads full ADR file to scope the spec to author |
+| KB schema drift / type-location mismatch | Reads KB entry frontmatter + body |
+| Subdivision candidate | Reads full spec body to assess split |
+
+**Pre-flight: stuck-marker recovery.** Before re-entering the pick
+list after a prior `/curate` run, check
+`.curate/_dispatches/` for unacknowledged markers:
+
+```bash
+bash .claude/scripts/dispatch-marker.sh stuck .curate/_dispatches
+```
+
+If non-empty, surface each one via AskUserQuestion:
+- **"Re-dispatch <finding-key>"** — clear the marker, include the
+  finding in this run.
+- **"Skip <finding-key>"** — leave marker in place; it will resurface
+  next run.
+- **"Investigate manually"** — print the marker JSON via
+  `dispatch-marker.sh status` and stop.
+
+This mirrors `/work-resume rule 0` and `/spec-backfill` C0.
+
+**Phase A — diagnose + propose** (autonomous sub-agent):
+
+```bash
+bash .claude/scripts/dispatch-marker.sh begin .curate/_dispatches <finding-key>--propose
+```
+
+Agent prompt verbatim (substitute `<finding-key>`, `<finding-type>`,
+`<scan-summary-excerpt>` — copy the 1–3 rows from
+`.curate/scan-summary.md` that describe this finding):
+
+```
+You are the diagnose + propose stage for /curate finding
+<finding-key> of type <finding-type>.
+
+Scan summary excerpt:
+<scan-summary-excerpt>
+
+Read whatever artifacts the resolution playbook for this finding type
+requires (see `.claude/skills/curate/SKILL.md` Step 4 subsections —
+look up the row whose label matches `<finding-type>` and follow its
+"Read the X file" / "compare against Y" instructions for the read
+portion ONLY). Build a structured proposal.
+
+Return EXACTLY ONE LINE — a JSON object — matching this shape:
+
+{"finding_key":"<finding-key>","finding_type":"<type>",
+ "diagnosis":"<2–3 sentence summary of what you found>",
+ "options":[
+   {"label":"<≤4 words>","description":"<≤80 chars>",
+    "side_effect":"<one of: invoke-architect | invoke-research |
+                   invoke-spec-author | edit-file | log-only | other>",
+    "side_effect_args":{...}}
+ ],
+ "auto_applicable":<bool>,
+ "auto_apply_instructions":<string|null>}
+
+Cap at 4 options. Always include a "Skip" option as the LAST option.
+
+`auto_applicable: true` is allowed ONLY for these types: index rebuild
+(not in dispatchable list — would not reach this prompt), `kb-citation`
+with a single obvious successor target (rename-and-update mechanical).
+For all other types, set `auto_applicable: false`. The coordinator
+treats out-of-whitelist auto_applicable claims as `false` regardless.
+
+DO NOT call AskUserQuestion. DO NOT edit any files. DO NOT log
+anything. Read-only stage. Any other return shape is a parse failure.
+```
+
+**Parse the proposal + ack marker.** Validate JSON via `jq -e
+'.finding_key and .options'`. On parse failure, mark
+`parse-failed: <first-80-chars>` and surface AskUserQuestion to the
+user with recovery options (re-dispatch, skip, handle-inline).
+
+```bash
+bash .claude/scripts/dispatch-marker.sh ack .curate/_dispatches <finding-key>--propose "<diagnosis>"
+```
+
+**Coordinator: AskUserQuestion.** Present `diagnosis` as the
+preamble; build options from the `options[]` list. The user's choice
+becomes the input to Phase B.
+
+If `auto_applicable: true` AND the type is in the whitelist
+(`kb-citation` only), skip the AskUserQuestion and proceed directly
+to Phase B with the `auto_apply_instructions`.
+
+**Phase B — apply** (autonomous sub-agent, idempotent):
+
+```bash
+bash .claude/scripts/dispatch-marker.sh begin .curate/_dispatches <finding-key>--apply
+```
+
+Agent prompt verbatim:
+
+```
+You are the apply stage for /curate finding <finding-key>.
+
+Chosen option:
+  label: <user's chosen label>
+  side_effect: <one of: invoke-architect | invoke-research |
+                invoke-spec-author | edit-file | log-only | other>
+  side_effect_args: <JSON from proposal>
+
+Execute the side effect:
+
+- invoke-architect → Use the Agent tool to invoke /architect with the
+  arguments in side_effect_args.problem_statement. Wait for return.
+- invoke-research → Use the Agent tool to invoke /research with
+  side_effect_args.subject.
+- invoke-spec-author → Use the Agent tool to invoke /spec-author with
+  side_effect_args.feature_id + side_effect_args.title.
+- edit-file → Use Edit tool to apply side_effect_args.old_string →
+  side_effect_args.new_string in side_effect_args.file_path.
+- log-only → no side effect; just log to review-log.
+- other → side_effect_args.notes describes the action; record it in
+  review-log with status `manual-resolution-required`.
+
+After executing, append to .curate/review-log.md via:
+  bash .claude/scripts/curate-review-log.sh append \
+    .curate/review-log.md "$(date +%F)" "<finding-key>" \
+    "<status: resolved | deferred | skipped | manual-resolution-required>" \
+    "<one-line notes>"
+
+Return EXACTLY ONE LINE:
+
+  RESOLVED|<finding-key>|<one-line-summary>
+  DEFERRED|<finding-key>|<reason>
+  SKIPPED|<finding-key>
+  MANUAL|<finding-key>|<reason>
+
+DO NOT call AskUserQuestion. The decision is final. Any other return
+is a parse failure.
+```
+
+**Parse Phase B + ack the apply marker.** Same payload-lost /
+user-stopped / parse-failed handling as `/spec-backfill` C2e. On
+success, ack the marker:
+
+```bash
+bash .claude/scripts/dispatch-marker.sh ack .curate/_dispatches <finding-key>--apply "<return-line>"
+```
+
+Return to the pick list with the finding marked resolved.
+
+**Why this works across the dispatch boundary:**
+
+- Each sub-agent has a fresh context window — its file reads cost ~0
+  to the coordinator.
+- The coordinator holds only: the pick list (text), the in-flight
+  finding's proposal JSON (~1–2 KB briefly), the user's choice
+  (<100 bytes), the final summary (<200 bytes kept across iterations).
+- After 30 findings: ~6 KB of accumulated summaries vs ~200 KB
+  inline today.
+
+The protocol's first cut applies to the **Dispatchable types** above.
+Light findings (index rebuild, log appends, no-artifact-read
+bookkeeping) continue to use the inline patterns below.
+
+### User picks a number — inline patterns (light findings + fallback)
+
+For findings NOT in the **Dispatchable types** table above, OR if the
+dispatch fails and the user opts to "handle inline" during recovery,
+execute the action directly per the playbooks below. These are also
+the playbooks the dispatched sub-agent reads to know what to do —
+the only difference is who holds the file-read context.
 
 **Index/integrity fixes:** Fix directly — rebuild indexes, clean up stale
 entries. These are bookkeeping and don't need architectural judgment.

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -298,85 +298,184 @@ Use AskUserQuestion to confirm before starting if `<U>` exceeds 50:
 - **"Cap at 10 specs"** (or another cap)
 - **"Cancel"**
 
-### C2. Per-spec dispatch loop
+### C2. Per-spec two-phase dispatch loop
 
 For each spec with uncovered R-ids, in manifest order, run this loop
 until the dispatched count reaches the cap (if set) or the eligible
-set is empty:
+set is empty.
 
-**C2a. Write the dispatch marker.**
+**The two-phase pattern is mandatory.** The single-spec flow's Phase 2
+uses AskUserQuestion per R-id. Dispatched sub-agents (Agent tool) run
+to a single final-message return; the codebase convention is that
+sub-agents do NOT call AskUserQuestion mid-flow (the only documented
+sub-agent contract — see `/work-start all`, `/feature-coordinate` — is
+"run autonomously and return one message"). Two-phase dispatch
+respects that contract by splitting the work: sub-agent A runs the
+read-heavy discover + propose stage with no user prompting, the
+coordinator surfaces the per-R-id decisions via AskUserQuestion, then
+sub-agent B applies the decisions mechanically.
+
+**C2a. Phase A — discover + propose (sub-agent, autonomous).**
+
+Write the marker, then dispatch:
 
 ```bash
-bash .claude/scripts/dispatch-marker.sh begin .spec/_backfill-dispatches <spec-id>
+bash .claude/scripts/dispatch-marker.sh begin .spec/_backfill-dispatches <spec-id>--propose
 ```
 
-This creates `.spec/_backfill-dispatches/_dispatch-<spec-id>.json` with
-`ack: false`. The marker is gitignored. Flipped to `ack: true` once the
-sub-agent returns and the coordinator parses its result.
-
-**C2b. Dispatch the sub-agent.** Invoke the Agent tool with this prompt
-verbatim (substitute `<spec-id>`):
+Agent prompt verbatim (substitute `<spec-id>`):
 
 ```
-You are the per-spec backfill runner for <spec-id>.
+You are the discover + propose stage for /spec-backfill <spec-id>.
 
-Invoke /spec-backfill <spec-id>. The single-spec flow handles Phase 1
-(discover uncovered R-ids), Phase 2 (per-R-id candidate walk with user
-decisions), and Phase 3 (re-trace + summarize). AskUserQuestion in
-Phase 2 surfaces to the actual user — you do not auto-answer it. The
-user IS available across the dispatch boundary; do not assume
-autonomy.
+Run, in order:
+  1. bash .claude/scripts/spec-trace.sh --uncovered <spec-id>
+  2. For each uncovered R-id (cap at 12 — surface "more remain" in
+     output if there are more): extract the requirement text from the
+     spec file under ## Requirements; run
+     bash .claude/scripts/spec-backfill-candidates.sh <spec-id> <r-id>
+     and capture the top 5 candidates.
+  3. Read .spec/backfill-log.md if it exists; mark R-ids that already
+     have a terminal decision (annotated | waived) as "already_decided"
+     so the coordinator can skip them.
 
-When the per-spec flow completes, return EXACTLY ONE LINE on stdout
-matching this shape:
+Return EXACTLY ONE LINE — a JSON object — matching this shape:
+
+{"spec_id":"<spec-id>","total_uncovered":<int>,"more_remain":<bool>,
+ "items":[
+   {"r_id":"R3","requirement_text":"<≤200 chars>",
+    "candidates":[{"file":"<path>","line":<int>,"context":"<≤80 chars>","score":<float>}],
+    "already_decided":null},
+   ...
+ ]}
+
+If `total_uncovered` is 0, return:
+  {"spec_id":"<spec-id>","total_uncovered":0,"items":[]}
+
+DO NOT call AskUserQuestion. DO NOT edit any files. DO NOT log anything.
+Read-only stage. Coordinator handles all user interaction + log writes.
+
+Any other return shape is treated as a parse failure.
+```
+
+**C2b. Parse the proposal + ack marker.**
+
+Receive the JSON. Validate via `jq -e '.spec_id and .items'`. On
+parse failure, mark the propose-stage marker as failed and continue
+to next spec (the surfacing logic is in C2d).
+
+```bash
+bash .claude/scripts/dispatch-marker.sh ack .spec/_backfill-dispatches <spec-id>--propose "<one-line-summary>"
+```
+
+**C2c. Coordinator AskUserQuestion loop (per R-id).**
+
+For each `item` in `items` where `already_decided` is null:
+
+Build AskUserQuestion options dynamically from the top candidates plus
+the standard tail (Skip, Waive, Other). Present:
+
+```
+R3 — <requirement_text>
+
+Suggested annotation sites:
+  (a) <file>:<line>  (score: <s>)  <context>
+  (b) ...
+
+Pick one, or Skip / Waive / specify Other.
+```
+
+Collect the user's decision into a decision-set:
+
+```json
+{"spec_id":"<spec-id>","decisions":[
+  {"r_id":"R3","action":"annotate","file":"...","line":123},
+  {"r_id":"R5","action":"skip"},
+  {"r_id":"R7","action":"waive","reason":"<≤100 chars>"}
+]}
+```
+
+If the user picks "Other", validate the file path exists in coordinator
+before adding to the decision-set (same validation as today's inline
+flow).
+
+The decision-set lives in coordinator context briefly (~500 bytes per
+spec at most) — released as soon as Phase B returns.
+
+**C2d. Phase B — apply (sub-agent, autonomous, idempotent).**
+
+```bash
+bash .claude/scripts/dispatch-marker.sh begin .spec/_backfill-dispatches <spec-id>--apply
+```
+
+Agent prompt verbatim (substitute the JSON):
+
+```
+You are the apply stage for /spec-backfill <spec-id>.
+
+Decisions (JSON):
+<paste the decision-set JSON here>
+
+For each decision, in order:
+
+- action="annotate" → read the file at <file>, locate <line>, insert
+  a `@spec <spec-id>.<R-id>` annotation in a comment ABOVE the line
+  (per rules/spec-annotation-protocol.md comment syntax). If a sibling
+  @spec annotation already exists at that location, append to the
+  existing comment rather than adding a new line. Use the Edit tool.
+  Append to the log:
+    bash .claude/scripts/spec-backfill-log.sh append \
+      .spec/backfill-log.md "$(date +%F)" <spec-id> <R-id> annotated \
+      "<file>:<line>"
+
+- action="skip" → append `skipped` row to the log (no location).
+
+- action="waive" → append `waived` row with the reason in notes.
+
+Before each apply, query `bash .claude/scripts/spec-backfill-log.sh
+has-decision .spec/backfill-log.md <spec-id> <R-id>`. If a terminal
+decision (annotated | waived) already exists, skip this decision
+silently — the apply stage MUST be idempotent so a re-dispatch after a
+crash does not double-annotate.
+
+After all decisions, run:
+  bash .claude/scripts/spec-trace.sh --uncovered <spec-id>
+and count the remaining uncovered R-ids.
+
+Return EXACTLY ONE LINE:
 
   COMPLETE <spec-id> annotated=<N> skipped=<K> waived=<W> uncovered_after=<U>
 
-If the user breaks out mid-walk (any non-resume exit), return:
-
-  STOPPED <spec-id> annotated=<N> skipped=<K> waived=<W> remaining=<R>
-
-If the spec turns out to have zero uncovered R-ids after the log query
-(prior runs covered everything), return:
-
-  EMPTY <spec-id>
-
-Any other return is treated as a parse failure.
+DO NOT call AskUserQuestion. The decision set is final; do not
+re-prompt. Any other return is treated as a parse failure.
 ```
 
-**C2c. Wait for the return.** The Agent tool blocks until the sub-agent
-emits its final assistant message.
+**C2e. Parse Phase B return + ack the apply-stage marker.**
 
-**C2d. Classify and ack.** Parse the return into one of four shapes:
+Classify into one of:
 
-- **COMPLETE** / **STOPPED** / **EMPTY** — ack the marker with the
-  exact return line:
+- **COMPLETE …** — ack the marker:
   ```bash
-  bash .claude/scripts/dispatch-marker.sh ack .spec/_backfill-dispatches <spec-id> "<return-line>"
+  bash .claude/scripts/dispatch-marker.sh ack .spec/_backfill-dispatches <spec-id>--apply "<return-line>"
   ```
-  Print a one-line summary to the user: `<spec-id> — <return-line>`.
-  Continue to next spec.
+  Print `<spec-id> — <return-line>` to the user. Continue to next spec.
 
 - **Payload lost** — Agent return literally equals
-  `[Tool result missing due to internal error]`. Mark the marker as
-  failed:
-  ```bash
-  bash .claude/scripts/dispatch-marker.sh fail .spec/_backfill-dispatches <spec-id> "payload-lost"
-  ```
-  Surface via AskUserQuestion: "Pause for investigation" /
-  "Re-dispatch <spec-id>" / "Skip and continue".
+  `[Tool result missing due to internal error]`. Mark the apply
+  marker `payload-lost`. The propose marker is still acked, and the
+  log captured partial progress if Phase B did any work. Surface via
+  AskUserQuestion: "Re-dispatch <spec-id> apply" /
+  "Skip and continue" / "Investigate manually".
 
 - **User stopped** — Agent return contains
-  `The user doesn't want to proceed with this tool use`. Mark as
-  failed with reason `user-stopped`. Surface AskUserQuestion:
-  "Re-dispatch <spec-id>" / "Continue with next spec" / "Stop the run".
+  `The user doesn't want to proceed with this tool use`. Mark
+  `user-stopped`. Same recovery options.
 
-- **Parse failed** — return present but does not match any expected
-  shape. Mark as failed with reason `parse-failed: <first-80-chars>`.
-  Print the raw return to the user and offer the same recovery options
-  as user-stopped.
+- **Parse failed** — return present but does not match. Mark
+  `parse-failed: <first-80-chars>`. Print raw return; same recovery
+  options.
 
-**C2e. Honor the cap.** If a cap was set in C1 and the dispatched
+**C2f. Honor the cap.** If a cap was set in C1 and the dispatched
 count has reached it, exit the loop after acking the current spec.
 
 ### C3. Corpus summary


### PR DESCRIPTION
## Summary

Lands `/curate` Step 4 dispatch refactor AND corrects PR #85's `/spec-backfill --all` implementation. Both commands now use the same **two-phase dispatch pattern** that respects the codebase convention: dispatched sub-agents run autonomously and never call AskUserQuestion mid-flow.

## Why two-phase

PR #85 dispatched the single-spec `/spec-backfill` flow as a sub-agent and asserted "AskUserQuestion surfaces to the actual user — the user IS available across the dispatch boundary." A grep across `skills/` and `rules/` finds **zero** examples of AskUserQuestion-in-sub-agent. `/work-start all` and `/feature-coordinate` both explicitly run sub-agents with `automation_mode: autonomous` and bubble escalations back via the return line. The safe assumption is that AskUserQuestion in a dispatched sub-agent is at best unsupported and at worst hangs the Agent call indefinitely.

Two-phase respects the convention:

1. **Phase A** (sub-agent, autonomous): read artifacts → return structured JSON proposal. NO AskUserQuestion.
2. **Coordinator**: AskUserQuestion to the actual user using the proposal. Decision lives in coordinator briefly.
3. **Phase B** (sub-agent, autonomous, idempotent): apply the chosen action. NO AskUserQuestion. One-line summary.

## What ships

### `/spec-backfill --all` — C2 rewrite

- Phase A: discover uncovered R-ids + run candidate finder + build proposal JSON (capped: 12 R-ids/spec, top-5 candidates/R-id).
- Coordinator: AskUserQuestion loop per R-id, build decision-set.
- Phase B: Edit per `annotate` decision + append to backfill-log; queries `has-decision` before each apply for idempotency on re-dispatch.

### `/curate` Step 4 — new dispatch protocol

- **Dispatchable types** table listing ~9 finding types that warrant dispatch (ADR pressure/gravity/drift, KB stale, spec coverage/code drift, spec graduation, ADR-no-spec, KB schema drift, subdivision candidate).
- **Step 0 pre-flight** scans `.curate/_dispatches/` for stuck markers → AskUserQuestion recovery (re-dispatch / skip / investigate). Mirrors `/work-resume` rule 0 + `/spec-backfill` C0.
- **Phase A prompt** → proposal JSON with ≤4 options (Skip always last) + `auto_applicable` whitelisted to mechanical fixes only.
- **Coordinator AskUserQuestion** between phases.
- **Phase B prompt** → `invoke-architect` / `invoke-research` / `invoke-spec-author` / `edit-file` / `log-only` / `other` side effects.
- Light findings (index rebuild, log appends, bookkeeping) continue using the existing inline patterns under "User picks a number — inline patterns (light findings + fallback)."

## Coordinator context footprint

| Workload | Inline (today) | Two-phase dispatch (this PR) |
|----------|----------------|-------------------------------|
| /spec-backfill --all (12 specs) | ~360 KB | ~3 KB summaries + ~5–10 KB in-flight proposal |
| /curate (30 dispatchable findings) | ~200–300 KB | ~6 KB summaries + ~1–2 KB in-flight proposal |

## Test status

- `scenario-dispatch-marker.sh` — 21/21
- `scenario-curate-scan.sh` — 78/78
- `test-install.sh` — 74/74

No new test scenarios — both refactors are SKILL.md documentation that Claude follows at runtime. The dispatch primitive (`scripts/dispatch-marker.sh`) already has full coverage from PR #85.

## Adversarial pass — 10 edges considered

Documented in the commit message. Highlights: malformed JSON → parse-failed marker + recovery options; "Other" picks validated in coordinator; Phase B idempotency via `has-decision` query; auto_applicable whitelist enforced in coordinator regardless of sub-agent claim; stuck-marker recovery at Step 0; recursive Agent invocations from Phase B supported at depth-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)