### PR TITLE
fix(upgrade): include .spec/ and .work/ in upgrade banner

### DIFF
--- a/skills/upgrade-vallorcine/SKILL.md
+++ b/skills/upgrade-vallorcine/SKILL.md
@@ -7,8 +7,9 @@ description: "Check for and apply updates from the vallorcine source repository"
 Checks the source repository for a newer release of vallorcine and,
 with confirmation, downloads and applies it to this project.
 
-Safe to run at any time. Never touches .kb/, .decisions/, or .feature/.
-User-populated index files are preserved even when kit files are updated.
+Safe to run at any time. Never touches .kb/, .decisions/, .feature/,
+.work/, or .spec/. User-populated index files are preserved even when
+kit files are updated.
 
 ---
 
@@ -110,9 +111,12 @@ Updates (overwritten with new version):
 Preserved (never touched):
   .kb/                 your knowledge base
   .decisions/          your architecture decisions
+  .spec/               your specifications + registry
   .feature/            your in-progress feature work
+  .work/               your work groups + orchestrator state
   .kb/CLAUDE.md        if you have added topics
   .decisions/CLAUDE.md if you have added decisions
+  .spec/CLAUDE.md      if you have authored specs
 
 Use AskUserQuestion with options:
   - "Apply upgrade"


### PR DESCRIPTION
## Summary

The `/upgrade-vallorcine` banner listed `.kb/`, `.decisions/`, `.feature/` as preserved but omitted `.spec/` and `.work/` — even though `install.sh` preserves them identically via `_install_seed` (skips any file that already exists with "user data — never overwritten").

The omission was harmless but worried users into thinking spec corpora and work-group state might be overwritten on upgrade.

## Changes

| Surface | Before | After |
|---------|--------|-------|
| One-liner (L10) | "Never touches .kb/, .decisions/, or .feature/" | "Never touches .kb/, .decisions/, .feature/, .work/, or .spec/" |
| Detailed banner (L110+) | rows for .kb/ + .decisions/ + .feature/ | + rows for .spec/ and .work/; + `.spec/CLAUDE.md` alongside existing CLAUDE.md preservation notes |

No code change. `install.sh` behavior is unchanged — this only fixes the user-facing description to match what the kit already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)