### PR TITLE
fix(spec-backfill): 4 HIGH adversarial findings

### DIFF
--- a/scripts/spec-backfill-log.sh
+++ b/scripts/spec-backfill-log.sh
@@ -152,11 +152,39 @@ cmd_report() {
     echo "no log file at $log"
     return 0
   }
-  local total ann skp wav
+  # Effective counts use latest-status semantics — for each (spec, rid)
+  # pair, only the most recent decision counts. Without this, a row
+  # that flipped skipped → annotated counted as BOTH annotated and
+  # skipped, and the corpus summary overstated "skipped (will resurface)"
+  # for already-resolved requirements (2026-05-11 adversarial HIGH #1).
+  #
+  # `total` reports the raw row count (audit trail). `annotated` /
+  # `skipped` / `waived` report the effective state by (spec, rid).
+  local total
   total=$(grep -cE '^\| [0-9]{4}-[0-9]{2}-[0-9]{2} \|' "$log" 2>/dev/null || echo 0)
-  ann=$(awk -F'|' '$5 ~ /annotated/ {n++} END {print n+0}' "$log")
-  skp=$(awk -F'|' '$5 ~ /skipped/   {n++} END {print n+0}' "$log")
-  wav=$(awk -F'|' '$5 ~ /waived/    {n++} END {print n+0}' "$log")
+
+  # Use awk with last-write-wins indexing to compute effective counts.
+  local effective
+  effective=$(awk -F'|' '
+    {
+      gsub(/^ +| +$/, "", $3); gsub(/^ +| +$/, "", $4); gsub(/^ +| +$/, "", $5)
+      if ($3 != "" && $4 ~ /^R[0-9]/) {
+        # Last status wins for each (spec, rid) pair.
+        key = $3 "|" $4
+        latest[key] = $5
+      }
+    }
+    END {
+      ann = 0; skp = 0; wav = 0
+      for (k in latest) {
+        if (latest[k] == "annotated") ann++
+        else if (latest[k] == "skipped")   skp++
+        else if (latest[k] == "waived")    wav++
+      }
+      print ann " " skp " " wav
+    }
+  ' "$log")
+  read -r ann skp wav <<< "$effective"
   echo "rows: $total  annotated: $ann  skipped: $skp  waived: $wav"
 }
 

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -259,15 +259,34 @@ Before enumerating, check for unacknowledged dispatch markers under
 bash .claude/scripts/dispatch-marker.sh stuck .spec/_backfill-dispatches
 ```
 
-If output is non-empty, surface each stuck spec to the user via
-AskUserQuestion BEFORE starting the corpus walk:
+Each line is `<dispatch-id>|<dispatched_at>|...`. Dispatch IDs for
+this skill are **suffixed**: `<spec-id>--propose` (Phase A markers)
+or `<spec-id>--apply` (Phase B markers). The stuck output may show
+both, the same spec, or just one. **Group stuck markers by spec-id
+before surfacing** (2026-05-11 adversarial HIGH #2) — otherwise the
+user sees "Re-dispatch <spec>--propose" + "Re-dispatch <spec>--apply"
+as two separate prompts for the same spec, with no clear meaning
+because the user doesn't necessarily know what "--propose" vs
+"--apply" implies.
 
-- **"Re-dispatch <spec-id>"** — clear the marker and include the spec
-  in the run.
-- **"Skip <spec-id> for now"** — leave the marker; spec will be
-  surfaced again next run.
-- **"Investigate manually"** — print the marker contents
-  (`dispatch-marker.sh status …`) and stop the run.
+For each unique `<spec-id>` (stripping the `--propose`/`--apply`
+suffix via `${id%--*}`), pick the appropriate routing based on
+which markers exist:
+
+| Markers present | Meaning | Recommended action |
+|-----------------|---------|---------------------|
+| `--propose` only | Phase A ran but Phase B never dispatched. Decisions in memory were lost. | Re-dispatch Phase A (the user's prior decisions are gone; walk the spec again). |
+| `--apply` only | Phase B dispatched but never ack'd. Some annotations may already exist; the log records them. | **Investigate** first — list completed rows via `spec-backfill-log.sh list-decisions <log> <spec>`. Re-dispatching Phase A is safe (the log's terminal-decision filter skips them), but a partial Phase B's `skipped` rows from the lost run will surface again. |
+| Both | Phase A and Phase B both fired; result lost mid-Phase-B. | Same as `--apply` only — investigate the log first. |
+
+Use `AskUserQuestion` per unique spec-id, with options drawn from
+the table above:
+
+- **"Re-dispatch Phase A (walk spec again)"** — clears any
+  `<spec>--propose` marker, runs Phase A fresh.
+- **"Investigate via `spec-backfill-log.sh list-decisions`"** — print
+  the per-R-id state and stop the run for this spec.
+- **"Skip <spec> for now"** — leave markers; spec resurfaces next run.
 
 This mirrors `/work-resume rule 0` (PR #79) — any unacknowledged marker
 pre-empts the normal flow because it represents a previous run whose
@@ -425,6 +444,26 @@ flow).
 The decision-set lives in coordinator context briefly (~500 bytes per
 spec at most) — released as soon as Phase B returns.
 
+**Skip Phase B dispatch when the decision-set is no-op** (2026-05-11
+adversarial HIGH #4). Before invoking C2d:
+
+- If `decisions` is empty AND every item was `already_decided` (this is
+  a no-op re-run of an already-completed spec), skip C2d entirely.
+  Print `<spec-id> — all uncovered R-ids already terminal (no-op)` and
+  ack the propose marker with that summary. Continue to next spec.
+- If `decisions` is non-empty but contains ONLY `skip` actions (user
+  declined every R-id this round), there are still log rows to write
+  for audit trail — dispatch C2d normally so the `skipped` rows are
+  recorded (they're non-terminal and will resurface on the next run
+  with a forward-progress signal).
+- Otherwise dispatch C2d normally.
+
+This guard avoids paying full sub-agent overhead to log zero rows
+when re-running `/spec-backfill --all` after a clean completion (every
+Phase A returns items with `already_decided` set; previously the
+coordinator dispatched Phase B per spec just to confirm "no work to
+do").
+
 **C2d. Phase B — apply (sub-agent, autonomous, idempotent).**
 
 ```bash
@@ -498,7 +537,36 @@ Classify into one of:
   `parse-failed: <first-80-chars>`. Print raw return; same recovery
   options.
 
-**C2f. Honor the cap.** If a cap was set in C1 and the dispatched
+**C2f. Forward-progress re-loop for >12 uncovered specs** (2026-05-11
+adversarial HIGH #3). Phase A's prompt caps at 12 uncovered R-ids per
+dispatch and sets `more_remain=true` in the JSON when there are more.
+Without a re-loop, a spec with 30 uncovered R-ids only ever surfaces
+R-ids 1-12 across any number of `/spec-backfill --all` runs — R-ids
+13-30 are invisible because `skipped` rows from the first batch keep
+the same 12 surfacing first.
+
+After C2e ack, check the Phase A return's `more_remain` flag:
+
+- If `more_remain == false` → continue to next spec (current behavior).
+- If `more_remain == true`:
+  - Count this round's **forward progress** = number of decisions
+    whose action was `annotate` or `waive` (terminal in the log).
+  - If forward progress is **zero** (user skipped every R-id this
+    round), stop iterating this spec — the next batch would just
+    re-surface the same 12. Continue to next spec. The skipped R-ids
+    will resurface on the next `/spec-backfill --all` run.
+  - If forward progress is **>= 1**, re-dispatch Phase A for the same
+    spec (new propose marker, fresh AskUserQuestion loop). The
+    already-annotated/waived R-ids will be filtered by Phase A's
+    `already_decided` check; the user sees the next batch of 12
+    uncovered R-ids. Cap the inner loop at 3 iterations per spec to
+    prevent pathological cases.
+
+This makes the corpus walk eventually-complete for specs with >12
+uncovered R-ids, as long as the user makes forward progress at least
+once per round.
+
+**C2g. Honor the cap.** If a cap was set in C1 and the dispatched
 count has reached it, exit the loop after acking the current spec.
 
 ### C3. Corpus summary

--- a/tests/scenario-spec-backfill-corpus.sh
+++ b/tests/scenario-spec-backfill-corpus.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Scenario: /spec-backfill corpus mode (--all) — HIGH cluster fixes
+# from 2026-05-11 adversarial sweep.
+#
+# H1: spec-backfill-log.sh report uses latest-status semantics (covered
+#     in scenario-spec-backfill.sh Test 14 — verifies the fix here too).
+# H2: C0 stuck-marker recovery groups by spec-id (strip --propose /
+#     --apply suffix) so the user sees one prompt per spec, not two.
+# H3: C2f forward-progress re-loop for specs with >12 uncovered R-ids.
+# H4: Skip Phase B dispatch when decision-set is empty no-op.
+#
+# This is contract validation against the SKILL.md text — runtime
+# AskUserQuestion behavior can't be exercised in scenario tests.
+#
+# Run from repo root: bash tests/scenario-spec-backfill-corpus.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SKILL="$REPO_ROOT/skills/spec-backfill/SKILL.md"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+echo ""
+echo "scenario: /spec-backfill corpus mode (HIGH cluster 2)"
+echo "────────────────────────────────────────────────"
+
+# ── H2: C0 stuck-marker grouping by spec-id ────────────────────────────────
+
+echo ""
+echo "  H2 — C0 groups stuck markers by spec-id (strip --propose/--apply)"
+echo "  ───────────────────────────────────────────────────────────────"
+
+c0=$(awk '/^### C0\. Pre-flight: surface stuck dispatches/,/^### C1/' "$SKILL")
+
+if echo "$c0" | grep -qE 'suffixed|--propose|--apply'; then
+    pass "C0 acknowledges marker suffix convention"
+else
+    fail "C0 missing marker suffix convention"
+fi
+
+if echo "$c0" | grep -qE 'Group stuck markers by spec-id|group.*by spec-id'; then
+    pass "C0 prescribes grouping by spec-id"
+else
+    fail "C0 doesn't prescribe grouping by spec-id"
+fi
+
+if echo "$c0" | grep -qE '\$\{id%--\*\}|strip.*suffix'; then
+    pass "C0 names the suffix-strip pattern"
+else
+    fail "C0 missing suffix-strip pattern reference"
+fi
+
+# Per-marker routing table should distinguish three cases
+for marker_case in "propose. only" "apply. only" "Both"; do
+    if echo "$c0" | grep -qE "$marker_case"; then
+        pass "C0 routing covers: $marker_case"
+    else
+        fail "C0 routing missing case: $marker_case"
+    fi
+done
+
+if echo "$c0" | grep -qE 'AskUserQuestion'; then
+    pass "C0 uses AskUserQuestion (no prose recommendations)"
+else
+    fail "C0 missing AskUserQuestion"
+fi
+
+# ── H3: C2f forward-progress re-loop ───────────────────────────────────────
+
+echo ""
+echo "  H3 — C2f forward-progress re-loop for >12 uncovered R-ids"
+echo "  ─────────────────────────────────────────────────────────"
+
+c2f=$(awk '/^\*\*C2f\. Forward-progress re-loop/,/^\*\*C2g\. Honor the cap/' "$SKILL")
+
+if [[ -n "$c2f" ]]; then
+    pass "C2f section exists"
+else
+    fail "C2f section missing"
+fi
+
+if echo "$c2f" | grep -qE 'more_remain'; then
+    pass "C2f references more_remain flag"
+else
+    fail "C2f doesn't reference more_remain"
+fi
+
+if echo "$c2f" | grep -qE 'forward progress.*zero|zero forward progress'; then
+    pass "C2f handles zero-forward-progress case (stop iterating)"
+else
+    fail "C2f missing zero-forward-progress termination"
+fi
+
+if echo "$c2f" | grep -qE '3 iterations|cap.*iterations'; then
+    pass "C2f caps re-loop iterations (anti-pathology)"
+else
+    fail "C2f missing iteration cap"
+fi
+
+if echo "$c2f" | grep -qE 'annotate.*waive|terminal in the log'; then
+    pass "C2f counts annotate/waive as forward progress"
+else
+    fail "C2f forward-progress definition unclear"
+fi
+
+# ── H4: Skip empty Phase B dispatch ────────────────────────────────────────
+
+echo ""
+echo "  H4 — Skip Phase B dispatch when decision-set is no-op"
+echo "  ───────────────────────────────────────────────────"
+
+# The guard lives between C2c (build decision-set) and C2d (dispatch
+# Phase B). Look in the C2c–C2d transition area.
+c2_guard=$(awk '/^The decision-set lives in coordinator/,/^\*\*C2d/' "$SKILL")
+
+if echo "$c2_guard" | grep -qE 'Skip Phase B|decision-set is no-op'; then
+    pass "guard exists between C2c and C2d"
+else
+    fail "skip-empty guard missing"
+fi
+
+if echo "$c2_guard" | grep -qE 'all uncovered R-ids already terminal|already_decided'; then
+    pass "guard recognizes already_decided-only case"
+else
+    fail "guard doesn't recognize re-run-after-completion"
+fi
+
+if echo "$c2_guard" | grep -qE 'ack the propose marker|ack.*propose'; then
+    pass "guard still acks the propose marker on skip"
+else
+    fail "guard would leave propose marker stuck"
+fi
+
+if echo "$c2_guard" | grep -qE 'ONLY .skip. actions|only.*skip.*actions'; then
+    pass "guard distinguishes skip-only (still dispatch) from all-terminal (skip)"
+else
+    fail "guard doesn't distinguish skip-only from no-op cases"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1

--- a/tests/scenario-spec-backfill.sh
+++ b/tests/scenario-spec-backfill.sh
@@ -342,17 +342,31 @@ else
     fail "list-decisions output mismatch" "got: $output"
 fi
 
-# ── Test 14: report counts each status ──────────────────────────────────────
+# ── Test 14: report counts use latest-status semantics ────────────────────
+# (Updated 2026-05-11 per adversarial HIGH #1.)
+#
+# Pre-fix: cmd_report counted EACH row independently — so R2's two rows
+# (skipped then annotated) double-counted as both `skipped: 1` and
+# `annotated: 1`. The corpus-mode summary then overstated "skipped (will
+# resurface)" for already-resolved requirements.
+#
+# Post-fix: cmd_report uses latest-status semantics per (spec, rid). R2's
+# latest is `annotated`, so the `skipped` count drops to 0.
+#
+# Log state for this test:
+#   R1: annotated (one row)
+#   R2: skipped (row 1) → annotated (row 2) — latest is annotated
+#   R3: waived (one row)
+# Effective counts: annotated=2, skipped=0, waived=1.
 
 echo ""
-echo "── Test 14: report counts each status correctly"
+echo "── Test 14: report counts use latest-status semantics (HIGH #1)"
 
-# Log has: R1 annotated, R2 skipped+annotated, R3 waived → 4 rows total
 output=$(bash "$LOG" report "$TEST_BASE/log.md" 2>/dev/null)
-if echo "$output" | grep -qE 'rows: 4 +annotated: 2 +skipped: 1 +waived: 1'; then
-    pass "report counts rows=4 / annotated=2 / skipped=1 / waived=1"
+if echo "$output" | grep -qE 'rows: 4 +annotated: 2 +skipped: 0 +waived: 1'; then
+    pass "report counts rows=4 (raw) / annotated=2 / skipped=0 / waived=1 (effective)"
 else
-    fail "report counts mismatch" "got: $output"
+    fail "report counts wrong (expected latest-status semantics)" "got: $output"
 fi
 
 # ── Test 15: invalid status rejected ────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR 2 of 4 from the HIGH-findings cleanup. Covers `/spec-backfill` + `scripts/spec-backfill-log.sh`.

## Fixes

**H1 — report counts inflated when rows superseded.** `cmd_report` counted each row independently — a row flipped from skipped→annotated counted as BOTH. C3 corpus summary overstated "skipped". Fix: latest-status semantics per (spec, rid).

**H2 — C0 stuck-marker recovery ambiguous on suffixed IDs.** Markers are `<spec>--propose` (Phase A) / `<spec>--apply` (Phase B). Surfacing each as a separate prompt confused the user. Fix: group by spec-id (`${id%--*}`); per-spec routing table distinguishes which markers exist.

**H3 — corpus mode lacked forward-progress for specs with >12 uncovered.** Phase A's 12-cap made R-ids 13+ invisible across any number of runs. Fix: new C2f re-loop. After ack, if `more_remain=true` AND ≥1 forward progress (annotate/waive), re-dispatch Phase A. Capped at 3 iterations to prevent pathology; zero-progress stops the inner loop.

**H4 — Phase B dispatched on empty decision-set.** Re-runs after completion paid full sub-agent overhead to log zero rows. Fix: skip Phase B when `decisions` empty AND every item already terminal. Skip-only (user declined every R-id) still dispatches for audit-trail.

## Test 14 update

The existing Test 14 in `scenario-spec-backfill.sh` previously encoded the buggy behavior as expected (`annotated: 2 skipped: 1`). Corrected to the latest-status-correct values (`annotated: 2 skipped: 0`) with an inline explanation. This is a behavior change — anyone parsing the output of `spec-backfill-log.sh report` will see different counts after upgrade.

## Tests

| Suite | Result |
|-------|--------|
| `scenario-spec-backfill.sh` | 18/18 (Test 14 corrected) |
| `scenario-spec-backfill-corpus.sh` | NEW — 16 contract checks |

🤖 Generated with [Claude Code](https://claude.com/claude-code)