### PR TITLE
fix(curate): 4 HIGH adversarial findings

### DIFF
--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1339,19 +1339,39 @@ fi
 # is not referenced anywhere". The classification matters because the user
 # remediation differs: the former needs a refactor of existing annotations,
 # the latter needs new annotations from scratch.
+#
+# 2026-05-11 adversarial HIGH #4: pre-fix this ran a recursive grep over
+# the entire source tree PER unannotated spec — for 50 unannotated specs
+# on a large repo (jlsm scale) this is 50 full-tree walks, which was the
+# main driver of Analysis 18's 10-15 min runtime documented in SKILL.md.
+# The fix builds a one-time index file (`spec-refs-index.txt`) containing
+# every `@spec <id>...` line in the source tree, ONCE before the spec
+# loop. Per-spec membership becomes a single grep -qF against the index
+# (O(file_size), not O(tree_size × specs)).
+SPEC_REFS_INDEX="$TMPDIR_SCAN/spec-refs-index.txt"
+> "$SPEC_REFS_INDEX"
+grep -rhoE '@spec [A-Za-z][A-Za-z0-9_.-]*' \
+    --include='*.java' --include='*.py' --include='*.js' \
+    --include='*.ts' --include='*.go' --include='*.rs' \
+    --include='*.kt' --include='*.scala' --include='*.c' \
+    --include='*.cpp' --include='*.h' --include='*.hpp' \
+    --include='*.cs' --include='*.rb' --include='*.swift' \
+    --include='*.m' --include='*.sh' \
+    --exclude-dir='node_modules' --exclude-dir='vendor' \
+    --exclude-dir='target' --exclude-dir='build' --exclude-dir='dist' \
+    . 2>/dev/null \
+    | sort -u > "$SPEC_REFS_INDEX" || true
+
 has_bare_annotations() {
     local sid="$1"
-    local sid_re="${sid//./\\.}"
-    grep -rqE "@spec ${sid_re}([^.A-Za-z0-9_-]|\$)" \
-        --include='*.java' --include='*.py' --include='*.js' \
-        --include='*.ts' --include='*.go' --include='*.rs' \
-        --include='*.kt' --include='*.scala' --include='*.c' \
-        --include='*.cpp' --include='*.h' --include='*.hpp' \
-        --include='*.cs' --include='*.rb' --include='*.swift' \
-        --include='*.m' --include='*.sh' \
-        --exclude-dir='node_modules' --exclude-dir='vendor' \
-        --exclude-dir='target' --exclude-dir='build' --exclude-dir='dist' \
-        . 2>/dev/null
+    # A "bare" reference is `@spec <sid>` followed by NOT a dot (no
+    # `.R<n>` suffix). Match exactly via fixed-string grep on `@spec
+    # <sid> ` (note trailing space) — any line starting with that and
+    # NOT containing a dot in the matched identifier qualifies.
+    awk -v target="@spec $sid" '
+        $0 == target { found = 1; exit }
+        END { exit (found ? 0 : 1) }
+    ' "$SPEC_REFS_INDEX"
 }
 
 if [[ -f ".spec/registry/manifest.json" ]] && command -v jq >/dev/null 2>&1; then
@@ -2345,9 +2365,22 @@ if [[ -d ".decisions" && -f ".spec/registry/manifest.json" ]] && command -v jq >
 
     # Walk every ADR. Eligible = status accepted/proposed (would normally
     # have a spec). Skip rejected/superseded/deferred — those don't owe one.
+    #
+    # 2026-05-11 adversarial HIGH #2: previously used `-mindepth 2
+    # -maxdepth 2`, which silently skipped ADRs at deeper paths like
+    # `.decisions/<area>/<slug>/adr.md` (grouped-decisions layouts).
+    # Now walks any depth and derives the slug as the path-relative
+    # directory name. Spec decision_refs use the same slug convention
+    # (e.g., `area/slug` or just `slug`), so we compute the slug as
+    # the relative path under .decisions/ minus the trailing /adr.md.
     while IFS= read -r adr_file; do
         [[ -f "$adr_file" ]] || continue
-        slug="$(basename "$(dirname "$adr_file")")"
+        # Derive the slug: strip leading .decisions/ and trailing /adr.md
+        # so `.decisions/foo/adr.md` → `foo` and
+        # `.decisions/security/auth-tokens/adr.md` → `security/auth-tokens`.
+        slug="${adr_file#./}"
+        slug="${slug#.decisions/}"
+        slug="${slug%/adr.md}"
 
         # Skip if any spec references it.
         if grep -qxF "$slug" "$TMPDIR_SCAN/_adr-referenced.txt" 2>/dev/null; then
@@ -2373,7 +2406,7 @@ if [[ -d ".decisions" && -f ".spec/registry/manifest.json" ]] && command -v jq >
 
         echo "ADR_NO_SPEC|$slug|$adr_status|$adr_title" \
             >> "$TMPDIR_SCAN/adr-no-spec.txt"
-    done < <(find .decisions -mindepth 2 -maxdepth 2 -type f -name 'adr.md' 2>/dev/null | sort)
+    done < <(find .decisions -mindepth 2 -type f -name 'adr.md' 2>/dev/null | sort)
 
     rm -f "$TMPDIR_SCAN/_adr-referenced.txt"
 
@@ -2951,7 +2984,14 @@ if [[ -s "$TMPDIR_SCAN/kb-citation-drift.txt" ]]; then
     echo "" >> "$SUMMARY_FILE"
 fi
 
-# Spec annotation coverage rollup (Analysis 18b — F5)
+# Spec annotation coverage rollup (Analysis 18b — F5).
+# When MAX_SPECS_TRACED=0 (fast-scan path for large repos), Analyses 18
+# and 18b skip entirely — no rollup row in the tmp file. Pre-fix, the
+# section just disappeared from scan-summary.md with no explanation
+# (2026-05-11 adversarial HIGH #3), so the user reading the summary
+# couldn't tell "no annotation gaps" from "annotation analysis didn't
+# run." Emit an explicit "skipped" section in that case so the omission
+# is a positive signal.
 if [[ -s "$TMPDIR_SCAN/spec-annotation-rollup.txt" ]]; then
     while IFS='|' read -r _ traced unann bare drift full unann_pct bare_pct drift_pct full_pct; do
         echo "## Spec Annotation Coverage Rollup" >> "$SUMMARY_FILE"
@@ -2976,6 +3016,19 @@ if [[ -s "$TMPDIR_SCAN/spec-annotation-rollup.txt" ]]; then
             echo "" >> "$SUMMARY_FILE"
         fi
     done < "$TMPDIR_SCAN/spec-annotation-rollup.txt"
+elif (( MAX_SPECS_TRACED == 0 )); then
+    # Explicit "skipped" marker when fast-scan path was chosen. The
+    # absence of this section without explanation previously read as
+    # "no annotation gaps found" — which is wrong; the analysis just
+    # didn't run. 2026-05-11 adversarial HIGH #3.
+    echo "## Spec Annotation Coverage Rollup" >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
+    echo "_Skipped this run (\`--max-specs-traced 0\`). Per-spec annotation" >> "$SUMMARY_FILE"
+    echo "gap analysis (Analysis 18) and the corpus-level rollup (Analysis 18b)" >> "$SUMMARY_FILE"
+    echo "both require tracing each APPROVED spec; the fast-scan path skips" >> "$SUMMARY_FILE"
+    echo "them to keep runtime under 60s on large repos. Re-run with" >> "$SUMMARY_FILE"
+    echo "\`--max-specs-traced 50\` (or higher) to surface annotation gaps._" >> "$SUMMARY_FILE"
+    echo "" >> "$SUMMARY_FILE"
 fi
 
 # Spec graduation candidates (Analysis 27)

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -1127,23 +1127,18 @@ appends, trivial bookkeeping), handle inline as today.
 | KB schema drift / type-location mismatch | Reads KB entry frontmatter + body |
 | Subdivision candidate | Reads full spec body to assess split |
 
-**Pre-flight: stuck-marker recovery.** Before re-entering the pick
-list after a prior `/curate` run, check
-`.curate/_dispatches/` for unacknowledged markers:
+**Stuck-marker recovery already happened in Step 0.** Pre-fix, this
+section duplicated Step 0's pre-flight (lines 90-150) — users were
+prompted twice for the same stuck marker in one session (2026-05-11
+adversarial HIGH #1). Step 0 is the single recovery point; if the
+user reaches Step 4 with stuck markers present, Step 0 already
+surfaced them and the user made their choice. Do NOT re-run
+`dispatch-marker.sh stuck` here.
 
-```bash
-bash .claude/scripts/dispatch-marker.sh stuck .curate/_dispatches
-```
-
-If non-empty, surface each one via AskUserQuestion:
-- **"Re-dispatch <finding-key>"** — clear the marker, include the
-  finding in this run.
-- **"Skip <finding-key>"** — leave marker in place; it will resurface
-  next run.
-- **"Investigate manually"** — print the marker JSON via
-  `dispatch-marker.sh status` and stop.
-
-This mirrors `/work-resume rule 0` and `/spec-backfill` C0.
+If markers accumulate AFTER Step 0 (Phase A succeeded, Phase B
+interrupted mid-session within the SAME run), they're surfaced at
+the natural recovery boundary — typically the C2e ack-or-fail
+classifier directly within this iteration.
 
 **Phase A — diagnose + propose** (autonomous sub-agent):
 

--- a/tests/scenario-curate-high-cluster.sh
+++ b/tests/scenario-curate-high-cluster.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Scenario: /curate + curate-scan.sh HIGH fixes from 2026-05-11
+# adversarial sweep.
+#
+# H1: Step 4 no longer duplicates Step 0's stuck-marker recovery.
+# H2: Analysis 29 drops -maxdepth 2 (handles nested ADR layouts).
+# H3: MAX_SPECS_TRACED=0 writes an explicit "skipped" section so the
+#     omission is a positive signal, not a silent gap.
+# H4: has_bare_annotations uses a one-time index file (no per-spec
+#     recursive grep over the whole source tree).
+#
+# Run from repo root: bash tests/scenario-curate-high-cluster.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SCAN="$REPO_ROOT/scripts/curate-scan.sh"
+SKILL="$REPO_ROOT/skills/curate/SKILL.md"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+echo ""
+echo "scenario: /curate + curate-scan.sh HIGH cluster"
+echo "────────────────────────────────────────────────"
+
+# ── H1: Step 4 doesn't duplicate stuck-marker recovery ─────────────────────
+
+echo ""
+echo "  H1 — Step 4 no longer duplicates Step 0 stuck-marker recovery"
+echo "  ─────────────────────────────────────────────────────────"
+
+step4=$(awk '/^### Step 4 dispatch protocol/,/^## Step 5/' "$SKILL")
+
+if echo "$step4" | grep -qE 'Stuck-marker recovery already happened in Step 0'; then
+    pass "Step 4 explicitly references Step 0's single recovery point"
+else
+    fail "Step 4 doesn't acknowledge Step 0 handles stuck markers"
+fi
+
+# Step 4 must NOT call `dispatch-marker.sh stuck` again (that was the duplicate).
+if echo "$step4" | grep -qE 'dispatch-marker\.sh stuck \.curate/_dispatches'; then
+    fail "Step 4 still re-runs dispatch-marker.sh stuck (duplicates Step 0)"
+else
+    pass "Step 4 doesn't re-run dispatch-marker.sh stuck"
+fi
+
+# Step 0 still has the stuck-marker pre-flight (the canonical recovery point).
+step0=$(awk '/^## Step 0 — Pre-flight/,/^## Step 0\.5/' "$SKILL")
+if echo "$step0" | grep -qE 'dispatch-marker\.sh stuck'; then
+    pass "Step 0 retains the canonical stuck-marker recovery"
+else
+    fail "Step 0 missing stuck-marker recovery (would lose feature entirely)"
+fi
+
+# ── H2: Analysis 29 walks nested ADR layouts ───────────────────────────────
+
+echo ""
+echo "  H2 — Analysis 29 drops -maxdepth 2 (handles nested ADRs)"
+echo "  ──────────────────────────────────────────────────────"
+
+# Find the Analysis 29 find invocation
+a29=$(awk '/^# ── Analysis 29:/,/rm -f.*_adr-referenced\.txt/' "$SCAN")
+
+if echo "$a29" | grep -qE 'find \.decisions -mindepth 2 -type f -name .adr\.md'; then
+    pass "Analysis 29 uses -mindepth 2 with no -maxdepth (handles nested)"
+else
+    fail "Analysis 29 not using the corrected find invocation"
+fi
+
+if echo "$a29" | grep -qE '\-mindepth 2 -maxdepth 2'; then
+    fail "Analysis 29 still has the -maxdepth 2 restriction"
+else
+    pass "Analysis 29 no longer has -maxdepth 2 restriction"
+fi
+
+# The slug derivation must use the relative path (not just basename),
+# so `.decisions/area/slug/adr.md` → `area/slug`.
+if echo "$a29" | grep -qE 'slug.*\.decisions/'; then
+    pass "Analysis 29 derives slug from path-relative location"
+else
+    fail "Analysis 29 still uses basename-only slug"
+fi
+
+# ── H3: MAX_SPECS_TRACED=0 writes explicit "skipped" section ───────────────
+
+echo ""
+echo "  H3 — MAX_SPECS_TRACED=0 writes explicit Skipped rollup section"
+echo "  ─────────────────────────────────────────────────────────────"
+
+# Set up a tiny project and run with --max-specs-traced 0.
+TEST_DIR="/tmp/vallorcine/scenario-curate-max0"
+rm -rf "$TEST_DIR" 2>/dev/null || true
+mkdir -p "$TEST_DIR/.claude/scripts" "$TEST_DIR/.spec/registry" "$TEST_DIR/.spec/domains" "$TEST_DIR/.curate"
+cp "$SCAN" "$TEST_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$TEST_DIR/.claude/scripts/" 2>/dev/null || true
+
+# Minimal git fixture so the scan doesn't bail.
+cd "$TEST_DIR"
+git init -q
+git config user.email t@t.t
+git config user.name t
+echo "hello" > foo.txt
+git add -A
+git commit -q -m "init"
+
+# Manifest with one APPROVED spec (so the analysis WOULD have something to skip).
+cat > .spec/registry/manifest.json <<'EOF'
+{
+  "schema_version": 2,
+  "specs": [
+    {"id": "test.example", "state": "APPROVED"}
+  ]
+}
+EOF
+
+# Run with --max-specs-traced 0
+bash .claude/scripts/curate-scan.sh --init --max-specs-traced 0 >/dev/null 2>&1
+
+if [[ -f .curate/scan-summary.md ]]; then
+    if grep -q "^## Spec Annotation Coverage Rollup" .curate/scan-summary.md \
+       && grep -qE "Skipped this run.*max-specs-traced 0" .curate/scan-summary.md; then
+        pass "MAX_SPECS_TRACED=0 writes explicit Skipped rollup section"
+    else
+        fail "no 'Skipped this run' marker for max-specs-traced=0" \
+             "$(grep -A2 'Annotation Coverage Rollup' .curate/scan-summary.md || echo '<missing>')"
+    fi
+else
+    fail "scan-summary.md not created"
+fi
+
+cd "$REPO_ROOT"
+rm -rf "$TEST_DIR" 2>/dev/null || true
+
+# ── H4: has_bare_annotations uses one-time index ───────────────────────────
+
+echo ""
+echo "  H4 — has_bare_annotations uses one-time index (no per-spec walk)"
+echo "  ──────────────────────────────────────────────────────────────"
+
+# The script must define SPEC_REFS_INDEX and pre-build it once.
+if grep -qE 'SPEC_REFS_INDEX=' "$SCAN"; then
+    pass "SPEC_REFS_INDEX variable declared (one-time index path)"
+else
+    fail "SPEC_REFS_INDEX variable missing — per-spec walks still in place"
+fi
+
+# The pre-built grep MUST be outside the spec loop (one call before
+# the `while IFS= read -r sid` enumeration).
+# Verify by checking the line ordering.
+index_build_line=$(grep -nE 'grep -rhoE .@spec ' "$SCAN" | head -1 | cut -d: -f1)
+spec_loop_line=$(grep -nE 'while IFS= read -r sid; do' "$SCAN" | head -1 | cut -d: -f1)
+if [[ -n "$index_build_line" && -n "$spec_loop_line" && "$index_build_line" -lt "$spec_loop_line" ]]; then
+    pass "index pre-built BEFORE the per-spec loop (line $index_build_line < $spec_loop_line)"
+else
+    fail "index build / loop ordering wrong (or grep pattern not found)"
+fi
+
+# has_bare_annotations should NOT do a recursive grep itself.
+hba_body=$(awk '/^has_bare_annotations\(\)/,/^}$/' "$SCAN")
+if echo "$hba_body" | grep -qE 'grep -rqE.*@spec'; then
+    fail "has_bare_annotations still does recursive grep per call"
+else
+    pass "has_bare_annotations no longer does recursive grep per call"
+fi
+
+# has_bare_annotations should reference the SPEC_REFS_INDEX file
+if echo "$hba_body" | grep -qE 'SPEC_REFS_INDEX'; then
+    pass "has_bare_annotations checks against SPEC_REFS_INDEX"
+else
+    fail "has_bare_annotations doesn't reference the index file"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

PR 3 of 4. Covers `/curate` + `scripts/curate-scan.sh`.

## Fixes

**H1 — Step 4 duplicated Step 0's stuck-marker recovery.** Users were prompted twice in one session for the same stuck marker. Removed Step 4's pre-flight; it now points at Step 0 as the single recovery point.

**H2 — Analysis 29 silently skipped nested ADR layouts.** `-maxdepth 2` excluded `.decisions/<area>/<slug>/adr.md`. Slug derivation also produced wrong values. Fix: drop `-maxdepth 2`; derive slug as path-relative location.

**H3 — `MAX_SPECS_TRACED=0` silently disabled rollup with no signal.** Fast-scan path made the Spec Annotation Coverage Rollup section disappear from scan-summary.md without explanation. Fix: emit an explicit `_Skipped this run..._` section when MAX_SPECS_TRACED=0 so the omission is a positive signal.

**H4 — `has_bare_annotations` did unbounded recursive grep per spec.** For N unannotated specs, N full-tree walks over 16 file extensions (the main driver of Analysis 18's 10-15 min runtime). Fix: pre-build one-time `spec-refs-index.txt` BEFORE the spec loop; `has_bare_annotations` becomes a single awk match against the index. O(file_size) instead of O(tree_size × specs).

## Tests

- `scenario-curate-high-cluster.sh` (NEW, 11 checks)
- `scenario-curate-scan.sh`: 86/86 (no regression)
- `test-install.sh`: 74/74 (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)