### PR TITLE
fix(spec-backfill): 4 MEDIUM adversarial findings

### DIFF
--- a/scripts/dispatch-marker.sh
+++ b/scripts/dispatch-marker.sh
@@ -155,10 +155,29 @@ write_marker() {
 read_field() {
   local path="$1" field="$2"
   [[ -f "$path" ]] || return 0
-  grep -oE "\"$field\":[[:space:]]*\"[^\"]*\"" "$path" 2>/dev/null \
-    | head -1 \
-    | sed -E "s/^\"$field\":[[:space:]]*\"([^\"]*)\"$/\1/" \
-    | head -1 || true
+  # 2026-05-11 adversarial MED #3: the original regex `"[^"]*"` stopped
+  # at the first quote inside the value — even an escaped `\"`. For
+  # result/failure_reason values containing escape sequences (e.g.,
+  # spec-backfill stuck reports with "Re-dispatch \"foo\"" inside),
+  # this returned a truncated prefix. Prefer jq when available since
+  # it handles escape sequences correctly; fall back to a regex that
+  # consumes backslash-escapes greedily.
+  if command -v jq >/dev/null 2>&1; then
+    local val
+    val=$(jq -r --arg f "$field" '.[$f] // empty' "$path" 2>/dev/null || true)
+    printf '%s' "$val"
+    return 0
+  fi
+  # Regex fallback: match `"field": "..."` where the value may contain
+  # `\"` (escaped quote) or `\\` (escaped backslash). The pattern
+  # `([^"\\]|\\.)*` consumes any character that's not `"` or `\`, OR a
+  # `\` followed by any character (which absorbs `\"` and `\\` together).
+  perl -ne 'if (/"'"$field"'":\s*"((?:[^"\\]|\\.)*)"/) { my $v = $1; $v =~ s/\\"/"/g; $v =~ s/\\\\/\\/g; print $v; exit }' "$path" 2>/dev/null \
+    || grep -oE "\"$field\":[[:space:]]*\"[^\"]*\"" "$path" 2>/dev/null \
+       | head -1 \
+       | sed -E "s/^\"$field\":[[:space:]]*\"([^\"]*)\"$/\1/" \
+       | head -1 \
+    || true
 }
 
 read_bool_field() {

--- a/scripts/spec-backfill-candidates.sh
+++ b/scripts/spec-backfill-candidates.sh
@@ -170,8 +170,20 @@ else
 fi
 
 if [[ ${#SCAN_DIRS[@]} -eq 0 ]]; then
-  echo "[backfill] no source directories to scan in $PROJECT_ROOT" >&2
-  exit 0
+  # 2026-05-11 adversarial MED #4: previously exited 0 with empty
+  # stdout — Phase A's sub-agent treated this identically to "no
+  # candidate sites found for the requirement", and across a whole
+  # corpus this looked like a quiet zero-result. Now exit 3 with a
+  # distinct error code so the caller can fail-fast for the corpus
+  # rather than presenting "Skip / Waive / Other" for every R-id with
+  # no signal that the underlying scan never happened.
+  if [[ -n "${SPEC_TRACE_DIRS:-}" ]]; then
+    echo "[backfill] ERROR: SPEC_TRACE_DIRS='$SPEC_TRACE_DIRS' but none of those directories exist in $PROJECT_ROOT" >&2
+  else
+    echo "[backfill] ERROR: no source directories found in $PROJECT_ROOT (looked for src/lib/app/main/test/tests/spec/modules/examples/benchmarks)" >&2
+    echo "[backfill]        Set SPEC_TRACE_DIRS=<dir1,dir2,...> if your project uses a non-standard layout." >&2
+  fi
+  exit 3
 fi
 
 # ── Grep each token, accumulate hits, then score ────────────────────────────

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -404,7 +404,10 @@ Any other return shape is treated as a parse failure.
 
 Receive the JSON. Validate via `jq -e '.spec_id and .items'`. On
 parse failure, mark the propose-stage marker as failed and continue
-to next spec (the surfacing logic is in C2d).
+to next spec (the surfacing logic is in C2e — mark the propose marker
+as failed via `bash .claude/scripts/dispatch-marker.sh fail
+.spec/_backfill-dispatches <spec-id>--propose "parse-failed: <first
+80 chars>"`, surface to user, continue).
 
 ```bash
 bash .claude/scripts/dispatch-marker.sh ack .spec/_backfill-dispatches <spec-id>--propose "<one-line-summary>"
@@ -609,6 +612,30 @@ behaving as expected.
 - **Edit collides with an existing annotation that already covers this
   R-id.** That should not happen if Phase 1 filtered correctly, but if
   it does: log as `annotated` (idempotent on the log) and continue.
-- **User aborts mid-walk.** The log preserves every decision applied so
-  far; rerunning resumes from where the user left off. Do not revert
-  applied annotations.
+- **User aborts mid-walk (single-spec mode).** The log preserves every
+  decision applied so far; rerunning resumes from where the user left
+  off. Do not revert applied annotations.
+- **User aborts mid-AskUserQuestion loop (corpus mode C2c)** — 2026-05-11
+  adversarial MED #2. In corpus mode, decisions are collected in
+  coordinator memory across multiple `AskUserQuestion` prompts (one per
+  R-id) BEFORE Phase B dispatches and writes log rows. A user abort
+  (ESC) after, say, 5 of 12 R-ids leaves 5 answered decisions in
+  memory with 7 unanswered. Without explicit handling, the run exits
+  and ALL 5 decisions are discarded — the user has to redo them on the
+  next run.
+
+  When a corpus-mode C2c AskUserQuestion returns a user-abort signal:
+  1. **Dispatch Phase B with the PARTIAL decision-set** the user has
+     already answered. Phase B is idempotent (log dedupe + has-decision
+     filter) so this is safe.
+  2. After Phase B completes, surface to the user that the run is
+     stopping with progress preserved:
+     ```
+     Aborted mid-walk on <spec-id> at R-id <N>/<total>.
+     <K> decisions applied to log; <total - K> R-ids will resurface on
+     the next /spec-backfill --all run.
+     ```
+  3. Exit the corpus loop (do NOT continue to the next spec).
+
+  The full corpus run is interruptible at any boundary; this fix makes
+  the in-spec walk interruptible too without losing answered decisions.

--- a/tests/scenario-spec-backfill-medium.sh
+++ b/tests/scenario-spec-backfill-medium.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Scenario: /spec-backfill MEDIUM fixes from 2026-05-11 adversarial sweep.
+#
+# M1: C2b parse-failure references C2e (not the typo C2d).
+# M2: User-aborts-mid-AskUserQuestion-loop dispatches Phase B with
+#     partial decision-set instead of losing all answered decisions.
+# M3: dispatch-marker.sh read_field handles escaped quotes inside
+#     result/failure_reason values.
+# M4: spec-backfill-candidates.sh exits 3 (loud) when SCAN_DIRS is empty.
+#
+# Run from repo root: bash tests/scenario-spec-backfill-medium.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SKILL="$REPO_ROOT/skills/spec-backfill/SKILL.md"
+DM="$REPO_ROOT/scripts/dispatch-marker.sh"
+CAND="$REPO_ROOT/scripts/spec-backfill-candidates.sh"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+TEST_DIR="/tmp/vallorcine/scenario-spec-backfill-medium"
+cleanup() { rm -rf "$TEST_DIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: /spec-backfill MEDIUM cluster"
+echo "────────────────────────────────────────────────"
+
+# ── M1: C2b parse-failure references C2e ───────────────────────────────────
+
+echo ""
+echo "  M1 — C2b parse-failure cross-references C2e (not the typo C2d)"
+echo "  ──────────────────────────────────────────────────────────"
+
+if grep -qE 'parse failure.*marker.*failed.*continue.*C2e|surfacing logic is in C2e' "$SKILL"; then
+    pass "C2b parse-failure path references C2e"
+else
+    fail "C2b parse-failure still references wrong section"
+fi
+
+# The fail-marker invocation should be named explicitly
+if tr '\n' ' ' < "$SKILL" | tr -s ' ' | grep -qE 'dispatch-marker\.sh fail .spec/_backfill-dispatches <spec-id>--propose'; then
+    pass "C2b spells out the dispatch-marker.sh fail invocation"
+else
+    fail "C2b doesn't spell out fail-marker invocation"
+fi
+
+# ── M2: user-abort mid-loop dispatches Phase B with partial set ───────────
+
+echo ""
+echo "  M2 — mid-AskUserQuestion abort dispatches Phase B with partial set"
+echo "  ────────────────────────────────────────────────────────────"
+
+fmodes=$(awk '/User aborts mid-AskUserQuestion/,/Exit the corpus loop/' "$SKILL")
+
+if [[ -n "$fmodes" ]]; then
+    pass "Failure modes section covers mid-loop abort"
+else
+    fail "mid-loop abort case missing"
+fi
+
+if echo "$fmodes" | grep -qE 'PARTIAL decision-set|partial decision-set'; then
+    pass "mid-loop abort dispatches Phase B with partial decisions"
+else
+    fail "mid-loop abort doesn't dispatch Phase B"
+fi
+
+if echo "$fmodes" | grep -qE 'Phase B is idempotent'; then
+    pass "rationale references Phase B idempotency"
+else
+    fail "missing idempotency rationale"
+fi
+
+if echo "$fmodes" | tr '\n' ' ' | tr -s ' ' | grep -qE 'will resurface on the next'; then
+    pass "user told remaining R-ids will resurface"
+else
+    fail "missing resume guidance"
+fi
+
+# ── M3: dispatch-marker read_field handles escaped quotes ─────────────────
+
+echo ""
+echo "  M3 — dispatch-marker read_field handles escaped quotes"
+echo "  ───────────────────────────────────────────────────"
+
+cleanup
+mkdir -p "$TEST_DIR"
+
+# Build an UN-ACK'd marker with an escaped-quote failure_reason —
+# `stuck` iterates unack'd markers and runs read_field on each field.
+cat > "$TEST_DIR/_dispatch-test.json" <<'EOF'
+{
+  "schema_version": 1,
+  "id": "test",
+  "dispatched_at": "2026-05-11T00:00:00Z",
+  "ack": false,
+  "result": null,
+  "failure_reason": "spec-backfill failed: \"foo\" then \"bar\" terminated",
+  "acknowledged_at": null
+}
+EOF
+
+# Use the dispatch-marker.sh stuck (which iterates + reads via read_field)
+stuck_out=$(bash "$DM" stuck "$TEST_DIR" 2>/dev/null || true)
+
+# Pre-fix: failure_reason would be truncated at first `\"`, so the
+# stuck output would NOT contain "bar".
+# Post-fix: should contain "bar" (full string preserved through the
+# jq path or the perl regex fallback).
+if [[ "$stuck_out" == *"bar"* ]]; then
+    pass "read_field preserves content past escaped quotes in failure_reason"
+else
+    fail "read_field still truncates at escaped quote" "got: $stuck_out"
+fi
+
+# ── M4: spec-backfill-candidates.sh exits 3 on empty SCAN_DIRS ────────────
+
+echo ""
+echo "  M4 — spec-backfill-candidates.sh exits 3 (loud) on empty SCAN_DIRS"
+echo "  ──────────────────────────────────────────────────────────────"
+
+cleanup
+mkdir -p "$TEST_DIR/empty-proj/.spec/registry"
+echo '{"schema_version":2,"specs":[{"id":"test.foo","state":"APPROVED"}]}' > "$TEST_DIR/empty-proj/.spec/registry/manifest.json"
+mkdir -p "$TEST_DIR/empty-proj/.spec/domains/test"
+cat > "$TEST_DIR/empty-proj/.spec/domains/test/foo.md" <<'EOF'
+---
+{"id":"test.foo","version":1,"state":"APPROVED","status":"ACTIVE","domains":["test"]}
+---
+
+# test.foo
+
+## Requirements
+
+R1. The system must validate input tokens.
+
+---
+
+## Design Narrative
+.
+EOF
+
+cd "$TEST_DIR/empty-proj"
+# No src/lib/app/test dirs exist — scan dirs should be empty.
+# Capture exit code without tripping set -e.
+out=$(bash "$CAND" "test.foo" "R1" 2>&1) && rc=0 || rc=$?
+cd "$REPO_ROOT"
+
+if [[ $rc -eq 3 ]]; then
+    pass "spec-backfill-candidates exits 3 on empty SCAN_DIRS"
+else
+    fail "expected exit 3, got $rc"
+fi
+
+if echo "$out" | grep -qE "ERROR.*no source directories|ERROR.*none of those directories"; then
+    pass "error message names the problem"
+else
+    fail "error message doesn't explain the failure" "got: $out"
+fi
+
+# With SPEC_TRACE_DIRS set but nonexistent, same failure mode + different msg
+cd "$TEST_DIR/empty-proj"
+out=$(SPEC_TRACE_DIRS=nope bash "$CAND" "test.foo" "R1" 2>&1) && rc=0 || rc=$?
+cd "$REPO_ROOT"
+if [[ $rc -eq 3 ]] && echo "$out" | grep -qE "SPEC_TRACE_DIRS"; then
+    pass "SPEC_TRACE_DIRS-with-no-existing-dir path exits 3 + names env var"
+else
+    fail "SPEC_TRACE_DIRS path didn't fail as expected" "rc=$rc, got: $out"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

MED PR 2 of 3.

| # | Fix |
|---|-----|
| M1 | C2b parse-failure cross-ref typo (C2d → C2e) + spell out dispatch-marker invocation |
| M2 | Mid-AskUserQuestion abort dispatches Phase B with partial decision-set instead of losing all 5 answered decisions |
| M3 | `dispatch-marker.sh` read_field handles escaped quotes (prefer jq; fall back to perl regex with proper escape handling) |
| M4 | `spec-backfill-candidates.sh` exits 3 (loud) on empty SCAN_DIRS instead of silent empty stdout |

## Tests

`tests/scenario-spec-backfill-medium.sh` — 10 checks (including LIVE tests for M3 read_field-with-escapes and M4 empty-SCAN_DIRS). No regressions: spec-backfill (18/18), corpus (16/16), dispatch-marker (21/21), install (74/74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)