### PR TITLE
feat(work-start): user-required escalation contract for sub-agents (PR A of 3)

### DIFF
--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -410,17 +410,31 @@ Replace Steps 3–5 with this block when `all` is the argument.
       /feature-refactor → /feature-pr.
 
       Treat automation_mode as autonomous. Do not pause between
-      pipeline stages. If a stage escalates (test conflict, missing
-      tests, refactor escalation), record it in the feature's
-      cycle-log.md and continue with remaining stages where possible.
+      pipeline stages. If a stage hits a TECHNICAL escalation (test
+      conflict, missing tests, refactor escalation), record it in the
+      feature's cycle-log.md and continue with remaining stages where
+      possible — this is auto-handled and reported in your summary.
 
-      Distinguish two failure modes in your final return:
+      If a stage hits a USER-REQUIRED escalation (design ambiguity,
+      missing context the kit can't supply, irreconcilable spec
+      conflict, an impossible requirement), follow the user-required
+      escalation contract from /work-start: write
+      .feature/<feature-slug>/escalation.json with the schema in the
+      "User-required escalation contract" section, append a
+      `user-escalation — <category>: <question>` entry to cycle-log.md,
+      set status.md substage to `awaiting-user-input`, then halt the
+      WD and return ESCALATION_AT_<stage> as below.
+
+      Distinguish these return modes in your final return:
 
       - If the /work-start invocation reports a `[claim] CONFLICT:`
         message from work-claim.sh (another terminal advanced the WD
         between the coordinator's enumeration and this dispatch),
         return:
           "<group-slug>--<wd-id>: SKIPPED — claim conflict"
+
+      - If you wrote escalation.json per the contract, return:
+          "<group-slug>--<wd-id>: ESCALATION_AT_<stage> — <category>: <question>"
 
       - Any other failure (feature directory creation, status.md
         write error, pipeline escalation, unexpected exception) is an
@@ -438,8 +452,23 @@ Replace Steps 3–5 with this block when `all` is the argument.
       until the child emits its final assistant message.
 
    f. **Classify the return and update the marker.** The Agent tool
-      returns one of four shapes. Treat each distinctly — silent
-      assumptions corrupt the task list:
+      returns one of five shapes. Treat each distinctly — silent
+      assumptions corrupt the task list. **Match `ESCALATION_AT_`
+      before `STOPPED_AT_`** since both share the `<STATUS>_AT_<stage>`
+      shape.
+
+      - **Escalation return** matching `<group-slug>--<wd-id>: ESCALATION_AT_<stage> — <category>: <question>`.
+        The sub-agent halted awaiting user input and has written
+        `.feature/<group>--<wd>/escalation.json` with the structured
+        question (see "User-required escalation contract"). Mark with
+        the category as the reason so the future orchestrator can
+        route:
+        ```bash
+        bash .claude/scripts/work-dispatch.sh fail "<group-slug>" "<wd-id>" "escalation:<category>"
+        ```
+        Use `fail` (not `ack`) because the WD is not complete — it is
+        paused awaiting user input. Append to a dedicated escalations
+        list separate from the clean-return aggregate.
 
       - **Clean return** matching `<group-slug>--<wd-id>: <STATUS> — <detail>`
         (where STATUS is one of `COMPLETE`, `STOPPED_AT_<stage>`,
@@ -623,18 +652,38 @@ Replace Steps 3–5 with this block when `--parallel` is set.
 
    Invoke /feature-plan "<feature-slug>" and run the full pipeline
    through to /feature-refactor. Do not pause for user confirmation;
-   treat automation_mode as autonomous. If any stage escalates (spec
-   conflict, missing tests, test writer escalation), record it in
-   cycle-log.md and continue with the remaining stages where possible;
-   report the escalation in your final one-line summary.
+   treat automation_mode as autonomous.
 
-   Return a single summary line of the form:
-     "<feature-slug>: <COMPLETE | STOPPED_AT_<stage> | ERROR> — <detail>"
+   TECHNICAL escalations (spec conflict, missing tests, test writer
+   escalation) are auto-handled: record in cycle-log.md and continue
+   with remaining stages where possible; mention in your summary.
+
+   USER-REQUIRED escalations (design ambiguity, missing context the
+   kit can't supply, irreconcilable spec conflict, impossible
+   requirement) halt the WD. Follow the user-required escalation
+   contract from /work-start:
+     1. write .feature/<feature-slug>/escalation.json with the schema
+        in /work-start's "User-required escalation contract" section
+     2. append a `user-escalation — <category>: <question>` entry to
+        cycle-log.md
+     3. set status.md substage to `awaiting-user-input`
+     4. return ESCALATION_AT_<stage> per below
+
+   Return a single summary line of one of these forms:
+     "<feature-slug>: COMPLETE — <detail>"
+     "<feature-slug>: ESCALATION_AT_<stage> — <category>: <question>"
+     "<feature-slug>: STOPPED_AT_<stage> — <detail>"
+     "<feature-slug>: ERROR — <detail>"
    ```
 
-6. **Aggregate results — classify each return.** Use the same four-way
-   classification as Sequential mode Step 3f (clean / payload-lost /
-   user-stopped / parse-failed). For each sub-agent's return:
+6. **Aggregate results — classify each return.** Use the same
+   five-way classification as Sequential mode Step 3f (escalation /
+   clean / payload-lost / user-stopped / parse-failed). **Match
+   `ESCALATION_AT_` before `STOPPED_AT_`** since both share the
+   `<STATUS>_AT_<stage>` shape. For each sub-agent's return:
+   - Escalation (`ESCALATION_AT_<stage> — <category>: <question>`):
+     `bash .claude/scripts/work-dispatch.sh fail "<group>" "<wd-id>" "escalation:<category>"`
+     (use `fail` not `ack` — WD is paused awaiting user input)
    - Clean: `bash .claude/scripts/work-dispatch.sh ack "<group>" "<wd-id>" "<line>"`
    - Payload lost: `bash .claude/scripts/work-dispatch.sh fail "<group>" "<wd-id>" "payload-lost"`
    - User stopped: `bash .claude/scripts/work-dispatch.sh fail "<group>" "<wd-id>" "user-stopped"`
@@ -645,15 +694,21 @@ Replace Steps 3–5 with this block when `--parallel` is set.
    ── Parallel run complete · <group-slug> ───────
    Dispatched: <N>
    Complete: <n>/<N>
+   Escalations awaiting user input: <n>
+     WD-<nn> (<category>) — "<question>"
+          .feature/<group>--WD-<nn>/escalation.json
    Stopped mid-pipeline: <list with stage>
    Errored: <list with detail>
    Dispatch failures (payload-lost / user-stopped / parse-failed):
      <list with WD-id and reason>
    ───────────────────────────────────────────────
    ```
-   For stopped or errored WDs, the user's next action is usually
-   `/feature-resume "<feature-slug>"` to pick up where each sub-agent
-   left off. For dispatch failures, the next action is
+   For escalations, the user's next action is to open the listed
+   escalation.json file(s), resolve the design point (edit the spec,
+   add an ADR, supply context), then re-dispatch via
+   `/work-resume "<group-slug>"`. For stopped or errored WDs, the
+   user's next action is usually `/feature-resume "<feature-slug>"`.
+   For dispatch failures, the next action is
    `/work-resume "<group-slug>"` — it scans the dispatch markers and
    surfaces each stuck WD with the right recovery path (re-dispatch,
    inspect, or accept the partial result).
@@ -676,6 +731,127 @@ Replace Steps 3–5 with this block when `--parallel` is set.
   parallel is safe; if not, either cap at 1 or don't use parallel.
 - **Token / cost budget.** N parallel pipelines burn roughly N× the
   tokens and dollars of a single run. Budget accordingly.
+
+---
+
+## User-required escalation contract
+
+Two kinds of escalation happen during autonomous pipeline runs. They
+need to be distinguished — only one of them halts the WD.
+
+**Stage escalation** (existing, auto-continued): a pipeline stage hits
+a technical conflict it can handle within the pipeline — test writer
+can't write a failing test, refactor stage finds a spec conflict, etc.
+The kit's existing rules say: record in `cycle-log.md` and continue
+with remaining stages. The WD finishes (possibly with `STOPPED_AT_`)
+and the user sees the escalation in the post-run summary.
+
+**User-required escalation** (this contract): the sub-agent cannot
+proceed without user input. Common categories:
+
+| Category | When |
+|----------|------|
+| `design-choice` | Spec/ADR is ambiguous; multiple valid implementations. The sub-agent can identify them but cannot pick. |
+| `missing-context` | A referenced concept (symbol, decision, KB entry) doesn't resolve. The sub-agent searched and found nothing. |
+| `spec-conflict` | Two specs contradict each other on a point the current stage needs to honor. Cannot be reconciled in-pipeline. |
+| `impossible` | A requirement physically can't be satisfied (e.g., contradicts an external fact). Needs scope/spec revision. |
+| `other` | Escape hatch — use the `question` field to explain. |
+
+The sub-agent halts the WD and surfaces the question via a structured
+artifact. The parent (this skill, today; the orchestrator in a future
+PR) routes the question to the user.
+
+### Sub-agent obligations on user-required escalation
+
+When a sub-agent in `automation_mode: autonomous` encounters a
+user-required situation:
+
+1. **Write `.feature/<slug>/escalation.json`** with this schema (JSON,
+   atomic write via tmp + rename):
+
+   ```json
+   {
+     "schema_version": 1,
+     "feature_slug": "<group>--<wd>",
+     "wd_id": "WD-nn",
+     "group_slug": "<group-slug>",
+     "raised_at": "<ISO-8601 UTC>",
+     "blocking_stage": "feature-plan|feature-test|feature-implement|feature-refactor",
+     "category": "design-choice|missing-context|spec-conflict|impossible|other",
+     "question": "<one-line summary, suitable for AskUserQuestion prompt>",
+     "context": "<longer explanation; may include rationale + what was tried>",
+     "context_refs": ["<file:line>", "<spec-id.RN>", "<.decisions/slug>"],
+     "options": [
+       { "label": "<short>", "description": "<what choosing this means>" }
+     ]
+   }
+   ```
+
+   `context_refs` and `options` are optional. If the sub-agent has no
+   candidate answers, omit `options` — the user will provide one.
+
+2. **Record a `user-escalation` entry in `cycle-log.md`**:
+   ```
+   - <ISO-8601 UTC> user-escalation — <category>: <question>
+   ```
+   This complements escalation.json (which is the structured form) and
+   keeps cycle-log as the single audit timeline.
+
+3. **Update `status.md` substage** to `awaiting-user-input` so
+   `/work-resume` and `/feature-resume` recognize the halted state.
+
+4. **Return one line** of the form:
+   ```
+   <feature-slug>: ESCALATION_AT_<stage> — <category>: <question>
+   ```
+   The leading sentinel `ESCALATION_AT_` is what the parent classifier
+   matches. The `<category>: <question>` tail is for the human-readable
+   summary.
+
+### Parent classifier (5-way + dispatch-failure modes)
+
+Extend the sequential and parallel mode classifiers from 4 to 5
+recognized clean-return shapes. Order matters — match
+`ESCALATION_AT_` before `STOPPED_AT_` since both share the
+`<feature>: <STATUS>_AT_<stage>` shape.
+
+| Status pattern | Classification | Marker call |
+|----------------|----------------|-------------|
+| `: COMPLETE — ` | clean | `ack <line>` |
+| `: ESCALATION_AT_<stage> — ` | **escalation (new)** | `fail "escalation:<category>"` |
+| `: STOPPED_AT_<stage> — ` | stopped mid-pipeline | `ack <line>` |
+| `: SKIPPED — ` | skipped (claim conflict) | `ack <line>` |
+| `: ERROR — ` | errored | `ack <line>` |
+
+The dispatch-failure modes (`payload-lost`, `user-stopped`,
+`parse-failed`) remain unchanged. Use `fail` with reason
+`escalation:<category>` rather than `ack` for escalations because the
+WD did NOT complete — it is paused awaiting input. A future orchestrator
+will re-dispatch the WD after the user resolves the question.
+
+### Parent summary — escalations are surfaced distinctly
+
+Both sequential `all` and `--parallel` modes extend the post-run
+summary with an "Escalations awaiting user input" block:
+
+```
+── Parallel run complete · <group-slug> ───────
+Dispatched: 5
+Complete: 2/5
+Escalations awaiting user input: 1
+  WD-04 (design-choice) — "Use sealed permit or interface for codec?"
+       .feature/<group>--WD-04/escalation.json
+Stopped mid-pipeline: WD-07 (testing)
+Errored: 1 (WD-02)
+Dispatch failures: 0
+───────────────────────────────────────────────
+Next: open the escalation.json file(s) to read context, then re-dispatch
+the resolved WD with /work-resume "<group-slug>".
+```
+
+Until the future orchestrator (PR B/C) lands, the user opens
+escalation.json manually, resolves the design point (edits the spec,
+adds an ADR, updates context), then re-dispatches via `/work-resume`.
 
 ---
 

--- a/tests/scenario-work-start-escalation.sh
+++ b/tests/scenario-work-start-escalation.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# Scenario: user-required escalation contract is documented in /work-start.
+#
+# Like scenario-work-start-parallel.sh, the actual sub-agent dispatch
+# cannot be exercised in a scenario test — sub-agent orchestration
+# requires the Claude runtime. This test validates the documented
+# contract: that the SKILL.md has all the pieces a sub-agent and a
+# parent need to implement and detect user-required escalations
+# correctly. A future orchestrator (PR B) and /work-run skill (PR C)
+# will be built against this contract.
+#
+# Run from repo root: bash tests/scenario-work-start-escalation.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SKILL="$REPO_ROOT/skills/work-start/SKILL.md"
+TEST_BASE="/tmp/vallorcine/scenario-work-start-escalation"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cleanup
+mkdir -p "$TEST_BASE"
+
+echo ""
+echo "scenario: /work-start user-required escalation contract"
+echo "────────────────────────────────────────────────"
+
+# ── Contract section exists ─────────────────────────────────────────────────
+
+echo ""
+echo "  Contract section in SKILL.md"
+echo "  ────────────────────────────"
+
+if grep -q "^## User-required escalation contract" "$SKILL"; then
+    pass "has ## User-required escalation contract section"
+else
+    fail "missing ## User-required escalation contract section"
+fi
+
+# ── Categories enumerated ───────────────────────────────────────────────────
+
+echo ""
+echo "  Escalation categories"
+echo "  ─────────────────────"
+
+for cat in design-choice missing-context spec-conflict impossible other; do
+    if grep -qF "\`$cat\`" "$SKILL"; then
+        pass "category enumerated: $cat"
+    else
+        fail "category missing: $cat"
+    fi
+done
+
+# ── escalation.json schema fields ───────────────────────────────────────────
+
+echo ""
+echo "  escalation.json schema fields"
+echo "  ─────────────────────────────"
+
+# Required fields the orchestrator + UI both depend on
+for field in schema_version feature_slug wd_id group_slug raised_at \
+             blocking_stage category question context; do
+    if grep -qE "\"$field\"" "$SKILL"; then
+        pass "schema field present: $field"
+    else
+        fail "schema field missing: $field"
+    fi
+done
+
+# Optional but documented
+for field in context_refs options; do
+    if grep -qE "\"$field\"" "$SKILL"; then
+        pass "optional schema field documented: $field"
+    else
+        fail "optional schema field missing: $field"
+    fi
+done
+
+# ── Sub-agent obligations ───────────────────────────────────────────────────
+
+echo ""
+echo "  Sub-agent obligations on escalation"
+echo "  ───────────────────────────────────"
+
+if grep -qF "escalation.json" "$SKILL"; then
+    pass "obligation: write escalation.json"
+else
+    fail "obligation missing: write escalation.json"
+fi
+
+if grep -qF "user-escalation" "$SKILL"; then
+    pass "obligation: record user-escalation in cycle-log"
+else
+    fail "obligation missing: cycle-log entry"
+fi
+
+if grep -qF "awaiting-user-input" "$SKILL"; then
+    pass "obligation: status.md substage awaiting-user-input"
+else
+    fail "obligation missing: substage transition"
+fi
+
+if grep -qE "ESCALATION_AT_<stage>" "$SKILL"; then
+    pass "obligation: return ESCALATION_AT_<stage>"
+else
+    fail "obligation missing: return-line sentinel"
+fi
+
+# ── Both sub-agent prompts updated ──────────────────────────────────────────
+
+echo ""
+echo "  Sub-agent prompts carry escalation instructions"
+echo "  ──────────────────────────────────────────────"
+
+# Sequential mode prompt should mention USER-REQUIRED + escalation.json
+seq_block=$(awk '/sequential pipeline runner/,/parses this string/' "$SKILL")
+if echo "$seq_block" | grep -qF "USER-REQUIRED"; then
+    pass "sequential prompt mentions USER-REQUIRED escalation"
+else
+    fail "sequential prompt missing USER-REQUIRED reference"
+fi
+if echo "$seq_block" | grep -qF "escalation.json"; then
+    pass "sequential prompt instructs writing escalation.json"
+else
+    fail "sequential prompt missing escalation.json instruction"
+fi
+if echo "$seq_block" | grep -qF "ESCALATION_AT_<stage>"; then
+    pass "sequential prompt documents ESCALATION_AT_<stage> return"
+else
+    fail "sequential prompt missing ESCALATION_AT return form"
+fi
+
+# Parallel mode prompt should likewise
+par_block=$(awk '/parallel pipeline runner/,/^   \`\`\`$/' "$SKILL")
+if echo "$par_block" | grep -qF "USER-REQUIRED"; then
+    pass "parallel prompt mentions USER-REQUIRED escalation"
+else
+    fail "parallel prompt missing USER-REQUIRED reference"
+fi
+if echo "$par_block" | grep -qF "escalation.json"; then
+    pass "parallel prompt instructs writing escalation.json"
+else
+    fail "parallel prompt missing escalation.json instruction"
+fi
+if echo "$par_block" | grep -qF "ESCALATION_AT_<stage>"; then
+    pass "parallel prompt documents ESCALATION_AT_<stage> return"
+else
+    fail "parallel prompt missing ESCALATION_AT return form"
+fi
+
+# ── Classifier extended to 5-way in both modes ──────────────────────────────
+
+echo ""
+echo "  Classifier covers escalation in both modes"
+echo "  ──────────────────────────────────────────"
+
+# Sequential mode classifier (Step 3f)
+seq_classifier=$(awk '/Classify the return and update the marker/,/Append to the aggregate. Display incrementally/' "$SKILL")
+if echo "$seq_classifier" | grep -qF "Escalation return"; then
+    pass "sequential classifier has Escalation return case"
+else
+    fail "sequential classifier missing Escalation return case"
+fi
+if echo "$seq_classifier" | tr '\n' ' ' | tr -s ' ' | grep -qF "Match \`ESCALATION_AT_\` before \`STOPPED_AT_\`"; then
+    pass "sequential classifier documents match order"
+else
+    fail "sequential classifier missing match-order guidance"
+fi
+if echo "$seq_classifier" | grep -qF "escalation:<category>"; then
+    pass "sequential classifier uses fail with escalation:<category>"
+else
+    fail "sequential classifier missing fail-with-category convention"
+fi
+
+# Parallel mode classifier (Step 6)
+par_classifier=$(awk '/Aggregate results — classify each return/,/Concurrency caveats/' "$SKILL")
+if echo "$par_classifier" | grep -qF "five-way classification"; then
+    pass "parallel classifier upgraded to five-way"
+else
+    fail "parallel classifier still four-way"
+fi
+if echo "$par_classifier" | tr '\n' ' ' | tr -s ' ' | grep -qF "Match \`ESCALATION_AT_\` before \`STOPPED_AT_\`"; then
+    pass "parallel classifier documents match order"
+else
+    fail "parallel classifier missing match-order guidance"
+fi
+if echo "$par_classifier" | grep -qF "escalation:<category>"; then
+    pass "parallel classifier uses fail with escalation:<category>"
+else
+    fail "parallel classifier missing fail-with-category convention"
+fi
+
+# ── Summary block shows escalations distinctly ──────────────────────────────
+
+echo ""
+echo "  Summary block surfaces escalations distinctly"
+echo "  ─────────────────────────────────────────────"
+
+# The parallel summary block should include "Escalations awaiting user input"
+if grep -qF "Escalations awaiting user input" "$SKILL"; then
+    pass "summary line: Escalations awaiting user input"
+else
+    fail "summary missing: Escalations awaiting user input"
+fi
+
+# ── Sanity check: classifier match order is correct (sentinel test) ─────────
+
+echo ""
+echo "  Pattern-match sanity (real shell, not docs)"
+echo "  ──────────────────────────────────────────"
+
+# Pretend we got these return lines from sub-agents and verify the
+# classifier order produces the right routing. This is a tiny shell
+# version of what the LLM-driven classifier needs to do.
+
+classify() {
+    local line="$1"
+    # Order matters: ESCALATION_AT_ must match before STOPPED_AT_ because
+    # both contain `_AT_`. SKIPPED before ERROR is incidental.
+    case "$line" in
+        *": COMPLETE — "*)          echo "clean" ;;
+        *": ESCALATION_AT_"*" — "*) echo "escalation" ;;
+        *": SKIPPED — "*)           echo "clean" ;;
+        *": STOPPED_AT_"*" — "*)    echo "clean" ;;
+        *": ERROR — "*)             echo "clean" ;;
+        *)                          echo "parse-failed" ;;
+    esac
+}
+
+cases=(
+  "alpha--WD-01: COMPLETE — refactor clean|clean"
+  "alpha--WD-02: ESCALATION_AT_feature-plan — design-choice: codec interface?|escalation"
+  "alpha--WD-03: STOPPED_AT_feature-test — fixture missing|clean"
+  "alpha--WD-04: ERROR — feature dir already exists|clean"
+  "alpha--WD-05: SKIPPED — claim conflict|clean"
+  "garbage payload|parse-failed"
+)
+
+for tc in "${cases[@]}"; do
+    line="${tc%|*}"
+    expect="${tc##*|}"
+    got=$(classify "$line")
+    if [[ "$got" == "$expect" ]]; then
+        pass "classify: $expect ← \"${line:0:50}...\""
+    else
+        fail "classify: expected $expect got $got" "for line: $line"
+    fi
+done
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

PR A of 3 building toward the dynamic-DAG `/work-run` orchestrator. Establishes the contract that sub-agents and the parent dispatcher will both implement — self-contained and shippable on its own.

**The problem:** today, when a sub-agent in `automation_mode: autonomous` hits a situation requiring user design input (ambiguous spec, irreconcilable conflict, impossible requirement), it has no way to signal that distinctly. The kit's existing "stage escalation" path covers test-writer conflicts and refactor failures, but a true "need user input" gets funneled to `STOPPED_AT_<stage>` with the same shape as a recoverable stop. The future orchestrator (PR B) needs to route design questions to the user without confusing them with auto-recoverable stops.

## What this PR ships

**A formal escalation contract** (new section in `skills/work-start/SKILL.md`):

| Category | When |
|----------|------|
| `design-choice` | Spec/ADR ambiguous; multiple valid implementations |
| `missing-context` | Referenced concept doesn't resolve; sub-agent searched and found nothing |
| `spec-conflict` | Two specs contradict on a point the current stage needs |
| `impossible` | Requirement physically can't be satisfied |
| `other` | Escape hatch |

When a sub-agent triggers a user-required escalation:
1. Writes `.feature/<slug>/escalation.json` (schema_version, feature_slug, wd_id, group_slug, raised_at, blocking_stage, category, question, context + optional context_refs/options)
2. Appends `user-escalation — <category>: <question>` to cycle-log.md
3. Sets `status.md` substage → `awaiting-user-input`
4. Returns `<slug>: ESCALATION_AT_<stage> — <category>: <question>`

**5-way classifier** in both sequential `all` and `--parallel` modes (escalation / clean / payload-lost / user-stopped / parse-failed). Match order: `ESCALATION_AT_` before `STOPPED_AT_` since both share the `_AT_<stage>` shape. Escalations use `dispatch-marker fail escalation:<category>` (not `ack`) — the WD is paused, not complete.

**Post-run summary** surfaces escalations distinctly:
```
Escalations awaiting user input: 1
  WD-04 (design-choice) — "Use sealed permit or interface for codec?"
       .feature/<group>--WD-04/escalation.json
```

## What's NOT in this PR (saved for B/C, scoped intentionally)

- Orchestrator state machine + dispatch queue + dynamic re-dispatch (PR B)
- `/work-run` skill + AskUserQuestion-on-escalation UX (PR C)
- `/work-resume` escalation-aware routing — today the existing "stuck WD" path catches them via the fail-with-escalation marker; it just doesn't render the structured question yet (PR B/C)
- `/feature-*` skill changes — the sub-agent (outer Claude running the pipeline) handles escalation translation at the dispatcher level, so individual feature skills need no changes

## Backwards compatibility

The 4-way → 5-way classifier extension only adds a 5th case; existing `COMPLETE`, `STOPPED_AT_`, `ERROR`, `SKIPPED` return shapes route identically. Sub-agents that don't know about the contract continue working — they just never produce `ESCALATION_AT_` returns. No `MANIFEST` / `install.sh` / `scripts/` changes.

## Tests

- `tests/scenario-work-start-escalation.sh` — **40 checks** covering contract documentation, schema fields, sub-agent prompt instructions, classifier match-order, summary format, plus a real shell pattern-match sanity test (verifies ESCALATION_AT_ classifies before STOPPED_AT_)
- `tests/scenario-work-start-parallel.sh` — 21/21 (no regressions)
- `tests/test-install.sh` — 74/74 (no regressions)

## Test plan

- [x] All 40 contract checks pass
- [x] No regression in 21/21 parallel-mode tests
- [x] No regression in 74/74 install tests
- [x] Adversarial pass: classifier ordering, schema completeness, substage naming, backwards-compat, /work-resume's existing stuck-WD path covers escalation markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)