### PR TITLE
fix(work-decompose): 4 HIGH adversarial findings

### DIFF
--- a/scripts/work-validate.sh
+++ b/scripts/work-validate.sh
@@ -432,6 +432,27 @@ check_decompose_invariant() {
   local unsettled=()
   local settled_count=0
 
+  # "Defer all" escape hatch (2026-05-11 adversarial HIGH #4). When the
+  # user picks "Defer all to /work-plan" at Step 3, Phase B never runs,
+  # so by construction no cross-WD coordination surface is settled. The
+  # tentative WDs still need to validate structurally, but the
+  # cross-WD invariant cannot be enforced here — it's the user's
+  # explicit decision to defer settlement to /work-plan.
+  #
+  # The deferral is recorded in work.md frontmatter as
+  # `phase_b_deferred: true`. When that flag is set, skip the invariant
+  # check and emit a one-line note. /work-plan and /work-start will
+  # surface any actual cross-WD breakage when WD-level planning runs.
+  if [[ -f "$work_md" ]]; then
+    local deferred
+    deferred=$(work_fm "$work_md" "phase_b_deferred")
+    if [[ "$deferred" == "true" ]]; then
+      echo "  SKIP  decompose invariant: phase_b_deferred=true in work.md"
+      echo "        Cross-WD references will be settled at /work-plan time."
+      return 0
+    fi
+  fi
+
   # Build the union of all produces: entries across all WDs in the group.
   # Format in the set: "<type>:<ref>" (e.g. "spec:encryption/primitives").
   local -A PRODUCED

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -50,6 +50,33 @@ Run after `/work "<goal>"` has created the work group.
         2>/dev/null | head -1
    ```
 
+   **Scoped orphan check for "Add more" flows (2026-05-11 adversarial
+   HIGH #1).** When the user runs `/work-decompose` on a group that
+   already has some live WDs (the "Add more" pattern — extending an
+   existing decomposition with additional WDs), the global "any WD
+   past DRAFT" signal would always fire and mis-classify the
+   checkpoint as an orphan. The checkpoint frontmatter should record
+   which WD slot range Phase A is operating on:
+
+   ```yaml
+   phase_a_target_wds: ["WD-05", "WD-06"]   # the new WDs being added
+   ```
+
+   When this field is present in the checkpoint, restrict the orphan
+   detector to only those WD slots:
+
+   ```bash
+   for wd_id in <phase_a_target_wds>; do
+     [[ -f ".work/<group-slug>/${wd_id}.md" ]] \
+       && grep -qE '^status: (SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' \
+            ".work/<group-slug>/${wd_id}.md" \
+       && echo "orphan-candidate"
+   done | head -1
+   ```
+
+   If `phase_a_target_wds` is absent (legacy checkpoints, fresh
+   decomposition), fall back to the global scan above.
+
    Surface accordingly:
 
    **Genuine in-flight checkpoint** (no WDs past DRAFT, recent):
@@ -450,8 +477,21 @@ Use AskUserQuestion with options:
 If "Pre-commit some decisions": record the pre-committed choices, then
 remove matching items from the surfaces list before proceeding.
 
-If "Defer all": skip to Step 5 (Phase C) with the tentative decomposition.
-Log a warning in manifest.md that Phase B was deferred.
+If "Defer all": skip to Step 5 (Phase C) with the tentative
+decomposition. **Set `phase_b_deferred: true` in `work.md` frontmatter
+BEFORE running Step 7's validate** (2026-05-11 adversarial HIGH #4).
+
+Pre-fix, "Defer all" wedged at Step 7: `work-validate.sh --decompose`
+runs the cross-WD coordination-surface invariant, which by
+construction fails when no surfaces are settled. Users hit
+`unsettled cross-WD reference(s)` even though they explicitly chose
+to defer. The validator now respects `phase_b_deferred: true` and
+skips that invariant with a one-line "SKIP" note; downstream
+`/work-plan` and `/work-start` runs surface any actual cross-WD
+breakage when WD-level planning happens.
+
+Also append a `phase_b_deferred:` note to manifest.md's narrative so
+the user sees it in `/work-status` output.
 
 If "Adjust the seams": apply changes and re-present.
 
@@ -571,6 +611,38 @@ These become the `artifact_deps:` WDs will reference in Step 6.
 
 Atomic write each time (`.tmp` then rename). This way, a crash mid-Phase-B
 loses at most the in-flight surface, not all prior settlements.
+
+**Post-write self-validation (2026-05-11 adversarial HIGH #2 + #3).**
+The three structural mutations on one markdown file are LLM-driven —
+flipping the wrong row in the seams table when subjects collide on
+substring is a real failure mode. After each write, re-parse the
+checkpoint and verify:
+
+1. The new row is present in `## Phase B — Settled`.
+2. Exactly ONE row in the seams table has `Settled: yes` for THIS
+   surface (no other rows accidentally flipped).
+3. The total settled-count in the table equals the number of rows in
+   `## Phase B — Settled` (the two sections must agree).
+
+If the self-check fails:
+- Restore from the `.tmp` backup if it still exists.
+- Surface to the user via `AskUserQuestion` with options: **Retry the
+  edit** / **Investigate the checkpoint manually** / **Stop**.
+- Do NOT proceed to the next surface — silent corruption here cascades
+  on every subsequent settle.
+
+The pattern that historically bit users: two surfaces with subjects
+like "encoding for IDs" and "encoding for KIDs" — the LLM flips row 1
+when settling surface 2, leaving surface 1 marked as settled (without
+its artifact) and surface 2 marked as unsettled (with its artifact in
+Phase B — Settled). The cross-section count check catches this.
+
+**Migration note.** This SKILL still uses a markdown checkpoint that
+the LLM edits in place. The medium-term fix is a JSON checkpoint with
+a helper script (`work-decompose-checkpoint.sh settle <surface-id>
+<artifact-produced>`) doing the edits — same shape as
+`work-orchestrator.sh`. Until that migration lands, this self-check
+is the safety net.
 
 ---
 

--- a/tests/scenario-decompose-high-cluster.sh
+++ b/tests/scenario-decompose-high-cluster.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Scenario: /work-decompose + work-validate.sh HIGH fixes from 2026-05-11
+# adversarial sweep.
+#
+# H1: orphan classifier scoped to Phase A's target WD slots via
+#     phase_a_target_wds checkpoint field (no false positives on
+#     "Add more" flows).
+# H2/H3: post-write self-validation step after each checkpoint update
+#        (atomicity + LLM-parsing fragility safety net).
+# H4: "Defer all" no longer wedges Step 7 — work-validate.sh respects
+#     phase_b_deferred: true in work.md frontmatter and skips the
+#     cross-WD invariant.
+#
+# Run from repo root: bash tests/scenario-decompose-high-cluster.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SKILL="$REPO_ROOT/skills/work-decompose/SKILL.md"
+VALIDATE="$REPO_ROOT/scripts/work-validate.sh"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+echo ""
+echo "scenario: /work-decompose HIGH cluster"
+echo "────────────────────────────────────────────────"
+
+# ── H1: phase_a_target_wds scoping ──────────────────────────────────────────
+
+echo ""
+echo "  H1 — orphan classifier scoped to phase_a_target_wds"
+echo "  ───────────────────────────────────────────────"
+
+orphan_section=$(awk '/Orphan-checkpoint signal/,/Use AskUserQuestion with options:/' "$SKILL")
+
+if echo "$orphan_section" | grep -qE 'phase_a_target_wds'; then
+    pass "SKILL references phase_a_target_wds checkpoint field"
+else
+    fail "SKILL missing phase_a_target_wds reference"
+fi
+
+if echo "$orphan_section" | grep -qE 'Add more'; then
+    pass "SKILL acknowledges the 'Add more' flow"
+else
+    fail "SKILL doesn't mention 'Add more' flow"
+fi
+
+if echo "$orphan_section" | grep -qE 'absent.*legacy.*fall back|fall back to the global scan'; then
+    pass "SKILL provides legacy fallback when field is absent"
+else
+    fail "SKILL missing legacy fallback"
+fi
+
+# ── H2/H3: post-write self-validation ──────────────────────────────────────
+
+echo ""
+echo "  H2/H3 — post-write self-validation after checkpoint update"
+echo "  ────────────────────────────────────────────────────────"
+
+self_check=$(awk '/Post-write self-validation/{p=1} p; /^---$/ && p {p=0}' "$SKILL")
+
+if [[ -n "$self_check" ]]; then
+    pass "SKILL has Post-write self-validation section"
+else
+    fail "SKILL missing self-validation section"
+fi
+
+# Three checks must be specified
+if echo "$self_check" | grep -qE 'new row is present.*Phase B — Settled'; then
+    pass "check 1: new row exists in Phase B — Settled"
+else
+    fail "check 1 missing"
+fi
+
+if echo "$self_check" | tr '\n' ' ' | tr -s ' ' | grep -qE 'Exactly ONE row.*seams table.*Settled: yes|exactly ONE'; then
+    pass "check 2: exactly one row flipped in seams table"
+else
+    fail "check 2 missing"
+fi
+
+if echo "$self_check" | grep -qiE 'count.*equals.*settled|two sections must agree'; then
+    pass "check 3: cross-section count agreement"
+else
+    fail "check 3 missing"
+fi
+
+if echo "$self_check" | tr '\n' ' ' | tr -s ' ' | grep -qE 'AskUserQuestion.*Retry'; then
+    pass "self-validation failure routes via AskUserQuestion"
+else
+    fail "self-validation failure doesn't use AskUserQuestion"
+fi
+
+# Migration note acknowledges the JSON-checkpoint future direction
+if echo "$self_check" | grep -qE 'JSON checkpoint|helper script.*settle'; then
+    pass "Migration note documents the JSON-checkpoint future direction"
+else
+    fail "Migration note missing"
+fi
+
+# ── H4: work-validate.sh tolerates phase_b_deferred ────────────────────────
+
+echo ""
+echo "  H4 — work-validate.sh respects phase_b_deferred: true"
+echo "  ───────────────────────────────────────────────────"
+
+# Validator code path
+val_section=$(awk '/check_decompose_invariant\(\)/,/Build the union of all produces/' "$VALIDATE")
+
+if echo "$val_section" | grep -qF "phase_b_deferred"; then
+    pass "validator code checks phase_b_deferred field"
+else
+    fail "validator doesn't check phase_b_deferred"
+fi
+
+if echo "$val_section" | grep -qE 'SKIP.*invariant|return 0'; then
+    pass "validator skips invariant when flag is set"
+else
+    fail "validator doesn't short-circuit on deferred flag"
+fi
+
+# SKILL.md prescribes writing the flag when "Defer all" is chosen
+defer_section=$(awk '/^If "Defer all"/,/^If "Adjust the seams"/' "$SKILL")
+
+if echo "$defer_section" | grep -qE 'phase_b_deferred: true'; then
+    pass "SKILL prescribes writing phase_b_deferred: true on Defer all"
+else
+    fail "SKILL doesn't prescribe writing the flag"
+fi
+
+if echo "$defer_section" | grep -qE 'BEFORE running Step 7'; then
+    pass "SKILL orders write BEFORE validate runs"
+else
+    fail "SKILL ordering unclear"
+fi
+
+# ── H4 LIVE: validate a fixture with phase_b_deferred set ──────────────────
+
+echo ""
+echo "  H4 LIVE — validator actually skips when flag is set"
+echo "  ──────────────────────────────────────────────────"
+
+TEST_DIR="/tmp/vallorcine/scenario-decompose-defer"
+rm -rf "$TEST_DIR" 2>/dev/null || true
+mkdir -p "$TEST_DIR/.work/deferred-group" "$TEST_DIR/.claude/scripts" "$TEST_DIR/.spec/registry" "$TEST_DIR/.decisions"
+cp "$VALIDATE" "$TEST_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/work-resolve.sh" "$TEST_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/work-lib.sh" "$TEST_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$TEST_DIR/.claude/scripts/" 2>/dev/null || true
+echo '{"schema_version":2,"specs":[]}' > "$TEST_DIR/.spec/registry/manifest.json"
+
+# work.md with phase_b_deferred: true
+cat > "$TEST_DIR/.work/deferred-group/work.md" <<'EOF'
+---
+group: deferred-group
+goal: Test deferral
+status: DRAFT
+phase_b_deferred: true
+---
+
+## Tentative WDs
+
+| WD | Title |
+|----|-------|
+| WD-01 | Test |
+EOF
+
+# A WD with an artifact_dep that wouldn't resolve (the kind of thing
+# the invariant would normally fail on).
+cat > "$TEST_DIR/.work/deferred-group/WD-01.md" <<'EOF'
+---
+id: WD-01
+title: Test WD
+group: deferred-group
+status: DRAFT
+domains: [test]
+artifact_deps:
+  - { type: spec, ref: "nonexistent/contract", required_state: APPROVED }
+produces: []
+---
+
+## Summary
+Test.
+
+## Acceptance Criteria
+Test.
+EOF
+
+# Run validate --decompose. Without the H4 fix, this would FAIL on the
+# unsettled cross-WD reference. With the fix, it SKIPs that check
+# because phase_b_deferred is true.
+cd "$TEST_DIR"
+out=$(bash .claude/scripts/work-validate.sh --group deferred-group --decompose 2>&1 || true)
+cd "$REPO_ROOT"
+
+if echo "$out" | grep -qE "SKIP.*decompose invariant.*phase_b_deferred"; then
+    pass "validator SKIPs invariant with explicit message on deferred group"
+else
+    fail "validator didn't skip on deferred flag" "got: $out"
+fi
+
+# It MUST NOT print FAIL for the cross-WD reference (the bug we're fixing).
+if echo "$out" | grep -qE "unsettled cross-WD reference"; then
+    fail "validator still fails on unsettled refs despite deferred flag"
+else
+    pass "no 'unsettled cross-WD reference' error when deferred"
+fi
+
+rm -rf "$TEST_DIR" 2>/dev/null || true
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

PR 4 of 4. Covers `/work-decompose` SKILL + `scripts/work-validate.sh`.

## Fixes

**H1 — orphan classifier mis-classified "Add more" flows.** Global "any WD past DRAFT" signal always fired on groups already partially decomposed. Fix: scope the detector to the WD slots Phase A is operating on, tracked via `phase_a_target_wds` in the checkpoint frontmatter. Fall back to global scan when the field is absent.

**H2 + H3 — checkpoint atomicity + LLM-parsing fragility.** Step 4 did three structural mutations on one markdown file via LLM editing; subject-substring collisions could flip the wrong seams row and silently corrupt the checkpoint. Fix: post-write self-validation re-parses and verifies (1) new row in Phase B — Settled, (2) exactly ONE row flipped in seams table, (3) cross-section count agreement. Failure routes via AskUserQuestion. Migration note documents the JSON-checkpoint future direction.

**H4 — "Defer all" wedged Step 7.** `work-validate.sh --decompose` ran the cross-WD invariant which by construction fails when no surfaces are settled. Fix: validator reads `phase_b_deferred: true` from `work.md` frontmatter and SKIPs the invariant with a clear message. SKILL prescribes writing the flag before Step 7 runs.

## Tests

`scenario-decompose-high-cluster.sh` — 15 checks including a LIVE validator run against a fixture with `phase_b_deferred: true` that would otherwise fail the unsettled-references invariant.

No regressions: scenario-work-validate (22/22), scenario-work-resolve (21/21), test-install (74/74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)