### PR TITLE
fix(work-start): all-mode picks up stranded IMPLEMENTING WDs

### DIFF
--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -365,24 +365,67 @@ escalations surface to the user.
 Replace Steps 3–5 with this block when `all` is the argument.
 
 1. **Initial enumeration.** Read `_readiness.json` (refreshed by the
-   resolver call in Step 2) and collect every WD whose status is
-   `SPECIFIED`. If zero, report and stop:
+   resolver call in Step 2) and collect WDs into three sets:
+
+   - **`specified`** — WDs whose status is `SPECIFIED`. Dispatch the
+     full single-WD `/work-start` pipeline for each.
+   - **`stranded_implementing`** — WDs whose status is `IMPLEMENTING`
+     (or the legacy alias `IN_PROGRESS`) that are NOT being actively
+     run by another session. These are typically WDs whose prior
+     `/work-start` run claimed them (SPECIFIED → IMPLEMENTING) but
+     didn't finish the pipeline — for example, a crashed sub-agent
+     or a stalled `/feature-coordinate` dispatch. **Route these via
+     `/feature-resume "<feature-slug>"`** (NOT another `/work-start`,
+     which would re-trigger `work-claim.sh` and fail on the already-
+     IMPLEMENTING state). The feature slug is `<group>--<wd-id>`.
+
+     **Active vs stranded distinction.** A WD is `stranded` (eligible
+     for re-dispatch) if EITHER:
+     - `.work/<group>/_dispatch-<wd-id>.json` does not exist, OR
+     - The marker exists but is in state `fail` (prior attempt errored), OR
+     - The marker is in state `begin` and its `dispatched_at` is more
+       than 30 minutes old (assume the dispatcher died).
+
+     A WD is `active` (skip — another session is running it) if the
+     marker is in state `begin` and was written within the last 30
+     minutes. Surface skipped active WDs in the plan display so the
+     user can stop their other session if it's actually dead.
+   - **`needs_planning`** — WDs whose status is `SPECIFYING`. These
+     are mid-`/spec-author` arbitration and need `/work-plan
+     "<group-slug>" "<wd-id>"` to finish. Surface them as
+     informational; `/work-start all` does not start planning work.
+
+   If `specified` and `stranded_implementing` are BOTH empty, report
+   and stop:
    ```
-   No SPECIFIED work definitions in '<group-slug>' — run /work-plan
-   "<group-slug>" all to specify READY WDs first, or check
-   /work-status for blockers.
+   No work to start in '<group-slug>' — no SPECIFIED or stranded
+   IMPLEMENTING WDs.
+   <if needs_planning is non-empty:>
+   Note: <P> WD(s) need /work-plan "<group-slug>" to finish their
+   arbitration (currently SPECIFYING):
+     - WD-<nn> — <title>
+     - ...
    ```
 
 2. **Show the plan.** Compute the initial run order — sort by
    unblocking value (most downstream dependents first), tie-breaking
-   by fewer artifact dependencies. Display:
+   by fewer artifact dependencies. IMPLEMENTING WDs sort BEFORE
+   SPECIFIED ones (finish in-flight work first). Display:
    ```
    ── Sequential start plan ──────────────────────
    Group: <group-slug>
-   SPECIFIED WDs: <N>
-   Initial order (by unblocking value):
-     1. WD-<nn> — <title>  (unblocks: <list>)
-     2. WD-<nn> — ...
+   Stranded IMPLEMENTING WDs to resume: <M>  (via /feature-resume)
+   SPECIFIED WDs to start: <N>               (full pipeline)
+   <if needs_planning is non-empty:>
+   Note: <P> SPECIFYING WD(s) need /work-plan first:
+     - WD-<nn> — <title>
+   <if any active-skipped WDs:>
+   Skipping (another session active): <list of WD-ids>
+   <end>
+   Initial order (by unblocking value, IMPLEMENTING first):
+     1. WD-<nn> [resume] — <title>  (unblocks: <list>)
+     2. WD-<nn> [start]  — <title>  (unblocks: <list>)
+     3. ...
    Note: a WD's completion may unblock a sibling that's currently
    BLOCKED on a wd: dep — the loop re-enumerates between iterations,
    so the run may include WDs not in this initial list.
@@ -401,19 +444,32 @@ Replace Steps 3–5 with this block when `all` is the argument.
       satisfy a `wd:` or spec dep that promotes a sibling from
       BLOCKED to SPECIFIED in iteration N+1.
 
-   b. **Pick the next.** From the current SPECIFIED list, pick the
-      WD with the highest unblocking value (same heuristic as Step 2).
-      Skip WDs the run has already dispatched (track in a dispatched
-      set keyed by WD id). If no SPECIFIED WD remains that hasn't been
-      dispatched, exit the loop.
+   b. **Pick the next.** From the combined `stranded_implementing` ∪
+      `specified` sets, pick the WD with the highest unblocking value
+      (same heuristic as Step 2; IMPLEMENTING WDs sort before
+      SPECIFIED ones). Skip WDs the run has already dispatched (track
+      in a dispatched set keyed by WD id). Also re-evaluate the
+      "active vs stranded" check (Step 1) on each iteration — markers
+      can flip from `begin` to `ack`/`fail` between iterations. If no
+      eligible WD remains, exit the loop.
 
    c. **Honor the cap.** If the user chose a cap in Step 2 and the
       dispatched count has reached it, exit the loop.
 
-   d. **Dispatch ONE sub-agent that recursively invokes the
-      single-WD `/work-start`.** This is critical — do NOT hand-roll
-      the feature creation + claim + pipeline dispatch logic in this
-      coordinator. The single-WD flow already does it correctly.
+   d. **Dispatch ONE sub-agent.** Route based on the WD's current
+      status — same coordinator, different inner skill:
+
+      - **SPECIFIED** → sub-agent invokes single-WD `/work-start
+        "<group>" <wd-id> --nested` (handles feature dir creation,
+        claim, full pipeline).
+      - **IMPLEMENTING** (stranded) → sub-agent invokes
+        `/feature-resume "<group>--<wd-id>"` (picks up the existing
+        feature directory from where the prior pipeline stopped;
+        no claim needed — WD is already IMPLEMENTING).
+
+      Do NOT hand-roll feature creation + claim + pipeline dispatch
+      logic in this coordinator. Each inner skill handles its
+      respective flow correctly.
 
       **Before the Agent call**, write a dispatch marker so a
       lost-payload or rejected-dispatch failure does not leave the
@@ -425,9 +481,14 @@ Replace Steps 3–5 with this block when `all` is the argument.
       `ack: false`. Step 3f flips it to `ack: true` once the result is
       parsed (or marks `failure_reason` when parsing fails). The marker
       is what `/work-resume` uses to detect stuck dispatches and
-      surface them as recovery candidates.
+      surface them as recovery candidates. For resume-mode dispatches,
+      the marker overwrites any stale pre-existing marker — the new
+      one supersedes.
 
-      **Then invoke the sub-agent** with this prompt verbatim:
+      **Then invoke the sub-agent.** Use ONE of the two prompts below
+      based on the WD's status.
+
+      **Prompt A — SPECIFIED WD (fresh start):**
       ```
       You are the sequential pipeline runner for <group-slug> /
       <wd-id>.
@@ -477,6 +538,38 @@ Replace Steps 3–5 with this block when `all` is the argument.
 
       Return exactly ONE line and nothing else after. The coordinator
       parses this string.
+      ```
+
+      **Prompt B — IMPLEMENTING WD (stranded resume):**
+      ```
+      You are the sequential resume runner for <group-slug> /
+      <wd-id>. The WD is already IMPLEMENTING — a prior /work-start
+      dispatch claimed it and started the pipeline, but did not run
+      it to completion (typically because of a crashed sub-agent or
+      a stalled inner-dispatch step). The feature directory exists
+      at .feature/<group-slug>--<wd-id>/ with status.md reflecting
+      the stage where the prior run stopped.
+
+      Invoke /feature-resume "<group-slug>--<wd-id>". It will read
+      status.md, identify the stage to resume from, and continue the
+      pipeline through /feature-pr. Do NOT re-invoke /work-start —
+      work-claim.sh would reject the transition (already IMPLEMENTING).
+
+      Treat automation_mode as autonomous. TECHNICAL escalations are
+      auto-handled (record in cycle-log, continue). USER-REQUIRED
+      escalations follow the contract: write
+      .feature/<group-slug>--<wd-id>/escalation.json, append a
+      user-escalation entry to cycle-log.md, set status.md substage
+      to awaiting-user-input, then return ESCALATION_AT_<stage>.
+
+      Return exactly ONE line matching the same classifier shape as
+      Prompt A:
+        "<group-slug>--<wd-id>: COMPLETE — <detail>"
+        "<group-slug>--<wd-id>: ESCALATION_AT_<stage> — <category>: <question>"
+        "<group-slug>--<wd-id>: STOPPED_AT_<stage> — <detail>"
+        "<group-slug>--<wd-id>: ERROR — <one-line detail>"
+
+      Nothing else after.
       ```
 
    e. **Wait for the sub-agent to return.** The Agent tool blocks

--- a/tests/scenario-work-start-all-implementing.sh
+++ b/tests/scenario-work-start-all-implementing.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Scenario: /work-start <group> all picks up stranded IMPLEMENTING WDs
+#
+# Real bug hit on jlsm: WD-01 was claimed by an earlier /work-start that
+# crashed mid-pipeline (the nested-dispatch bug). WD-01 was left at
+# status: IMPLEMENTING with status.md reflecting partial progress. The
+# user ran /work-start <group> all to retry — but the enumeration only
+# picked SPECIFIED WDs, so WD-01 fell through and required a separate
+# manual /feature-resume.
+#
+# Fix: the all flow enumerates BOTH SPECIFIED and stranded IMPLEMENTING
+# WDs, routing IMPLEMENTING ones through /feature-resume (not another
+# /work-start, which would reject the SPECIFIED→IMPLEMENTING transition
+# via work-claim.sh). SPECIFYING WDs (mid-/spec-author Pass 2) are
+# surfaced as informational ("needs /work-plan") since arbitration is
+# /work-plan's concern.
+#
+# Run from repo root: bash tests/scenario-work-start-all-implementing.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SKILL="$REPO_ROOT/skills/work-start/SKILL.md"
+
+passed=0
+failed=0
+total=0
+
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+echo ""
+echo "scenario: /work-start all picks up stranded IMPLEMENTING WDs"
+echo "────────────────────────────────────────────────"
+
+# ── Sequential-all flow enumerates both SPECIFIED and IMPLEMENTING ──────────
+
+echo ""
+echo "  Step 1 enumeration covers SPECIFIED + IMPLEMENTING"
+echo "  ────────────────────────────────────────────────"
+
+step1=$(awk '/^### Sequential-all flow/,/^2\. \*\*Show the plan/' "$SKILL")
+
+if echo "$step1" | grep -qE '`specified`.*SPECIFIED'; then
+    pass 'Step 1 declares `specified` set'
+else
+    fail 'Step 1 missing `specified` set'
+fi
+
+if echo "$step1" | grep -qE '`stranded_implementing`'; then
+    pass 'Step 1 declares `stranded_implementing` set'
+else
+    fail 'Step 1 missing `stranded_implementing` set'
+fi
+
+if echo "$step1" | grep -qE '`needs_planning`.*SPECIFYING'; then
+    pass 'Step 1 declares `needs_planning` set (SPECIFYING WDs)'
+else
+    fail 'Step 1 missing `needs_planning` set'
+fi
+
+# ── Routing: IMPLEMENTING uses /feature-resume, not another /work-start ────
+
+echo ""
+echo "  IMPLEMENTING routing uses /feature-resume"
+echo "  ───────────────────────────────────────"
+
+if echo "$step1" | tr '\n' ' ' | tr -s ' ' | grep -qE "Route these via .?/feature-resume"; then
+    pass "Step 1 routes IMPLEMENTING WDs through /feature-resume"
+else
+    fail "Step 1 doesn't route IMPLEMENTING through /feature-resume"
+fi
+
+if echo "$step1" | grep -qE 'NOT another.*work-start|would.*re-trigger.*work-claim'; then
+    pass "Step 1 warns against re-invoking /work-start on IMPLEMENTING"
+else
+    fail "Step 1 missing warning about /work-start re-invocation"
+fi
+
+# ── Active vs stranded distinction documented ──────────────────────────────
+
+echo ""
+echo "  Active vs stranded marker distinction"
+echo "  ────────────────────────────────────"
+
+if echo "$step1" | tr '\n' ' ' | tr -s ' ' | grep -qE "Active vs stranded distinction"; then
+    pass "Step 1 documents the active vs stranded distinction"
+else
+    fail "Step 1 missing active vs stranded section"
+fi
+
+if echo "$step1" | grep -qE "30 minutes|30 min"; then
+    pass "Step 1 names the stuck-marker threshold (30 min)"
+else
+    fail "Step 1 missing stuck-marker threshold"
+fi
+
+if echo "$step1" | tr '\n' ' ' | tr -s ' ' | grep -qE 'state .?begin.? and.*dispatched_at'; then
+    pass "Step 1 checks marker dispatched_at for staleness"
+else
+    fail "Step 1 missing dispatched_at staleness check"
+fi
+
+# ── Plan display surfaces all three sets ───────────────────────────────────
+
+echo ""
+echo "  Plan display in Step 2"
+echo "  ────────────────────"
+
+step2=$(awk '/^2\. \*\*Show the plan/,/^3\. \*\*Iterate/' "$SKILL")
+
+if echo "$step2" | grep -qE "Stranded IMPLEMENTING WDs to resume"; then
+    pass "plan display shows stranded IMPLEMENTING count"
+else
+    fail "plan display missing IMPLEMENTING count"
+fi
+
+if echo "$step2" | grep -qE "SPECIFIED WDs to start"; then
+    pass "plan display shows SPECIFIED count"
+else
+    fail "plan display missing SPECIFIED count"
+fi
+
+if echo "$step2" | grep -qE "SPECIFYING WD.*need /work-plan"; then
+    pass "plan display surfaces SPECIFYING note (informational)"
+else
+    fail "plan display missing SPECIFYING note"
+fi
+
+if echo "$step2" | tr '\n' ' ' | tr -s ' ' | grep -qE "IMPLEMENTING WDs sort BEFORE SPECIFIED|IMPLEMENTING first"; then
+    pass "plan documents IMPLEMENTING-first ordering"
+else
+    fail "plan missing IMPLEMENTING-first ordering rule"
+fi
+
+# ── Dispatch loop has two prompts (Prompt A + Prompt B) ────────────────────
+
+echo ""
+echo "  Dispatch loop has separate prompts per state"
+echo "  ──────────────────────────────────────────"
+
+step3d=$(awk '/^   d\. \*\*Dispatch ONE sub-agent/,/^   e\.|^   \*\*Wait/' "$SKILL")
+
+if echo "$step3d" | grep -qE 'Prompt A.*SPECIFIED'; then
+    pass "Step 3d defines Prompt A for SPECIFIED WDs"
+else
+    fail "Step 3d missing Prompt A"
+fi
+
+if echo "$step3d" | grep -qE 'Prompt B.*IMPLEMENTING'; then
+    pass "Step 3d defines Prompt B for IMPLEMENTING WDs"
+else
+    fail "Step 3d missing Prompt B"
+fi
+
+# Prompt B should invoke /feature-resume, NOT /work-start
+prompt_b=$(awk '/Prompt B — IMPLEMENTING/,/Nothing else after/' "$SKILL")
+
+if echo "$prompt_b" | grep -qE 'Invoke /feature-resume'; then
+    pass "Prompt B invokes /feature-resume"
+else
+    fail "Prompt B missing /feature-resume invocation"
+fi
+
+if echo "$prompt_b" | grep -qE 'Do NOT re-invoke /work-start|would.*reject.*transition'; then
+    pass "Prompt B explicitly warns against re-invoking /work-start"
+else
+    fail "Prompt B missing /work-start re-invocation warning"
+fi
+
+# Both prompts share the same return-line classifier (consistency)
+if echo "$prompt_b" | grep -qE 'COMPLETE.*ESCALATION_AT_.*STOPPED_AT_.*ERROR' \
+   || echo "$prompt_b" | tr '\n' ' ' | grep -qE 'COMPLETE.*ESCALATION_AT_'; then
+    pass "Prompt B uses the 5-way classifier shape (consistent with Prompt A)"
+else
+    fail "Prompt B return shape inconsistent with Prompt A"
+fi
+
+# ── Iteration loop picks from combined set ─────────────────────────────────
+
+echo ""
+echo "  Iteration picks from combined set"
+echo "  ────────────────────────────────"
+
+step3b=$(awk '/^   b\. \*\*Pick the next/,/^   c\./' "$SKILL")
+
+if echo "$step3b" | tr '\n' ' ' | grep -qE "stranded_implementing.*specified|combined .stranded_implementing. .* .specified."; then
+    pass "Step 3b picks from combined stranded_implementing ∪ specified"
+else
+    fail "Step 3b doesn't unify both sets"
+fi
+
+if echo "$step3b" | tr '\n' ' ' | tr -s ' ' | grep -qiE "IMPLEMENTING WDs sort before SPECIFIED|IMPLEMENTING first"; then
+    pass "Step 3b sorts IMPLEMENTING before SPECIFIED"
+else
+    fail "Step 3b missing IMPLEMENTING-first ordering"
+fi
+
+if echo "$step3b" | tr '\n' ' ' | tr -s ' ' | grep -qE 're-evaluate.*active vs stranded|markers can flip'; then
+    pass "Step 3b re-evaluates active vs stranded each iteration"
+else
+    fail "Step 3b doesn't refresh active/stranded between iterations"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## The bug

Real one you hit on jlsm: WD-01 was claimed by an earlier `/work-start` that crashed mid-pipeline (the nested-dispatch bug we fixed in v0.19.2). The WD was left at `status: IMPLEMENTING` with `status.md` reflecting partial progress (planning + stubs done, `/feature-coordinate` not yet dispatched). Running `/work-start <group> all` to retry only enumerated SPECIFIED WDs — stranded IMPLEMENTING WDs fell through and you had to "separately finish" them.

You also noted WD-08 and WD-10 are paused at Pass 2 arbitration — those are SPECIFYING, mid-`/work-plan`. They're surfaced as an informational note since arbitration is `/work-plan`'s concern, not `/work-start`'s.

## The fix

The `all` flow now enumerates three sets:

| Set | Status | Route |
|-----|--------|-------|
| `specified` | SPECIFIED | full pipeline via single-WD `/work-start --nested` |
| `stranded_implementing` | IMPLEMENTING (no active dispatcher) | resume via `/feature-resume "<group>--<wd-id>"` |
| `needs_planning` | SPECIFYING | informational note ("run `/work-plan` first") |

**Why route IMPLEMENTING through `/feature-resume`:** invoking `/work-start` again on an IMPLEMENTING WD would hit `work-claim.sh`'s SPECIFIED→IMPLEMENTING guard and exit with a CONFLICT message. `/feature-resume` is the canonical "pick up from where the prior pipeline stopped" entry point.

## Active vs stranded distinction

A WD is **stranded** (eligible for re-dispatch) if its dispatch marker is:
- missing, OR
- in `fail` state, OR
- in `begin` state with `dispatched_at` more than 30 minutes old.

Markers in fresh `begin` state mean another session is actively running the WD — surfaced as "skipped (another session active)" so you can stop the other session if it's actually dead.

## Ordering

IMPLEMENTING WDs sort before SPECIFIED — finish in-flight work before starting fresh. Re-evaluated each iteration since markers can flip between turns.

## Dispatch loop

Same coordinator, two prompts:
- **Prompt A** (SPECIFIED) → `/work-start --nested`
- **Prompt B** (IMPLEMENTING) → `/feature-resume "<group>--<wd-id>"`

Both share the 5-way classifier shape from PR A's escalation contract (COMPLETE / ESCALATION / STOPPED / ERROR / SKIPPED).

## Tests

- `tests/scenario-work-start-all-implementing.sh` — **20 contract checks** covering enumeration sets, routing, active-vs-stranded threshold, plan display surfaces, dispatch loop's two-prompt structure, and re-evaluation between iterations.
- No regressions: parallel (21/21), escalation (40/40), nested (19/19), install (74/74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)