### PR TITLE
fix(work-start): --nested flag prevents nested-Agent dispatch failure

### DIFF
--- a/skills/feature-coordinate/SKILL.md
+++ b/skills/feature-coordinate/SKILL.md
@@ -15,6 +15,32 @@ is `balanced` or `speed`.
 
 Read `.feature/<slug>/status.md`.
 
+- **Nested-dispatch guard (CRITICAL — refuse to run inside a dispatched
+  sub-agent).** If status.md contains `nested_in_dispatch: true`, this
+  skill was invoked inside a `/work-start --nested` / `/work-run`
+  dispatched sub-agent. The dispatched-sub-agent context cannot itself
+  issue Agent tool calls, so this skill's work-unit parallel batches
+  would fail at runtime. The orchestrator already provides parallelism
+  at the WD level. Refuse to run:
+  ```
+  🔀 COORDINATOR · <slug>
+  ───────────────────────────────────────────────
+  ERROR: This feature was dispatched as a sub-agent of /work-start or
+  /work-run (status.md has nested_in_dispatch: true). /feature-coordinate
+  cannot run inside a dispatched sub-agent — nested Agent tool calls are
+  not supported, and the orchestrator is already providing parallelism
+  at the WD level.
+
+  /feature-plan should have forced execution_strategy: cost on this
+  feature before reaching this skill. If you're seeing this error, the
+  upstream /feature-plan invocation didn't honor nested_in_dispatch.
+  Inspect status.md and update execution_strategy to cost manually,
+  then run /feature-test "<slug>" --unit WU-1 to start sequential
+  work-unit execution.
+  ───────────────────────────────────────────────
+  ```
+  Stop with exit 1.
+
 - Verify `execution_strategy` is `balanced` or `speed`. If it is `cost` or `not-set`:
   ```
   🔀 COORDINATOR · <slug>

--- a/skills/feature-plan/SKILL.md
+++ b/skills/feature-plan/SKILL.md
@@ -709,7 +709,28 @@ Manual mode. I'll prompt you at each stage boundary.
 
 ### Step 4b — Start test writing or coordinator
 
-**If `execution_strategy` is `balanced` or `speed`:**
+**First — check for nested-dispatch context.** Read `status.md`. If it
+contains `nested_in_dispatch: true` (set by `/work-start --nested`
+when this feature was dispatched as part of `/work-start all`,
+`/work-start --parallel`, or `/work-run`), force
+`execution_strategy: cost` regardless of any prior setting. The
+dispatched sub-agent context cannot dispatch nested Agent tool
+calls, so `/feature-coordinate`'s parallel batching would fail at
+runtime. The orchestrator already provides parallelism at the WD
+level — sequential work-unit execution inside each WD is correct.
+
+If `nested_in_dispatch` is true AND the existing `execution_strategy`
+in status.md is `balanced` or `speed`, overwrite it to `cost` and
+append a brief note to `cycle-log.md`:
+
+```
+- <iso-now> execution-strategy-forced — was: <prior>, now: cost (nested_in_dispatch)
+```
+
+Then fall through to the `cost` branch below.
+
+**If `execution_strategy` is `balanced` or `speed`** (and
+`nested_in_dispatch` is NOT true):
 
 ```
 ───────────────────────────────────────────────
@@ -719,7 +740,8 @@ Run /feature-resume "<slug>" at any point to see batch status.
 ```
 Invoke `/feature-coordinate "<slug>"` as a sub-agent immediately.
 
-**If `execution_strategy` is `cost` (or not set):**
+**If `execution_strategy` is `cost` (or not set, or forced from
+`nested_in_dispatch`):**
 
 If work units are defined:
 ```

--- a/skills/work-run/SKILL.md
+++ b/skills/work-run/SKILL.md
@@ -437,12 +437,17 @@ For each WD in `READY` (one per line):
    ```
    You are the dynamic pipeline runner for <feature-slug>.
 
-   Invoke /work-start "<group-slug>" <wd-id> — it will detect that
-   the WD is already IMPLEMENTING (orchestrator set this), create
+   Invoke /work-start "<group-slug>" <wd-id> --nested — the --nested
+   flag tells /work-start to write nested_in_dispatch: true +
+   execution_strategy: cost into status.md (because nested sub-agent
+   contexts cannot dispatch /feature-coordinate's parallel batches).
+   /work-start will then claim the WD via work-claim.sh, create
    the feature directory at .feature/<feature-slug>/ if not present,
    and run the single-WD pipeline (/feature-plan → /feature-test →
    /feature-implement → /feature-refactor → /feature-pr) in
-   automation_mode autonomous.
+   automation_mode autonomous with execution_strategy cost (sequential
+   work-unit execution — the orchestrator provides parallelism at
+   the WD level).
 
    <If escalation-resolved.md exists, insert here verbatim:>
    ── Prior escalation resolution ──

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -1,9 +1,9 @@
 ---
 description: "Start implementing a specified work definition — implementation pipeline only"
-argument-hint: "<group-slug> [WD-nn | next | all | --parallel [N]]"
+argument-hint: "<group-slug> [WD-nn | next | all | --parallel [N]] [--nested]"
 ---
 
-# /work-start "<group-slug>" [WD-nn | next | all | --parallel [N]]
+# /work-start "<group-slug>" [WD-nn | next | all | --parallel [N]] [--nested]
 
 Bridges a work definition from a work group into the implementation pipeline.
 Creates a `.feature/` directory and hands off to planning, testing, and
@@ -240,6 +240,32 @@ pipeline_mode: implementation
 
 Set stage = `planning`, substage = `loading-context`.
 
+**If `--nested` was passed** (this single-WD invocation is being driven
+by `/work-start all`, `/work-start --parallel`, or `/work-run` — i.e.,
+this whole `/work-start` is itself running inside a dispatched
+sub-agent), add these additional fields:
+
+```yaml
+nested_in_dispatch: true
+execution_strategy: cost
+```
+
+**Why:** the dispatched-sub-agent context cannot itself dispatch
+nested Agent tool calls — `/feature-coordinate` (which `/feature-plan`
+would otherwise invoke for balanced/speed strategies) needs Agent
+dispatch for its work-unit parallel batches. Inside an already-
+dispatched sub-agent, that nested dispatch fails at runtime. The
+orchestrator already provides parallelism at the WD level (multiple
+sub-agents running concurrently); within each WD, sequential
+execution is correct.
+
+`/feature-plan` honors `nested_in_dispatch: true` by forcing
+`execution_strategy: cost` and routing directly to
+`/feature-test --unit WU-1` (or sequential single-WU flow) rather
+than invoking `/feature-coordinate`. `/feature-coordinate` has a
+defensive guard in its Step 0 that errors out if invoked with this
+flag set.
+
 Stage Completion table — implementation stages only:
 
 | Stage | Status |
@@ -327,8 +353,11 @@ mode-gating in pipeline skills.
   — see Parallel mode caveats.
 
 Both modes use `automation_mode: autonomous` and
-`execution_strategy: balanced` for the dispatched sub-agents (set by
-the single-WD flow at Step 4c). Routine choices auto-default;
+`execution_strategy: cost` for the dispatched sub-agents (set by the
+single-WD flow at Step 4c via the `--nested` flag; nested sub-agents
+cannot dispatch nested Agent calls so `/feature-coordinate`'s parallel
+batching can't run inside them, and the parallelism is already provided
+at the WD level by this skill). Routine choices auto-default;
 escalations surface to the user.
 
 ### Sequential-all flow
@@ -403,11 +432,13 @@ Replace Steps 3–5 with this block when `all` is the argument.
       You are the sequential pipeline runner for <group-slug> /
       <wd-id>.
 
-      Invoke /work-start "<group-slug>" <wd-id>. The single-WD flow
-      will create the feature directory, claim the WD via
-      work-claim.sh (SPECIFIED → IMPLEMENTING), and hand off to
-      /feature-plan → /feature-test → /feature-implement →
-      /feature-refactor → /feature-pr.
+      Invoke /work-start "<group-slug>" <wd-id> --nested. The single-WD
+      flow will create the feature directory with nested_in_dispatch:
+      true + execution_strategy: cost in status.md (because nested
+      dispatch can't invoke /feature-coordinate — see /work-start's
+      4c section), claim the WD via work-claim.sh (SPECIFIED →
+      IMPLEMENTING), and hand off to /feature-plan → /feature-test →
+      /feature-implement → /feature-refactor → /feature-pr.
 
       Treat automation_mode as autonomous. Do not pause between
       pipeline stages. If a stage hits a TECHNICAL escalation (test
@@ -627,11 +658,15 @@ Replace Steps 3–5 with this block when `--parallel` is set.
    - "Stop — I'll start them manually"
 
 4. **Create feature directories (all WDs, sequential).** For each
-   dispatched WD, run Step 4 from the single-WD path in full: generate
-   `brief.md`, verify readiness, write `status.md`, update the WD's
-   status to `IMPLEMENTING`. Do this sequentially — these operations
-   touch the `.work/` tree and are fast. Fanning out here adds no
-   measurable benefit and risks racing on `manifest.md` regeneration.
+   dispatched WD, run Step 4 from the single-WD path in full **treating
+   `--nested` as set** (the dispatched sub-agent cannot itself dispatch
+   `/feature-coordinate`; status.md must carry `nested_in_dispatch:
+   true` + `execution_strategy: cost` so `/feature-plan` routes
+   sequentially): generate `brief.md`, verify readiness, write
+   `status.md` with the nested fields per 4c, update the WD's status
+   to `IMPLEMENTING`. Do this sequentially — these operations touch
+   the `.work/` tree and are fast. Fanning out here adds no measurable
+   benefit and risks racing on `manifest.md` regeneration.
 
 5. **Dispatch sub-agents concurrently.** First, write a dispatch
    marker for every WD that's about to be dispatched (so a payload-

--- a/tests/scenario-nested-dispatch.sh
+++ b/tests/scenario-nested-dispatch.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Scenario: --nested flag prevents /feature-coordinate from running inside
+# a /work-start or /work-run dispatched sub-agent.
+#
+# Background. The user hit a real bug on jlsm: /work-start dispatched a
+# sub-agent that ran /feature-plan, which (because the WD's
+# execution_strategy was balanced) invoked /feature-coordinate, which
+# tried to dispatch its own work-unit sub-agents via Agent. Nested Agent
+# dispatch isn't supported in dispatched sub-agent contexts, so the
+# pipeline broke.
+#
+# Fix: /work-start grows a --nested flag. When set, Step 4c writes
+# nested_in_dispatch: true + execution_strategy: cost into status.md.
+# /feature-plan honors the flag by forcing execution_strategy: cost
+# (bypassing /feature-coordinate). /feature-coordinate has a defensive
+# Step 0 guard that errors if invoked with the flag set.
+#
+# This is a contract-validation test — SKILL.md text + flag wiring.
+# Runtime LLM behavior is out of scope.
+#
+# Run from repo root: bash tests/scenario-nested-dispatch.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+WORK_START="$REPO_ROOT/skills/work-start/SKILL.md"
+WORK_RUN="$REPO_ROOT/skills/work-run/SKILL.md"
+FEATURE_PLAN="$REPO_ROOT/skills/feature-plan/SKILL.md"
+FEATURE_COORDINATE="$REPO_ROOT/skills/feature-coordinate/SKILL.md"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+echo ""
+echo "scenario: --nested dispatch flag"
+echo "────────────────────────────────────────────────"
+
+# ── /work-start advertises --nested in argument-hint + header ───────────────
+
+echo ""
+echo "  /work-start exposes --nested"
+echo "  ───────────────────────────"
+
+if grep -qE -- '^argument-hint:.*--nested' "$WORK_START"; then
+    pass "argument-hint lists --nested"
+else
+    fail "--nested missing from argument-hint"
+fi
+
+if grep -qE -- '^# /work-start.*--nested' "$WORK_START"; then
+    pass "usage header lists --nested"
+else
+    fail "usage header missing --nested"
+fi
+
+# ── Step 4c documents the --nested status.md fields ─────────────────────────
+
+echo ""
+echo "  Step 4c writes nested_in_dispatch + execution_strategy"
+echo "  ────────────────────────────────────────────────────"
+
+step4c=$(awk '/^### 4c — Write status.md/,/^### 4d/' "$WORK_START")
+
+if echo "$step4c" | grep -qF -- "--nested"; then
+    pass "Step 4c references --nested flag"
+else
+    fail "Step 4c missing --nested handling"
+fi
+
+if echo "$step4c" | grep -qF "nested_in_dispatch: true"; then
+    pass "Step 4c writes nested_in_dispatch: true"
+else
+    fail "Step 4c missing nested_in_dispatch field"
+fi
+
+if echo "$step4c" | grep -qF "execution_strategy: cost"; then
+    pass "Step 4c forces execution_strategy: cost when nested"
+else
+    fail "Step 4c missing execution_strategy: cost"
+fi
+
+# Why-section reasoning must be documented (so future readers don't remove it)
+if echo "$step4c" | grep -qiE "nested.*Agent.*call|cannot.*dispatch|nested.*sub-agent"; then
+    pass "Step 4c explains why nesting fails"
+else
+    fail "Step 4c missing the explanation of WHY"
+fi
+
+# ── Sequential `all` mode sub-agent prompt uses --nested ────────────────────
+
+echo ""
+echo "  Sequential all-mode sub-agent prompt passes --nested"
+echo "  ──────────────────────────────────────────────────"
+
+seq_prompt=$(awk '/sequential pipeline runner/,/parses this string/' "$WORK_START")
+if echo "$seq_prompt" | grep -qF -- "--nested"; then
+    pass "sequential sub-agent prompt invokes /work-start with --nested"
+else
+    fail "sequential prompt missing --nested"
+fi
+
+# ── Parallel-mode Step 4 treats --nested as set ────────────────────────────
+
+echo ""
+echo "  Parallel mode parent Step 4 treats --nested as set"
+echo "  ────────────────────────────────────────────────"
+
+# The parallel-mode parent runs single-WD Step 4 directly (not via Agent).
+# It must explicitly include the --nested fields.
+parallel_section=$(awk '/^### Parallel-mode flow|^## Parallel mode/,/^## /' "$WORK_START")
+if echo "$parallel_section" | tr '\n' ' ' | tr -s ' ' | grep -qiE "treating .--nested. as set|--nested.*set"; then
+    pass "parallel-mode Step 4 says to treat --nested as set"
+else
+    fail "parallel-mode doesn't enforce --nested fields"
+fi
+
+# ── The execution_strategy comment in the choosing-mode table ──────────────
+
+echo ""
+echo "  Mode-comparison note reflects execution_strategy: cost"
+echo "  ────────────────────────────────────────────────────"
+
+if grep -qE "execution_strategy: cost.*dispatched|cost.*for the dispatched" "$WORK_START"; then
+    pass "/work-start documents execution_strategy: cost for dispatched"
+else
+    fail "/work-start still says balanced for dispatched (stale)"
+fi
+
+if grep -qF "balanced" "$WORK_START" && grep -qF "for the dispatched sub-agents" "$WORK_START" && grep -qE "execution_strategy: balanced.*dispatched" "$WORK_START"; then
+    fail "/work-start still describes execution_strategy: balanced for dispatched"
+else
+    pass "no stale 'execution_strategy: balanced for dispatched' claim"
+fi
+
+# ── /work-run dispatch prompt uses --nested ────────────────────────────────
+
+echo ""
+echo "  /work-run dispatch prompt uses --nested"
+echo "  ──────────────────────────────────────"
+
+if grep -qF -- "--nested" "$WORK_RUN"; then
+    pass "/work-run references --nested"
+else
+    fail "/work-run missing --nested"
+fi
+
+# Extract the sub-agent prompt block from /work-run (around line 440)
+run_prompt=$(awk '/dynamic pipeline runner/,/^   \`\`\`$/' "$WORK_RUN")
+if echo "$run_prompt" | grep -qF -- "--nested"; then
+    pass "/work-run sub-agent prompt invokes /work-start --nested"
+else
+    fail "/work-run dispatch prompt missing --nested"
+fi
+
+# ── /feature-plan honors nested_in_dispatch ────────────────────────────────
+
+echo ""
+echo "  /feature-plan honors nested_in_dispatch"
+echo "  ──────────────────────────────────────"
+
+# Step 4b is the routing decision (coordinator vs sequential)
+step4b=$(awk '/^### Step 4b/,/^### Step 4c|^## Step 5|^### Step 5/' "$FEATURE_PLAN")
+
+if echo "$step4b" | grep -qF "nested_in_dispatch"; then
+    pass "Step 4b checks nested_in_dispatch field"
+else
+    fail "Step 4b doesn't read nested_in_dispatch"
+fi
+
+if echo "$step4b" | grep -qiE "force execution_strategy|forced from|overwrite.*execution_strategy"; then
+    pass "Step 4b forces execution_strategy: cost when nested"
+else
+    fail "Step 4b doesn't force cost-mode when nested"
+fi
+
+# Must NOT invoke /feature-coordinate when nested. The text path for nested
+# should fall through to the cost branch.
+if echo "$step4b" | tr '\n' ' ' | tr -s ' ' | grep -qiE "nested.*cost.*branch|fall through to the .cost. branch|forced from .nested"; then
+    pass "Step 4b routes nested case to cost branch (skips coordinator)"
+else
+    fail "Step 4b doesn't route nested case away from coordinator"
+fi
+
+# ── /feature-coordinate defensive guard ────────────────────────────────────
+
+echo ""
+echo "  /feature-coordinate refuses to run when nested"
+echo "  ────────────────────────────────────────────"
+
+step0=$(awk '/^## Step 0 — Pre-flight/,/^## Step 0a|^## Step 1/' "$FEATURE_COORDINATE")
+
+if echo "$step0" | grep -qF "nested_in_dispatch"; then
+    pass "Step 0 checks nested_in_dispatch"
+else
+    fail "Step 0 missing nested_in_dispatch guard"
+fi
+
+if echo "$step0" | grep -qiE "cannot run inside.*dispatched|refuse to run|nested-dispatch guard"; then
+    pass "Step 0 explicitly refuses to run when nested"
+else
+    fail "Step 0 missing refuse-to-run message"
+fi
+
+if echo "$step0" | grep -qE 'exit 1|Stop with exit 1'; then
+    pass "Step 0 nested guard exits non-zero"
+else
+    fail "Step 0 nested guard doesn't exit non-zero"
+fi
+
+# Defensive guard must come BEFORE the existing execution_strategy check,
+# so a misconfigured status.md still fails the right way.
+nested_line=$(echo "$step0" | grep -n "nested_in_dispatch" | head -1 | cut -d: -f1)
+strategy_line=$(echo "$step0" | grep -n "Verify .execution_strategy. is .balanced. or .speed" | head -1 | cut -d: -f1)
+if [[ -n "$nested_line" && -n "$strategy_line" && "$nested_line" -lt "$strategy_line" ]]; then
+    pass "nested guard runs before execution_strategy check"
+else
+    fail "nested guard should be first" "nested=$nested_line strategy=$strategy_line"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Real bug you hit on jlsm: `/work-start` dispatched a sub-agent that ran the feature pipeline. `/feature-plan`, seeing `execution_strategy=balanced`, invoked `/feature-coordinate`, which tried to dispatch its own work-unit sub-agents via the `Agent` tool. Nested `Agent` dispatch isn't supported in dispatched sub-agent contexts, so the pipeline broke.

## Fix shape

`/work-start` grows a `--nested` flag. When set:
- Step 4c writes `nested_in_dispatch: true` + `execution_strategy: cost` into `status.md`, with a comment explaining why.

All three dispatchers pass `--nested` through to the inner `/work-start`:
- `/work-start all` (sequential dispatcher) — sub-agent prompt updated
- `/work-start --parallel` (parent runs Step 4 directly) — Step 4 says "treat `--nested` as set"
- `/work-run` — sub-agent prompt updated

Downstream:
- `/feature-plan` Step 4b checks `nested_in_dispatch`. If true, forces `execution_strategy=cost` and routes directly to `/feature-test --unit` (bypassing `/feature-coordinate`).
- `/feature-coordinate` Step 0 has a defensive guard: refuses to run if `nested_in_dispatch=true` with a clear error message.

## Why this shape

The orchestrator (`/work-start --parallel` and `/work-run`) already provides parallelism at the WD level — multiple sub-agents running concurrently. Inside each WD, sequential work-unit execution is correct; parallelizing again inside an already-parallel WD is unnecessary AND breaks at runtime due to nested-Agent restrictions.

## Tests

`tests/scenario-nested-dispatch.sh` — **19 contract checks**:
- `/work-start` exposes `--nested` in argument-hint + usage header
- Step 4c writes `nested_in_dispatch` + `execution_strategy: cost`
- Sequential and parallel modes wire `--nested` correctly
- `/work-run` dispatch prompt invokes with `--nested`
- `/feature-plan` reads `nested_in_dispatch` and forces cost mode
- `/feature-coordinate` refuses to run when nested (Step 0 guard, exits non-zero, runs BEFORE the existing execution_strategy check)

No regressions:
- `scenario-work-start-parallel`: 21/21
- `scenario-work-start-escalation`: 40/40
- `scenario-work-run`: 64/64
- `test-install`: 74/74

🤖 Generated with [Claude Code](https://claude.com/claude-code)