### PR TITLE
fix: 5 CRITICAL bugs from adversarial sweep (curate rotation, work-validate enum, obligations schema, FQ R-id, no-op summary)

### DIFF
--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -77,6 +77,30 @@ SINCE_DATE="$(date -d "-${WINDOW_MONTHS} months" +%Y-%m-%d 2>/dev/null || date -
 
 if [[ -n "$LAST_SHA" && "$LAST_SHA" == "$CURRENT_SHA" ]]; then
     echo "No new commits since last scan." >&2
+    # CRIT 5 (2026-05-11 adversarial). Overwrite scan-summary.md with a
+    # distinct no-op marker so Step 1.1's sentinel check + downstream
+    # readers can tell "scan was a no-op" apart from "scan completed
+    # with findings." Previously, this exit path left the PRIOR scan's
+    # summary on disk with its still-valid sentinel — /curate would
+    # consume days-old findings as if fresh.
+    SUMMARY_FILE="${SUMMARY_FILE:-$CURATE_DIR/scan-summary.md}"
+    mkdir -p "$(dirname "$SUMMARY_FILE")" 2>/dev/null || true
+    cat > "$SUMMARY_FILE" <<EOF
+# Curation Scan Summary
+
+Scan date: $(date +%Y-%m-%d)
+Scan mode: no-op
+Current HEAD: $CURRENT_SHA
+Last scanned HEAD: $LAST_SHA
+
+_No new commits since last scan. The prior findings (if any) have been
+addressed or aged out; re-run with \`--init\` to force a fresh scan
+against the full window._
+
+---
+
+✓ Scan complete: $(date -u +"%Y-%m-%dT%H:%M:%SZ") · no-op · current_head=$CURRENT_SHA
+EOF
     exit 0
 fi
 
@@ -133,6 +157,27 @@ COMMIT_COUNT="$(grep -cE '^[0-9a-f]{40}$' "$TMPDIR_SCAN/raw-log.txt" 2>/dev/null
 
 if [[ "$COMMIT_COUNT" -eq 0 ]]; then
     echo "No commits found in scan range." >&2
+    # CRIT 5 (2026-05-11 adversarial). Same no-op overwrite as the
+    # LAST_SHA==CURRENT_SHA path above — see that block for rationale.
+    SUMMARY_FILE="${SUMMARY_FILE:-$CURATE_DIR/scan-summary.md}"
+    mkdir -p "$(dirname "$SUMMARY_FILE")" 2>/dev/null || true
+    cat > "$SUMMARY_FILE" <<EOF
+# Curation Scan Summary
+
+Scan date: $(date +%Y-%m-%d)
+Scan mode: no-op
+Current HEAD: $CURRENT_SHA
+Window: ${WINDOW_MONTHS} months
+Commits scanned: 0
+
+_No commits found in the scan window. Either the window is too narrow
+or the repo has no qualifying activity. Re-run with a wider
+\`--window-months\` value or check that \`git log\` returns commits._
+
+---
+
+✓ Scan complete: $(date -u +"%Y-%m-%dT%H:%M:%SZ") · no-op · current_head=$CURRENT_SHA · commits=0
+EOF
     exit 0
 fi
 

--- a/scripts/index-verify.sh
+++ b/scripts/index-verify.sh
@@ -222,10 +222,42 @@ if [[ "$CHECK_DECISIONS" == "1" && -d ".decisions" && -f ".decisions/CLAUDE.md" 
                 mapfile -t row_nums < <(awk -v s="$sep_line" -v e="$ra_end" 'NR>s && NR<=e && /^\| / {print NR}' '.decisions/CLAUDE.md')
                 total="${#row_nums[@]}"
                 if (( total > keep )); then
+                    # Sort the rows by accepted-date column (4th pipe field)
+                    # descending before trimming. Without this, the overflow
+                    # archives bottom-N rows assuming they're oldest — but
+                    # auto-repair inserts missing rows on top in filesystem
+                    # order, and pre-existing rows live wherever they were
+                    # written. Document order ≠ date order. The 2026-05-10
+                    # jlsm bug: /curate rotated newer 2026-04-26 ADRs out
+                    # and pulled older 2026-03-19 ADRs in. Sorting first
+                    # makes the invariant explicit (date-desc) so the
+                    # bottom-N overflow really does pick the oldest.
+                    first_row="${row_nums[0]}"
+                    last_row="${row_nums[$((total - 1))]}"
+                    sorted_rows="$(sed -n "${first_row},${last_row}p" '.decisions/CLAUDE.md' \
+                        | awk -F'|' '{
+                            d=$4
+                            gsub(/^[[:space:]]+|[[:space:]]+$/, "", d)
+                            printf "%s\t%s\n", d, $0
+                          }' \
+                        | sort -t$'\t' -k1,1 -r \
+                        | cut -f2-)"
+                    # Rebuild file with sorted rows replacing the original block.
+                    {
+                        sed -n "1,$((first_row - 1))p" '.decisions/CLAUDE.md'
+                        printf '%s\n' "$sorted_rows"
+                        sed -n "$((last_row + 1)),\$p" '.decisions/CLAUDE.md'
+                    } > '.decisions/CLAUDE.md.tmp' && mv '.decisions/CLAUDE.md.tmp' '.decisions/CLAUDE.md'
+
+                    # Re-read row positions after the rewrite (line numbers
+                    # haven't shifted because we wrote the same number of rows,
+                    # but be defensive).
+                    mapfile -t row_nums < <(awk -v s="$sep_line" -v e="$ra_end" 'NR>s && NR<=e && /^\| / {print NR}' '.decisions/CLAUDE.md')
+                    total="${#row_nums[@]}"
+
                     overflow_count=$(( total - keep ))
-                    # Rows are stored newest-first (auto-repair inserts right
-                    # after the separator). Overflow the LAST `overflow_count`
-                    # rows = oldest by insertion order.
+                    # Rows are now in date-desc order. Overflow the LAST
+                    # `overflow_count` rows = oldest by accepted-date.
                     first_overflow_idx=$(( total - overflow_count ))
                     first_line="${row_nums[$first_overflow_idx]}"
                     last_line="${row_nums[$((total - 1))]}"

--- a/scripts/work-validate.sh
+++ b/scripts/work-validate.sh
@@ -69,11 +69,17 @@ validate_wd_file() {
       [[ -z "$val" ]] && errors+=("Missing required field: $field")
     done
 
-    # Check 3: status is valid enum
+    # Check 3: status is valid enum.
+    # MUST include every state work-resolve.sh can produce, or re-running
+    # /work-decompose on a group with any in-flight WD wedges at this
+    # check. SPECIFYING and IMPLEMENTING are produced by work-resolve.sh;
+    # IN_PROGRESS is the legacy alias for IMPLEMENTING. 2026-05-11
+    # adversarial finding: missing enum entries silently rejected valid
+    # in-flight WDs.
     local status
     status=$(work_fm "$file" "status")
-    if [[ -n "$status" && ! "$status" =~ ^(DRAFT|SPECIFIED|READY|IN_PROGRESS|COMPLETE|BLOCKED)$ ]]; then
-      errors+=("Invalid status: '$status' — must be DRAFT|SPECIFIED|READY|IN_PROGRESS|COMPLETE|BLOCKED")
+    if [[ -n "$status" && ! "$status" =~ ^(DRAFT|SPECIFYING|SPECIFIED|READY|IMPLEMENTING|IN_PROGRESS|COMPLETE|BLOCKED)$ ]]; then
+      errors+=("Invalid status: '$status' — must be DRAFT|SPECIFYING|SPECIFIED|READY|IMPLEMENTING|IN_PROGRESS|COMPLETE|BLOCKED")
     fi
 
     # Check 4: domains is non-empty

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -230,6 +230,32 @@ line so they see the scope of what ran:
 Scan complete: <date> · traced <M>/<approved-count> specs · window <W>m
 ```
 
+**No-op scan detection** (CRIT 5, 2026-05-11 adversarial). When the
+scan script exits "No new commits since last scan" or "No commits
+found in scan range," it overwrites scan-summary.md with a `no-op`
+marker — the sentinel includes the literal substring `· no-op ·`.
+Detect this:
+
+```bash
+if tail -1 .curate/scan-summary.md | grep -q "· no-op ·"; then
+    # No-op scan — prior findings already addressed or no qualifying
+    # activity in window. Do NOT proceed into Step 2 with the prior
+    # summary as if it were fresh.
+fi
+```
+
+If detected, surface to the user via AskUserQuestion:
+
+- **"Force a fresh scan (`--init`)"** — re-runs against the full window
+  regardless of `LAST_SHA`.
+- **"Expand the window (`--window-months N`)"** — useful when commit
+  activity falls outside the default window.
+- **"Stop — nothing to curate right now"** — exit cleanly.
+
+Without this check, prior findings (potentially days/weeks old) get
+re-presented as if they were just discovered — confusing the user and
+re-surfacing already-resolved drift.
+
 If `specs_traced=0` in the sentinel AND APPROVED specs exist in the
 manifest, note that the annotation-coverage rollup (Analysis 18b) and
 the per-spec annotation gap analyses (Analysis 18) did not run for

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -62,8 +62,22 @@ Run the trace primitive in `--uncovered` mode:
 bash .claude/scripts/spec-trace.sh --uncovered <spec-id>
 ```
 
-Output is a parseable list, one R-id per line on stdout (e.g.
-`auth.token-validation.R3`); a count summary is on stderr.
+Output is a parseable list, one **fully-qualified R-id** per line on
+stdout (e.g. `auth.token-validation.R3`); a count summary is on stderr.
+
+**Important — strip the `<spec-id>.` prefix before passing to downstream
+scripts.** `spec-backfill-candidates.sh` and `spec-backfill-log.sh`
+both expect **bare R-ids** (e.g. `R3`), not fully-qualified ones. Pass
+the FQ form and the candidate finder errors with "Requirement '...' not
+found"; the log helpers' `has-decision` key never matches an annotated
+row. The 2026-05-11 adversarial finding (CRIT 4) confirmed this caused
+Phase 1's terminal-decision filter to silently no-op, re-walking
+already-annotated requirements.
+
+For each FQ R-id captured (e.g. `auth.token-validation.R3`), compute
+the bare form via shell expansion: `r_id="${fq_rid##*.}"` (yields
+`R3`). Use `r_id` for ALL subsequent `spec-backfill-candidates.sh` /
+`spec-backfill-log.sh` invocations.
 
 If output is empty: tell the user "spec is fully annotated — nothing to
 backfill" and stop.
@@ -71,9 +85,9 @@ backfill" and stop.
 If non-empty: capture the list and the count. Read `.spec/backfill-log.md`
 (initialize with `bash .claude/scripts/spec-backfill-log.sh init
 .spec/backfill-log.md` if it does not exist) and filter the list down to
-R-ids that do NOT yet have a terminal decision (`annotated` or `waived`).
-`skipped` rows from prior runs are NOT terminal — those resurface by
-design.
+R-ids (bare form) that do NOT yet have a terminal decision (`annotated`
+or `waived`). `skipped` rows from prior runs are NOT terminal — those
+resurface by design.
 
 Tell the user the plan in one or two sentences:
 
@@ -330,14 +344,23 @@ You are the discover + propose stage for /spec-backfill <spec-id>.
 
 Run, in order:
   1. bash .claude/scripts/spec-trace.sh --uncovered <spec-id>
+     This emits FULLY-QUALIFIED R-ids (e.g., `auth.foo.R3`).
   2. For each uncovered R-id (cap at 12 — surface "more remain" in
-     output if there are more): extract the requirement text from the
-     spec file under ## Requirements; run
-     bash .claude/scripts/spec-backfill-candidates.sh <spec-id> <r-id>
-     and capture the top 5 candidates.
-  3. Read .spec/backfill-log.md if it exists; mark R-ids that already
-     have a terminal decision (annotated | waived) as "already_decided"
-     so the coordinator can skip them.
+     output if there are more):
+     - Strip the spec-id prefix to get the bare R-id:
+       r_id="${fq_rid##*.}" (e.g., `auth.foo.R3` → `R3`).
+       spec-backfill-candidates.sh and spec-backfill-log.sh both
+       require BARE R-ids; passing the FQ form errors. (CRIT 4,
+       2026-05-11 adversarial.)
+     - Extract the requirement text from the spec file under
+       ## Requirements (match `^<r_id>[a-z]*(-…)?\.`).
+     - Run `bash .claude/scripts/spec-backfill-candidates.sh <spec-id>
+       <r_id>` (bare) and capture the top 5 candidates.
+  3. Read .spec/backfill-log.md if it exists; for each bare R-id, run
+     `bash .claude/scripts/spec-backfill-log.sh has-decision
+     .spec/backfill-log.md <spec-id> <r_id>`; mark R-ids whose
+     has-decision returns `annotated|waived` as "already_decided" so
+     the coordinator can skip them.
 
 Return EXACTLY ONE LINE — a JSON object — matching this shape:
 

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -156,13 +156,36 @@ If `--from-obligations` is present, skip Steps 1-4 and use this flow instead.
 
 ### OB-1 — Read and filter obligations
 
-Read `.spec/registry/_obligations.json`. Filter to open obligations only
-(`status == "open"`).
+Read `.spec/registry/_obligations.json`. The schema (verified against
+`scripts/spec-resolve.sh` lines 345-355 and
+`scripts/spec-obligations-gc.sh` lines 39-52) is:
+
+```json
+{
+  "obligations": [
+    {
+      "id": "OBL-...",
+      "target_feature": "<spec-id>",
+      "domains": ["<domain>", ...],
+      "description": "<free text>",
+      "status": "open" | "resolved" | ...
+    }
+  ]
+}
+```
+
+There is NO `spec`, `affects`, or `blocked_by` field — earlier drafts of
+this SKILL referenced fields that the producer never writes, so the
+filter and decomposition silently produced zero results (2026-05-11
+adversarial finding, CRIT 3).
+
+Filter to open obligations only (`status == "open"`).
 
 Apply filters if provided:
-- `--spec <spec-id>` → only obligations where `spec` matches. Spec ID can be
-  legacy `FXX` (e.g., `F12`) or domain.slug (e.g., `query.full-text-index`).
-- `--domain <domain>` → only obligations where `domains` array contains the value
+- `--spec <spec-id>` → only obligations where `target_feature` matches.
+  Spec ID can be legacy `FXX` (e.g., `F12`) or domain.slug (e.g.,
+  `query.full-text-index`).
+- `--domain <domain>` → only obligations where `domains` array contains the value.
 
 If no open obligations match the filters:
 ```
@@ -174,9 +197,9 @@ Display:
 ```
 Found <N> open obligations:
 
-| # | ID | Spec | Affected Reqs | Blocked By |
-|---|-----|------|---------------|------------|
-| 1 | <id> | <spec> | <count> | <blocked_by> |
+| # | ID | Target Feature | Domains | Description |
+|---|-----|---------------|---------|-------------|
+| 1 | <id> | <target_feature> | <domains joined> | <description first line> |
 ...
 ```
 
@@ -184,23 +207,33 @@ Found <N> open obligations:
 
 Analyze the obligations and group them by natural boundaries:
 
-1. **Same blocked_by** → obligations sharing a blocker should be in the same
-   WD (they need the same prerequisite work)
-2. **Code locality** — obligations affecting the same class/module should be
-   together
-3. **Dependency ordering** — if obligation A's fix is a prerequisite for
-   obligation B's fix, A's WD must come first (use `type: wd` deps)
-4. **Size** — keep each WD at a manageable scope. Split obligations that
-   represent multi-week efforts into separate WDs.
+1. **Same `target_feature`** → obligations against the same spec usually
+   belong to the same WD (they affect the same contract surface).
+2. **Domain overlap** — obligations sharing one or more `domains` values
+   are candidates for grouping; the WD's `domains` field is the union.
+3. **Dependency ordering** — if completing obligation A's WD is a
+   prerequisite for obligation B's WD (e.g., A introduces an interface
+   B depends on), use `type: wd` artifact_deps to encode the order.
+4. **Size** — keep each WD at a manageable scope. Split when the
+   obligation set spans multi-week scope.
 
 For each proposed WD, determine:
-- **status: SPECIFIED** — specs already exist, these are implementation-only
-- **artifact_deps** — add `type: wd` deps for ordering constraints between WDs
-- **Acceptance criteria** — map from the obligation's `affects` list:
-  each affected requirement becomes a testable criterion
-- **Summary** — synthesize from the obligation `description` field
-- **Implementation notes** — include `blocked_by` context and any
-  implementation hints from the description
+- **status: SPECIFIED** — specs already exist (the obligations target
+  specs that are already APPROVED); these WDs are implementation-only.
+- **artifact_deps** — add `type: wd` deps for ordering constraints between
+  WDs, and `type: spec required_state: APPROVED` for each `target_feature`
+  the WD addresses.
+- **Acceptance criteria** — derive from the obligation's `description`
+  field: each obligation typically maps to one testable criterion that
+  closes the gap it describes. If the description names specific
+  requirements (e.g., "R12, R13 currently unenforced"), each becomes a
+  criterion.
+- **Summary** — synthesize from the obligation `description` fields,
+  grouping multiple obligations' descriptions into one coherent WD
+  narrative.
+- **Implementation notes** — copy the relevant obligation descriptions
+  verbatim; the LLM running /feature-implement will use them as the
+  authoritative source of what needs to change.
 
 ### OB-3 — Present decomposition
 

--- a/tests/scenario-curate-scan.sh
+++ b/tests/scenario-curate-scan.sh
@@ -323,6 +323,24 @@ else
     fail "should skip when HEAD matches last scan" "got: $output"
 fi
 
+# CRIT 5 (2026-05-11 adversarial): no-op exit MUST overwrite scan-summary.md
+# with a distinct no-op marker so downstream readers can't mistake a
+# stale prior summary for fresh output.
+if [[ -f "$PROJECT/.curate/scan-summary.md" ]] && \
+   tail -1 "$PROJECT/.curate/scan-summary.md" | grep -q "· no-op ·"; then
+    pass "no-op exit writes scan-summary.md with no-op sentinel"
+else
+    fail "no-op exit should overwrite scan-summary.md with no-op sentinel" \
+         "tail: $(tail -1 "$PROJECT/.curate/scan-summary.md" 2>/dev/null)"
+fi
+
+# Scan mode should be 'no-op' in the body too (for human readers).
+if grep -q "^Scan mode: no-op" "$PROJECT/.curate/scan-summary.md"; then
+    pass "no-op summary has 'Scan mode: no-op' body line"
+else
+    fail "no-op summary missing 'Scan mode: no-op' header"
+fi
+
 # ── Test 10: Incremental scan — picks up new commits ────────────────────────
 
 echo ""

--- a/tests/scenario-index-verify.sh
+++ b/tests/scenario-index-verify.sh
@@ -431,6 +431,104 @@ fi
 
 rm -rf "$OVERFLOW_DIR" 2>/dev/null || true
 
+# ── Test 9b: overflow keeps the DATE-newest rows, not document-newest ───────
+# Regression for the 2026-05-10 jlsm bug: /curate rotated newer ADRs
+# (2026-04-26 et al.) out of "Recently Accepted" and pulled older ADRs
+# (2026-03-19 et al.) in. Root cause: the overflow trimmed from the bottom
+# assuming "newest is at the top," but auto-repair inserted missing rows
+# on top in filesystem order regardless of their accepted_at date. The
+# fix sorts the section by date desc before applying the cap.
+# This test specifically arranges document-order ≠ date-order so a
+# position-trimming implementation fails while a date-sorting one passes.
+
+echo ""
+echo "── Test 9b: Recently Accepted survivors selected by DATE, not document order"
+
+ORDER_DIR="/tmp/vallorcine/scenario-overflow-order"
+rm -rf "$ORDER_DIR" 2>/dev/null || true
+mkdir -p "$ORDER_DIR/.claude/scripts" "$ORDER_DIR/.decisions"
+cp "$REPO_ROOT/scripts/index-verify.sh" "$ORDER_DIR/.claude/scripts/"
+
+# Build a CLAUDE.md where the OLDER rows appear at the TOP and NEWER rows
+# at the BOTTOM — the opposite of the "newest first" assumption the old
+# overflow logic baked in. With 90 rows + the other sections we'll hit
+# the 80-line cap and trigger overflow.
+{
+    cat << 'HEAD'
+# Architecture Decisions — Master Index
+
+## Active Decisions
+| Problem | Slug | Date | Status | Recommendation |
+|---------|------|------|--------|----------------|
+
+## Recently Accepted (last 5)
+| Problem | Slug | Accepted | Recommendation |
+|---------|------|----------|----------------|
+HEAD
+    # Rows 1..85 are OLD (2026-01-*). Rows 86..90 are the NEW ones that
+    # SHOULD survive (2026-04-*). They live at the BOTTOM of the table.
+    for n in $(seq 1 85); do
+        d=$(printf "2026-01-%02d" $((n % 28 + 1)))
+        echo "| Old $n | adr-old-$n | $d | reco old $n |"
+    done
+    for n in $(seq 1 5); do
+        d=$(printf "2026-04-%02d" $((n * 5)))
+        echo "| New $n | adr-new-$n | $d | reco new $n |"
+    done
+    cat << 'TAIL'
+
+## Deferred
+| Problem | Slug | Deferred | Resume When |
+|---------|------|----------|-------------|
+
+## Closed
+| Problem | Slug | Closed | Reason |
+|---------|------|--------|--------|
+TAIL
+} > "$ORDER_DIR/.decisions/CLAUDE.md"
+
+(cd "$ORDER_DIR" && bash .claude/scripts/index-verify.sh --decisions 2>&1) >/tmp/index-verify-order.out
+
+# All 5 "New" rows (2026-04-*) should survive in CLAUDE.md.
+new_survivors="$(grep -cE '^\| New [0-9]+ \|' "$ORDER_DIR/.decisions/CLAUDE.md" 2>/dev/null; true)"
+new_survivors="${new_survivors:-0}"
+if (( new_survivors == 5 )); then
+    pass "all 5 date-newest rows survive in CLAUDE.md (sort-by-date works)"
+else
+    fail "expected 5 'New' rows surviving, got $new_survivors" \
+         "(this is the 2026-05-10 jlsm bug shape)"
+fi
+
+# All 85 "Old" rows (2026-01-*) should be in history.md.
+old_archived="$(grep -cE '^\| Old [0-9]+ \|' "$ORDER_DIR/.decisions/history.md" 2>/dev/null; true)"
+old_archived="${old_archived:-0}"
+if (( old_archived == 85 )); then
+    pass "all 85 date-older rows archived to history.md"
+else
+    fail "expected 85 'Old' rows archived, got $old_archived"
+fi
+
+# Zero "New" rows in history.md (would mean we archived newer rows — the bug).
+new_archived="$(grep -cE '^\| New [0-9]+ \|' "$ORDER_DIR/.decisions/history.md" 2>/dev/null; true)"
+new_archived="${new_archived:-0}"
+if (( new_archived == 0 )); then
+    pass "zero 'New' rows leaked into history (no inversion bug)"
+else
+    fail "$new_archived 'New' rows got archived (date-newer should never be archived)"
+fi
+
+# Sanity: the surviving 5 rows should be ordered date-desc (newest at top).
+# The fixture has New 1..5 with dates 2026-04-05, -10, -15, -20, -25.
+# After sort desc: New 5 (-25), New 4 (-20), New 3 (-15), New 2 (-10), New 1 (-05).
+first_remaining="$(grep -m1 -E '^\| New [0-9]+ \|' "$ORDER_DIR/.decisions/CLAUDE.md")"
+if echo "$first_remaining" | grep -qF "New 5"; then
+    pass "first surviving row is the date-newest (New 5, 2026-04-25)"
+else
+    fail "expected 'New 5' first, got: $first_remaining"
+fi
+
+rm -rf "$ORDER_DIR" 2>/dev/null || true
+
 # ── Test 10: under-cap files unchanged ──────────────────────────────────────
 
 echo ""

--- a/tests/scenario-work-validate.sh
+++ b/tests/scenario-work-validate.sh
@@ -152,6 +152,38 @@ else
     fail "invalid status should fail" "got: $output"
 fi
 
+# ── Test 3b: SPECIFYING and IMPLEMENTING in-flight states pass validation ────
+# Regression for 2026-05-11 adversarial finding: work-validate's enum was
+# missing SPECIFYING and IMPLEMENTING even though work-resolve.sh produces
+# them, wedging /work-decompose re-runs on groups with any in-flight WD.
+
+echo ""
+echo "── Test 3b: in-flight status enum values pass validation"
+
+for in_flight_status in SPECIFYING IMPLEMENTING; do
+    cat > ".work/test-group/wd-$in_flight_status.md" <<EOF
+---
+id: WD-IF-$in_flight_status
+title: In-flight test
+group: test-group
+status: $in_flight_status
+domains: [auth]
+---
+
+## Summary
+.
+
+## Acceptance Criteria
+.
+EOF
+    output="$(bash .claude/scripts/work-validate.sh ".work/test-group/wd-$in_flight_status.md" 2>&1 || true)"
+    if echo "$output" | grep -q "PASS"; then
+        pass "status: $in_flight_status passes validation"
+    else
+        fail "status: $in_flight_status should be valid" "got: $output"
+    fi
+done
+
 # ── Test 4: Empty domains fails ──────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

A four-agent adversarial review across `/work-decompose`, `/work-resume` + `work-claim.sh`, `/spec-backfill`, and `/curate` + `curate-scan.sh` surfaced **40 findings** (8 CRITICAL + 19 HIGH + 13 MEDIUM). This PR ships the **5 CRITICALs** that hit production code paths. HIGH/MEDIUM follow in a later wave.

## Fixes

### 1. `/curate` "Recently Accepted" rotation kept OLDER ADRs

The 2026-05-10 jlsm bug we documented but didn't fix until now. `scripts/index-verify.sh` trimmed bottom-N rows assuming newest-at-top, but auto-repair inserted missing rows on top in filesystem order regardless of date. So pre-existing user rows at the bottom (newer) got archived while freshly-inserted-on-top older ADRs stayed.

Fix: sort the table by accepted-date desc inside the overflow block, BEFORE the bottom-N trim. Runs only when overflow triggers (under-cap files stay untouched).

**Regression test (Test 9b):** fixture deliberately arranges document-order ≠ date-order ("Old" rows at top with 2026-01 dates, "New" rows at bottom with 2026-04 dates). Asserts survivors by IDENTITY — the 5 "New" rows survive, all 85 "Old" rows archive.

### 2. `work-validate.sh` status enum

Enum was missing `SPECIFYING` and `IMPLEMENTING` even though `work-resolve.sh` produces them. Re-running `/work-decompose` on any group with in-flight WDs wedged at validation.

Fix: enum extended. Test 3b: fixture WDs with each in-flight status pass validation.

### 3. `/work-decompose --from-obligations` schema drift

SKILL.md referenced `spec`, `affects`, `blocked_by` — `_obligations.json`'s actual schema (verified against `spec-resolve.sh` and `spec-obligations-gc.sh`) is `target_feature`, `domains`, `description`, `status`. Mode silently produced zero WDs.

Fix: OB-1/OB-2 rewritten to the correct schema with explicit reference to where it's enforced.

### 4. `/spec-backfill` FQ R-id mismatch

`spec-trace.sh --uncovered` emits fully-qualified R-ids; `spec-backfill-candidates.sh` and `spec-backfill-log.sh has-decision` expect bare R-ids. Phase 1 filter never matched; already-annotated requirements resurfaced on every run.

Fix: SKILL.md Phase 1 + corpus-mode Phase A explicitly strip the prefix (`r_id="${fq_rid##*.}"`) before downstream calls.

### 5. `/curate` no-op exits left stale summary

When `curate-scan.sh` exited "No new commits" or "No commits found," the prior summary stayed on disk with its valid sentinel. Step 1.1 passed; `/curate` consumed days-old findings as if fresh.

Fix: both exit paths now overwrite `scan-summary.md` with a distinct no-op marker. Step 1.1 detects via `grep "· no-op ·"` and routes via AskUserQuestion to `--init` / wider window / stop.

**Regression test:** asserts the no-op marker is written.

## Tests

| Suite | Before | After | Delta |
|-------|--------|-------|-------|
| `scenario-index-verify.sh` | 21 | 23 | +2 (Test 9b: 4 assertions for date-survivor identity) |
| `scenario-work-validate.sh` | 20 | 22 | +2 (Test 3b: SPECIFYING/IMPLEMENTING) |
| `scenario-curate-scan.sh` | 84 | 86 | +2 (no-op marker assertions) |
| `test-install.sh` | 74 | 74 | unchanged |

## Why ship all 5 in one PR

User explicitly requested bundled CRITICAL fixes so jlsm can upgrade past them in one cycle. Each fix is independent at the code level but they all share the same adversarial-pass origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)