### PR TITLE
feat(curate): scan-complete sentinel + fast-scan path (closes the 'got fooled' bug from jlsm walk)

### DIFF
--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1280,6 +1280,13 @@ fi
 > "$TMPDIR_SCAN/spec-unannotated.txt"
 > "$TMPDIR_SCAN/spec-bare-only.txt"
 > "$TMPDIR_SCAN/spec-annotation-drift.txt"
+# Pre-create the rollup tmpfile up here so the end-of-script counter
+# (`wc -l <…/spec-annotation-rollup.txt`) does not emit "No such file"
+# stderr when Analysis 18 is skipped (manifest missing or spec-trace.sh
+# unavailable). The rollup itself is written inside the SPEC_TRACE-found
+# block at the tail of Analysis 18; pre-creating an empty file here is
+# harmless when the block doesn't execute.
+> "$TMPDIR_SCAN/spec-annotation-rollup.txt"
 
 # has_bare_annotations <spec-id> — returns 0 if the source tree contains a
 # bare `@spec <sid>` reference (no `.R<n>` suffix). Used to differentiate
@@ -3055,6 +3062,30 @@ echo "  Spec graduation candidates: $(wc -l < "$TMPDIR_SCAN/spec-graduation.txt"
 echo "  Spec xref drift: $(wc -l < "$TMPDIR_SCAN/spec-xref-drift.txt" 2>/dev/null || echo 0)"
 echo "  Annotation rollup: $(wc -l < "$TMPDIR_SCAN/spec-annotation-rollup.txt" 2>/dev/null || echo 0)"
 echo "  ADRs without spec: $(wc -l < "$TMPDIR_SCAN/adr-no-spec.txt" 2>/dev/null || echo 0)"
+
+# ── Sentinel: mark the summary as complete ─────────────────────────────────
+# When this line is present at the end of scan-summary.md, /curate Step 1
+# knows the script ran end-to-end. When it's MISSING, the summary was
+# written but the script died before the report block — i.e. a partial
+# scan masquerading as a clean one. Without this, an interrupted scan
+# (Claude Code Bash timeout, ctrl-C, OOM) leaves a truncated summary that
+# reads as "all analyses ran and found nothing" — the failure mode we
+# need to detect.
+#
+# The trace-depth annotation records how many APPROVED specs were
+# actually run through spec-trace.sh in Analysis 18. When the user
+# passes `--max-specs-traced 0` for a fast scan, the rollup data is
+# missing by design; /curate Step 1 surfaces this so the user can
+# request a follow-up trace pass if needed.
+
+TRACED_COUNT="${specs_traced:-0}"
+
+cat >> "$SUMMARY_FILE" << SENTINEL
+
+---
+
+✓ Scan complete: $(date -u +"%Y-%m-%dT%H:%M:%SZ") · max_specs_traced=$MAX_SPECS_TRACED · specs_traced=$TRACED_COUNT · scan_mode=$SCAN_MODE · window_months=$WINDOW_MONTHS
+SENTINEL
 
 # ── Update curation state ─────────────────────────────────────────────────
 

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -187,6 +187,54 @@ bash .claude/scripts/curate-scan.sh [--init] [--window <months>] \
 Run the script. If it exits with "No new commits since last scan," report that
 and ask if the user wants to force a rescan with `--init`.
 
+### Step 1.1 — Verify scan completeness via sentinel (REQUIRED)
+
+After the scan script exits, before reading the summary in Step 2,
+check that `.curate/scan-summary.md` ends with the scan-complete
+sentinel. The sentinel is the last line and looks like:
+
+```
+✓ Scan complete: <iso-date> · max_specs_traced=<N> · specs_traced=<M> · scan_mode=<full|incremental> · window_months=<W>
+```
+
+A missing sentinel means the script exited before its final block —
+the summary was partially written and **must NOT be read as
+authoritative**. Common causes: Claude Code's default Bash timeout
+(jlsm-sized repos can run 10–15 min if Analysis 18 traces all
+APPROVED specs), manual Ctrl-C, context compaction mid-run.
+
+**Check:**
+
+```bash
+tail -1 .curate/scan-summary.md | grep -q "^✓ Scan complete:"
+```
+
+If absent → the scan was interrupted. Surface to the user via
+AskUserQuestion:
+
+- **"Re-run with `--init --max-specs-traced 0`"** — recommended for
+  large repos. Skips the per-spec annotation trace (Analysis 18),
+  which is the only analysis that typically pushes runtime past 60s.
+  Annotation-coverage rollup data will be absent; if needed, run a
+  follow-up trace pass with `--max-specs-traced 50` (or higher) once
+  the fast scan confirms the rest of the corpus is clean.
+- **"Re-run with `--init`"** — fresh full scan; same timeout risk.
+- **"Read partial summary anyway"** — only safe when the missing
+  analyses are known to not apply (small repos, first-time setup).
+  The user takes responsibility.
+
+If the sentinel IS present, surface its contents to the user in one
+line so they see the scope of what ran:
+
+```
+Scan complete: <date> · traced <M>/<approved-count> specs · window <W>m
+```
+
+If `specs_traced=0` in the sentinel AND APPROVED specs exist in the
+manifest, note that the annotation-coverage rollup (Analysis 18b) and
+the per-spec annotation gap analyses (Analysis 18) did not run for
+this scan. Offer to schedule a follow-up trace pass before closing.
+
 ---
 
 ## Step 1.5 — Verify-mode branch

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -1915,6 +1915,152 @@ fi
 
 cd "$REPO_ROOT"
 
+# ── Test 38: Scan-complete sentinel written when scan finishes cleanly ───────
+
+echo ""
+echo "── Test 38: scan-complete sentinel marks the summary as authoritative"
+
+if command -v jq >/dev/null 2>&1; then
+    SENT_DIR="$TEST_BASE/sentinel-project"
+    rm -rf "$SENT_DIR"; mkdir -p "$SENT_DIR"
+    cd "$SENT_DIR"
+    git init --initial-branch=main . >/dev/null 2>&1
+    git config user.email t@t.com; git config user.name t
+    mkdir -p .claude/scripts
+    cp "$REPO_ROOT/scripts/curate-scan.sh"  .claude/scripts/
+    cp "$REPO_ROOT/scripts/spec-lib.sh"     .claude/scripts/
+    echo "x" > a.md
+    git add -A && git commit -q -m "init"
+
+    bash .claude/scripts/curate-scan.sh --init >/dev/null 2>&1 || true
+
+    if tail -1 .curate/scan-summary.md | grep -q "^✓ Scan complete:"; then
+        pass "sentinel line present at end of summary"
+    else
+        fail "sentinel line missing"
+    fi
+
+    if tail -1 .curate/scan-summary.md | grep -q "max_specs_traced=50"; then
+        pass "sentinel records max_specs_traced setting"
+    else
+        fail "sentinel missing max_specs_traced field"
+    fi
+
+    if tail -1 .curate/scan-summary.md | grep -q "scan_mode=full"; then
+        pass "sentinel records scan_mode (full on --init)"
+    else
+        fail "sentinel missing scan_mode field"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+cd "$REPO_ROOT"
+
+# ── Test 39: Sentinel records specs_traced=0 with --max-specs-traced 0 ───────
+
+echo ""
+echo "── Test 39: --max-specs-traced 0 sentinel marks the trace as skipped"
+
+if command -v jq >/dev/null 2>&1; then
+    FAST_DIR="$TEST_BASE/sentinel-fast-project"
+    rm -rf "$FAST_DIR"; mkdir -p "$FAST_DIR"
+    cd "$FAST_DIR"
+    git init --initial-branch=main . >/dev/null 2>&1
+    git config user.email t@t.com; git config user.name t
+    mkdir -p .claude/scripts
+    cp "$REPO_ROOT/scripts/curate-scan.sh"  .claude/scripts/
+    cp "$REPO_ROOT/scripts/spec-lib.sh"     .claude/scripts/
+    cp "$REPO_ROOT/scripts/spec-trace.sh"   .claude/scripts/ 2>/dev/null || true
+    mkdir -p .spec/registry .spec/domains/auth
+
+    cat > .spec/registry/manifest.json <<'JSON'
+{
+  "schema_version": 2,
+  "specs": [
+    { "id": "auth.session", "path": ".spec/domains/auth/session.md",
+      "state": "APPROVED", "version": 1, "domains": ["auth"], "requires": [],
+      "invalidates": [], "decision_refs": [], "kb_refs": [] }
+  ]
+}
+JSON
+    cat > .spec/domains/auth/session.md <<'SPEC'
+---
+{
+  "id": "auth.session", "version": 1, "status": "ACTIVE", "state": "APPROVED",
+  "domains": ["auth"], "requires": [], "invalidates": [],
+  "amends": null, "amended_by": null,
+  "decision_refs": [], "kb_refs": []
+}
+---
+
+# auth.session
+
+## Requirements
+R1. Sessions exist.
+
+---
+
+## Design
+Notes.
+SPEC
+    git add -A && git commit -q -m "init"
+
+    bash .claude/scripts/curate-scan.sh --init --max-specs-traced 0 >/dev/null 2>&1 || true
+
+    if tail -1 .curate/scan-summary.md | grep -q "specs_traced=0"; then
+        pass "fast scan records specs_traced=0"
+    else
+        fail "fast scan did not record specs_traced=0" "got: $(tail -1 .curate/scan-summary.md)"
+    fi
+
+    if tail -1 .curate/scan-summary.md | grep -q "max_specs_traced=0"; then
+        pass "fast scan records max_specs_traced=0 setting"
+    else
+        fail "fast scan did not record max_specs_traced=0"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+cd "$REPO_ROOT"
+
+# ── Test 40: Truncated summary (simulates killed scan) lacks the sentinel ────
+
+echo ""
+echo "── Test 40: truncated summary fails the sentinel check"
+
+if command -v jq >/dev/null 2>&1; then
+    TRUNC_DIR="$TEST_BASE/sentinel-trunc-project"
+    rm -rf "$TRUNC_DIR"; mkdir -p "$TRUNC_DIR"
+    cd "$TRUNC_DIR"
+    git init --initial-branch=main . >/dev/null 2>&1
+    git config user.email t@t.com; git config user.name t
+    mkdir -p .claude/scripts .curate
+    cp "$REPO_ROOT/scripts/curate-scan.sh"  .claude/scripts/
+    cp "$REPO_ROOT/scripts/spec-lib.sh"     .claude/scripts/
+    echo "x" > a.md
+    git add -A && git commit -q -m "init"
+
+    bash .claude/scripts/curate-scan.sh --init >/dev/null 2>&1 || true
+
+    # Now simulate a killed scan: chop off the trailing sentinel block.
+    # Real-world equivalent: the script's final write block (sentinel +
+    # state update) never ran because the process was SIGTERM'd between
+    # the body of the last analysis and the sentinel append.
+    head -n -3 .curate/scan-summary.md > .curate/.tmp && mv .curate/.tmp .curate/scan-summary.md
+
+    if tail -1 .curate/scan-summary.md | grep -q "^✓ Scan complete:"; then
+        fail "sentinel present after truncation (test setup wrong)"
+    else
+        pass "truncated summary correctly fails sentinel check"
+    fi
+else
+    echo "  SKIP  jq not available"
+fi
+
+cd "$REPO_ROOT"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Discovered during today's jlsm walk: `/curate --init` on jlsm-sized repos (~100 approved specs) takes 10–15 minutes (Analysis 18's per-spec spec-trace pass dominates). Claude Code's default Bash timeout killed the scan mid-write at the Artifact Correlations section. The truncated `scan-summary.md` then reads as authoritative: every unwritten analysis section is parsed by downstream readers as "no findings here." The jlsm session was minutes from acting on a false-clean signal.

Two minimal fixes:

### Sentinel

`curate-scan.sh` appends a trailing line to `scan-summary.md` after the report block:

```
✓ Scan complete: <iso-date> · max_specs_traced=<N> · specs_traced=<M> · scan_mode=<mode> · window_months=<W>
```

`/curate` Step 1.1 (new) checks `tail -1` for this marker. If absent → scan was interrupted; AskUserQuestion with three remedies (re-run fast, re-run full, read partial anyway). If present with `specs_traced=0` → annotation-rollup data is absent (by design) and surfaced as a follow-up offer.

### Pre-create rollup tmpfile

Minor pre-existing bug — the end-of-script counter for `spec-annotation-rollup.txt` emitted "No such file" stderr when Analysis 18 was skipped (the `|| echo 0` fallback worked but printed). Pre-creating the empty tmpfile alongside the other Analysis 18 tmpfiles eliminates the noise.

## Chunking on large repos (already supported, now visible)

The existing `--max-specs-traced <n>` flag IS the chunking primitive:

| Invocation | Effect | jlsm wall-clock |
|------------|--------|------------------|
| `--max-specs-traced 0` | Skips Analysis 18 + 18b entirely | ~60s |
| `--max-specs-traced 50` (default) | Traces up to 50 APPROVED specs | ~10 min |
| `--max-specs-traced 200` | Traces all | 15+ min |

The full picture is achievable by running fast first (get F1/F8/F6/KB-drift signals immediately), then a follow-up trace pass for annotation rollup if needed. The sentinel makes the partial-state visible so the user knows whether a follow-up is required.

## Test plan

- [x] `bash tests/scenario-curate-scan.sh` — **84/84** (6 new tests for sentinel: clean-exit sentinel, --max-specs-traced 0 records specs_traced=0, truncated summary fails the check)
- [x] `bash tests/test-install.sh` — **74/74** (no install changes)
- [x] `bash -n scripts/curate-scan.sh` — clean

## Why no per-analysis checkpointing in this PR

The user request was "smaller scans that equal the longer one by chunking" — `--max-specs-traced 0` already provides that (fast scan + optional follow-up trace pass), and the sentinel makes both phases visible. Per-analysis resumable checkpoint state was considered: it requires persisting tmpfile contents across runs and merging scan-summary.md sections from multiple invocations. ~3x the surface area of this PR. The simpler fix addresses the actual "got fooled" bug; deeper resumability is a separate decision after we see how often the partial-scan warning fires in real use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)