### PR TITLE
fix: 5 MEDIUM findings (work-decompose + work-resume)

### DIFF
--- a/scripts/work-orchestrator.sh
+++ b/scripts/work-orchestrator.sh
@@ -126,6 +126,34 @@ validate_wd_id() {
 # both read epoch=5, both write epoch=6). The future /work-run skill
 # should detect contention via the orchestrator-state directory's existence
 # rather than running two sessions against the same group.
+#
+# 2026-05-11 adversarial MED #1 (cluster 1): defensive flock around
+# mutating cross-set transitions. /work-run is the single driver in
+# practice, but /work-resume Step 2c reads the same directory via
+# `status` and a `complete` running concurrently could trigger a
+# transient read on a partially-moved file (WD briefly in BOTH or
+# NEITHER of in-flight/ and completed/ during the rm + write window).
+#
+# The wrapper acquires an exclusive file lock on $dir/.state.lock for
+# the duration of the caller's block. If flock isn't available
+# (containers, ancient shells), the wrapper degrades to a no-op —
+# single-driver assumption stands. Callers wrap the rm + write_*
+# sequence in `acquire_state_lock "$dir"` as a guard.
+
+acquire_state_lock() {
+  local dir="$1"
+  # Returns 0 if lock acquired (caller proceeds), or sets up a no-op
+  # when flock is missing. The lock auto-releases when the calling
+  # shell's FD 9 closes (at function/script exit).
+  if command -v flock >/dev/null 2>&1; then
+    mkdir -p "$dir" 2>/dev/null || true
+    exec 9>"$dir/.state.lock"
+    flock -x -w 30 9 || {
+      echo "ERROR: failed to acquire state lock on $dir within 30s" >&2
+      exit 2
+    }
+  fi
+}
 
 # ── State-directory locator ─────────────────────────────────────────────────
 
@@ -641,6 +669,10 @@ cmd_complete() {
     exit 3
   fi
 
+  # Hold the state lock across the rm + write to prevent concurrent
+  # `status`/`dump`/`hung` from seeing a torn state.
+  acquire_state_lock "$dir"
+
   # Order: rm in-flight FIRST, then write completed. A crash between the
   # two leaves the WD in NEITHER set — recoverable on next re-resolve
   # since work-resolve will see the WD's underlying COMPLETE status and
@@ -684,6 +716,8 @@ cmd_block() {
   local feature_slug
   feature_slug=$(grep -oE '"feature_slug":[[:space:]]*"[^"]*"' "$dir/in-flight/$wd_id.json" \
     | sed -E 's/.*"([^"]*)"/\1/')
+
+  acquire_state_lock "$dir"
 
   # Order: rm in-flight FIRST, then write blocked. See cmd_complete for
   # rationale — neither-set crash window is recoverable; both-set isn't.
@@ -736,6 +770,8 @@ cmd_skip() {
     echo "ERROR: $wd_id is not blocked (cannot skip)" >&2
     exit 3
   fi
+
+  acquire_state_lock "$dir"
 
   # Order: rm blocked FIRST, then write completed — same crash-window
   # rationale as cmd_complete / cmd_block.

--- a/skills/work-decompose/SKILL.md
+++ b/skills/work-decompose/SKILL.md
@@ -46,7 +46,7 @@ Run after `/work "<goal>"` has created the work group.
    that wrote the WDs but never cleared the file. Use:
    ```bash
    find ".work/<group-slug>" -maxdepth 1 -name 'WD-*.md' \
-        -exec grep -lE '^status: (SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' {} + \
+        -exec grep -lE '^[[:space:]]*status:[[:space:]]*(SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' {} + \
         2>/dev/null | head -1
    ```
 
@@ -68,7 +68,7 @@ Run after `/work "<goal>"` has created the work group.
    ```bash
    for wd_id in <phase_a_target_wds>; do
      [[ -f ".work/<group-slug>/${wd_id}.md" ]] \
-       && grep -qE '^status: (SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' \
+       && grep -qE '^[[:space:]]*status:[[:space:]]*(SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' \
             ".work/<group-slug>/${wd_id}.md" \
        && echo "orphan-candidate"
    done | head -1
@@ -841,18 +841,7 @@ bash .claude/scripts/work-index.sh update "<group-slug>"
 
 Do not hand-edit the WDs count or any column in `.work/CLAUDE.md`.
 
-### Populate the readiness cache
-
-Run the resolver once now so `_readiness.json` reflects the freshly-written
-WDs. This makes `/work-resume` cheap on the first invocation after a
-`/clear` and gives parallel sessions immediate visibility into the new
-WDs:
-
-```bash
-bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
-```
-
-### Run invariant check
+### Run invariant check (BEFORE populating the readiness cache)
 
 ```bash
 bash .claude/scripts/work-validate.sh --group "<group-slug>" --decompose
@@ -860,13 +849,32 @@ bash .claude/scripts/work-validate.sh --group "<group-slug>" --decompose
 
 This verifies that every cross-WD reference has a settled group-level
 artifact (from Phase B or pre-existing). If the check fails, display the
-unsettled references and offer options:
+unsettled references and offer options via `AskUserQuestion`:
 - "Re-open Phase B to settle them"
 - "Mark them out of scope in work.md and proceed"
 - "Stop"
 
 Decomposition is not complete until the invariant passes or is
 explicitly waived.
+
+**Order matters here** (2026-05-11 adversarial MED #1). Previously this
+ran the resolver BEFORE validate, so a failed invariant left
+`_readiness.json` stamped with the post-resolver snapshot of a
+half-finished decomposition. `/work-resume` Step 3's mtime check then
+treated the cache as fresh and downstream skills consumed it as if
+decomposition completed. Run validate first; only populate the cache
+once decomposition is actually durable.
+
+### Populate the readiness cache
+
+Run the resolver once now so `_readiness.json` reflects the freshly-written
+WDs AND a passing decompose invariant. This makes `/work-resume` cheap
+on the first invocation after a `/clear` and gives parallel sessions
+immediate visibility into the new WDs:
+
+```bash
+bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
+```
 
 ### Clear the Phase A/B checkpoint
 

--- a/skills/work-resume/SKILL.md
+++ b/skills/work-resume/SKILL.md
@@ -119,14 +119,44 @@ distinct handling:
    Even if the group hasn't moved past DRAFT, the user has clearly
    abandoned this attempt; offer recovery.
 
-**Detection rule**: classify the checkpoint as an orphan if EITHER:
+**Detection rule (2026-05-11 adversarial MED #3 added a third signal):**
+classify the checkpoint as one of three states. Check in order; first
+match wins.
+
+- **(c) Corrupted / partially-deleted** — `manifest.md` lists WDs in
+  its Work Definitions table but FEWER `WD-*.md` files exist on disk
+  than the table claims, OR the manifest lists WDs that the
+  filesystem does not contain at all. Pre-fix: the orphan classifier
+  fell through to "genuinely in-flight" when the find returned zero
+  past-DRAFT WDs (because there were zero WDs at all), telling the
+  user to run `/work-decompose` to resume — but the underlying state
+  is corrupt, not in-flight. The user might restore from git, rerun
+  decompose, or accept the loss.
+
+  Detection:
+  ```bash
+  manifest_count=$(awk '/^\| WD-[0-9]/' .work/<group-slug>/manifest.md 2>/dev/null | wc -l)
+  fs_count=$(find .work/<group-slug> -maxdepth 1 -name 'WD-*.md' 2>/dev/null | wc -l)
+  if [[ "$manifest_count" -gt 0 ]] && (( fs_count < manifest_count )); then
+    classify_as=corrupted_partial
+  fi
+  ```
+
+  Surface via `AskUserQuestion`:
+  - **Restore from git** (recommended if the user remembers wiping
+    the dir) — exit so the user can `git checkout HEAD -- .work/<group>`
+  - **Re-run `/work-decompose` from scratch** — discard the checkpoint
+    and the inconsistent manifest entries
+  - **Stop** — exit and investigate
+
+Otherwise, classify the checkpoint as an orphan if EITHER:
 
 - (a) **At least one WD has progressed past DRAFT.** Use `find ... -exec`
   rather than piping to `xargs` — `xargs` without `-r` hangs on macOS
   when the input is empty:
   ```bash
   find ".work/<group-slug>" -maxdepth 1 -name 'WD-*.md' \
-       -exec grep -lE '^status: (SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' {} + \
+       -exec grep -lE '^[[:space:]]*status:[[:space:]]*(SPECIFYING|SPECIFIED|IMPLEMENTING|COMPLETE)$' {} + \
        2>/dev/null | head -1
   ```
   If the command prints any path, treat as orphan. Phase C must have run
@@ -269,15 +299,40 @@ state machine and Step 5 must not present a conflicting recommendation
 
 ## Step 3 — Refresh readiness cache (if needed)
 
-Decide whether the cache is fresh with this single check (mtime-based,
-no JSON parsing needed):
+Decide whether the cache is fresh with this two-stage check:
 
 ```bash
 CACHE=".work/<group-slug>/_readiness.json"
-if [[ ! -f "$CACHE" ]] || \
-   find ".work/<group-slug>" -maxdepth 1 \
+# Stage 1: cache missing OR any source file is strictly newer →
+# regenerate. The strict mtime comparison covers most cases.
+needs_refresh=0
+if [[ ! -f "$CACHE" ]]; then
+  needs_refresh=1
+elif find ".work/<group-slug>" -maxdepth 1 \
         \( -name 'WD-*.md' -o -name 'work.md' \) \
-        -newer "$CACHE" -print -quit | grep -q .; then
+        -newer "$CACHE" -print -quit 2>/dev/null | grep -q .; then
+  needs_refresh=1
+else
+  # Stage 2 (2026-05-11 adversarial MED #2): handle 1-second mtime
+  # granularity. On filesystems where mtime has seconds resolution
+  # (older HFS+, some network FS), a same-second edit then resolve
+  # would show as "not strictly newer" and the cache would serve
+  # stale data. Compare mtimes for equality and force a refresh
+  # when any source file has the SAME mtime as the cache — the
+  # rare false-positive cost (one extra resolver run) is cheap
+  # compared to the stale-cache cost.
+  cache_mtime=$(stat -c %Y "$CACHE" 2>/dev/null || stat -f %m "$CACHE" 2>/dev/null || echo 0)
+  for src in .work/<group-slug>/WD-*.md .work/<group-slug>/work.md; do
+    [[ -f "$src" ]] || continue
+    src_mtime=$(stat -c %Y "$src" 2>/dev/null || stat -f %m "$src" 2>/dev/null || echo 0)
+    if [[ "$src_mtime" -eq "$cache_mtime" ]]; then
+      needs_refresh=1
+      break
+    fi
+  done
+fi
+
+if (( needs_refresh )); then
   bash .claude/scripts/work-resolve.sh "<group-slug>" >/dev/null
 fi
 ```

--- a/tests/scenario-work-medium-cluster.sh
+++ b/tests/scenario-work-medium-cluster.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Scenario: work-decompose + work-resume MEDIUM fixes from 2026-05-11
+# adversarial sweep.
+#
+# decompose M1: Step 7 ordering — validate BEFORE populating cache.
+# decompose M2: orphan-detection regex tolerates YAML-indented status.
+# work-resume M1: orchestrator acquires state lock on mutating cmds.
+# work-resume M2: Step 3 mtime check has a same-mtime stage-2 path.
+# work-resume M3: Step 2a detects corrupted/partially-deleted state.
+#
+# Run from repo root: bash tests/scenario-work-medium-cluster.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+DECOMP_SKILL="$REPO_ROOT/skills/work-decompose/SKILL.md"
+RESUME_SKILL="$REPO_ROOT/skills/work-resume/SKILL.md"
+ORCH="$REPO_ROOT/scripts/work-orchestrator.sh"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+echo ""
+echo "scenario: work-decompose + work-resume MEDIUM cluster"
+echo "────────────────────────────────────────────────"
+
+# ── decompose M1: validate BEFORE cache populate ───────────────────────────
+
+echo ""
+echo "  decompose M1 — Step 7 runs validate BEFORE populating cache"
+echo "  ──────────────────────────────────────────────────────"
+
+# The validate section must appear in Step 7 BEFORE the cache populate section.
+val_line=$(grep -n "Run invariant check" "$DECOMP_SKILL" | grep -v "fails" | head -1 | cut -d: -f1)
+cache_line=$(grep -n "Populate the readiness cache" "$DECOMP_SKILL" | head -1 | cut -d: -f1)
+
+if [[ -n "$val_line" && -n "$cache_line" && "$val_line" -lt "$cache_line" ]]; then
+    pass "validate (line $val_line) runs BEFORE cache populate (line $cache_line)"
+else
+    fail "ordering wrong" "val=$val_line cache=$cache_line"
+fi
+
+if grep -qF "Order matters here" "$DECOMP_SKILL"; then
+    pass "SKILL documents why ordering matters"
+else
+    fail "ordering rationale missing"
+fi
+
+# ── decompose M2 + resume regex anchoring ─────────────────────────────────
+
+echo ""
+echo "  decompose M2 / resume — orphan regex tolerates YAML indentation"
+echo "  ───────────────────────────────────────────────────────────────"
+
+# All three sites should now use ^[[:space:]]*status: anchoring
+sites=0
+expected=3
+for line in $(grep -nE '^[[:space:]]+-exec grep -lE|^[[:space:]]+&& grep -qE' "$DECOMP_SKILL" "$RESUME_SKILL" 2>/dev/null | grep -oE '^[^:]+:[0-9]+' || true); do
+    sites=$((sites + 1))
+done
+
+# Simpler check: count the corrected pattern across both files
+corrected_count=$(grep -cE 'status:\[\[:space:\]\]\*\(SPECIFYING' "$DECOMP_SKILL" "$RESUME_SKILL" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+if (( corrected_count >= 3 )); then
+    pass "all 3 grep sites use tolerant anchoring ($corrected_count matches)"
+else
+    fail "expected >= 3 corrected grep sites, found $corrected_count"
+fi
+
+# No site should still have the brittle `^status:` anchor
+brittle_count=$( { grep -cE "'\^status: \(SPECIFYING" "$DECOMP_SKILL" "$RESUME_SKILL" 2>/dev/null || true; } | awk -F: '{s+=$2} END{print s+0}')
+if (( brittle_count == 0 )); then
+    pass "no brittle '^status: (...)' patterns remain"
+else
+    fail "$brittle_count brittle anchors remain"
+fi
+
+# ── work-resume M1: orchestrator acquires state lock ──────────────────────
+
+echo ""
+echo "  work-resume M1 — orchestrator state lock on mutators"
+echo "  ──────────────────────────────────────────────────"
+
+if grep -qE 'acquire_state_lock\(\)' "$ORCH"; then
+    pass "acquire_state_lock helper defined"
+else
+    fail "acquire_state_lock helper missing"
+fi
+
+# Each mutating command should call it
+for cmd in cmd_complete cmd_block cmd_skip; do
+    body=$(awk "/^${cmd}\\(\\)/,/^}/" "$ORCH")
+    if echo "$body" | grep -qE 'acquire_state_lock'; then
+        pass "$cmd acquires state lock"
+    else
+        fail "$cmd doesn't acquire state lock"
+    fi
+done
+
+# Lock helper should degrade gracefully when flock is missing
+helper_body=$(awk '/^acquire_state_lock\(\)/,/^}/' "$ORCH")
+if echo "$helper_body" | grep -qE 'command -v flock'; then
+    pass "lock helper degrades gracefully without flock"
+else
+    fail "lock helper hard-requires flock"
+fi
+
+# ── work-resume M2: same-mtime stage-2 ────────────────────────────────────
+
+echo ""
+echo "  work-resume M2 — Step 3 mtime check handles 1-sec granularity"
+echo "  ────────────────────────────────────────────────────────"
+
+step3=$(awk '/^## Step 3 — Refresh readiness cache/,/^---$/' "$RESUME_SKILL")
+
+if echo "$step3" | grep -qE '1-second mtime granularity|HFS\+|same-second'; then
+    pass "Step 3 acknowledges 1-second mtime granularity"
+else
+    fail "Step 3 missing mtime-granularity rationale"
+fi
+
+if echo "$step3" | grep -qE 'src_mtime.*-eq.*cache_mtime|same mtime'; then
+    pass "Step 3 forces refresh on same-mtime source files"
+else
+    fail "Step 3 missing same-mtime equality check"
+fi
+
+if echo "$step3" | grep -qE 'stat -c %Y.*stat -f %m'; then
+    pass "Step 3 uses portable GNU/BSD stat fallback"
+else
+    fail "Step 3 stat invocation not cross-platform"
+fi
+
+# ── work-resume M3: corrupted/partially-deleted detection ─────────────────
+
+echo ""
+echo "  work-resume M3 — Step 2a detects corrupted/partial state"
+echo "  ──────────────────────────────────────────────────────"
+
+step2a=$(awk '/Corrupted \/ partially-deleted/,/^Otherwise, classify/' "$RESUME_SKILL")
+
+if [[ -n "$step2a" ]]; then
+    pass "Step 2a has corrupted/partially-deleted case"
+else
+    fail "corrupted case missing"
+fi
+
+if echo "$step2a" | grep -qE 'manifest_count.*-gt 0.*fs_count'; then
+    pass "Step 2a compares manifest count vs filesystem count"
+else
+    fail "Step 2a missing manifest-vs-fs count check"
+fi
+
+if echo "$step2a" | grep -qE 'Restore from git'; then
+    pass "Step 2a offers 'Restore from git' option"
+else
+    fail "Step 2a missing restore option"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

MED PR 1 of 3. Covers `/work-decompose` + `/work-resume` MEDIUM findings.

| # | Surface | Fix |
|---|---------|-----|
| M1 | `/work-decompose` Step 7 | validate BEFORE cache populate (failed invariant no longer leaves stale cache) |
| M2 | `/work-decompose` + `/work-resume` orphan regex | anchor `^[[:space:]]*status:` (tolerates YAML indentation) |
| M1 | `scripts/work-orchestrator.sh` | `acquire_state_lock()` on mutating cmds (no torn reads) |
| M2 | `/work-resume` Step 3 | stage-2 same-mtime check (1-sec granularity filesystems) |
| M3 | `/work-resume` Step 2a | corrupted/partially-deleted detection signal + Restore from git option |

## Tests

`tests/scenario-work-medium-cluster.sh` — 15 contract checks. No regressions in orchestrator (71/71), routing (22/22), decompose-high (15/15), install (74/74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)