### PR TITLE
fix(curate): 4 MEDIUM adversarial findings

### DIFF
--- a/scripts/curate-scan.sh
+++ b/scripts/curate-scan.sh
@@ -1867,9 +1867,33 @@ if [[ -d ".kb" ]] && command -v curl >/dev/null 2>&1; then
                      2>/dev/null || true)
 
     # Atomic cache write: merge old + updates, dedupe by URL keeping latest.
-    if [[ -s "$LINK_ROT_CACHE_UPDATES" ]]; then
+    # 2026-05-11 adversarial MED #2: also prune URLs no longer referenced
+    # by any KB entry. Previously the cache grew monotonically — a URL
+    # deleted from KB stayed cached forever, eventually creating an
+    # unbounded `link-rot-cache.txt` for long-lived projects. Now we
+    # intersect the cache with LINK_ROT_SEEN (URLs actually referenced in
+    # this scan) and drop entries not in the set. Safe because every URL
+    # gets revisited in each scan (the cache only short-circuits the HTTP
+    # check, not the URL enumeration).
+    if [[ -s "$LINK_ROT_CACHE_UPDATES" ]] || [[ -s "$LINK_ROT_CACHE" ]]; then
+        # Emit the URLs we saw this scan into a tmp file for awk lookup.
+        > "$TMPDIR_SCAN/_link-rot-seen-urls.txt"
+        for url in "${!LINK_ROT_SEEN[@]}"; do
+            printf '%s\n' "$url" >> "$TMPDIR_SCAN/_link-rot-seen-urls.txt"
+        done
+
         cat "$LINK_ROT_CACHE" "$LINK_ROT_CACHE_UPDATES" 2>/dev/null \
-            | awk -F'|' 'NF >= 3 { cache[$1] = $0 } END { for (k in cache) print cache[k] }' \
+            | awk -F'|' -v seen_file="$TMPDIR_SCAN/_link-rot-seen-urls.txt" '
+                BEGIN {
+                  while ((getline line < seen_file) > 0) seen[line] = 1
+                  close(seen_file)
+                }
+                NF >= 3 {
+                  # Keep only entries whose URL was referenced this scan.
+                  if (seen[$1]) cache[$1] = $0
+                }
+                END { for (k in cache) print cache[k] }
+              ' \
             > "$LINK_ROT_CACHE.new"
         mv "$LINK_ROT_CACHE.new" "$LINK_ROT_CACHE"
     fi
@@ -2312,10 +2336,16 @@ if [[ -d ".spec" && -f ".spec/registry/manifest.json" ]]; then
         sfile=$(spec_file_for_id "$MANIFEST" "$sid")
         [[ -z "$sfile" || ! -f "$sfile" ]] && continue
 
-        # decision_refs → .decisions/<slug>/adr.md
+        # decision_refs → .decisions/<slug>/adr.md (standard layout)
+        # OR .decisions/<slug>.md (flat layout) — 2026-05-11 adversarial
+        # MED #4. Pre-fix this hardcoded the grouped-directory layout
+        # and false-positived every spec's decision_refs on projects
+        # using flat .decisions/<slug>.md naming, drowning the user in
+        # bogus xref-drift findings.
         while IFS= read -r dref; do
             [[ -z "$dref" ]] && continue
-            if [[ ! -f ".decisions/$dref/adr.md" ]]; then
+            if [[ ! -f ".decisions/$dref/adr.md" ]] \
+               && [[ ! -f ".decisions/$dref.md" ]]; then
                 echo "SPEC_XREF|$sid|decision_ref|$dref" \
                     >> "$TMPDIR_SCAN/spec-xref-drift.txt"
             fi

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -129,13 +129,34 @@ STUCK_MARKERS=$(bash .claude/scripts/dispatch-marker.sh stuck \
 
 Each row is `<finding-key>|<dispatched-at>|<has-result>|<failure-reason>`.
 
-If non-empty, surface BEFORE Step 1 (the scan run): for each stuck
-marker, use AskUserQuestion with three options —
-**"Re-dispatch"** (clear marker, include in this run),
-**"Skip for now"** (leave marker; next run will resurface it),
-**"Investigate manually"** (print marker JSON via
-`dispatch-marker.sh status .curate/_dispatches <finding-key>` and
-stop the `/curate` run).
+If non-empty, surface BEFORE Step 1 (the scan run). **Batch the prompt
+when N > 2 markers exist** (2026-05-11 adversarial MED #3) — per the
+kit-development "Interactive prompt standard," dynamic lists with >4
+items should use summary options rather than firing N consecutive
+AskUserQuestions in a row.
+
+- **N == 1**: single AskUserQuestion with three options —
+  **"Re-dispatch"** (clear marker, include in this run),
+  **"Skip for now"** (leave marker; next run will resurface it),
+  **"Investigate manually"** (print marker JSON via
+  `dispatch-marker.sh status .curate/_dispatches <finding-key>` and
+  stop the `/curate` run).
+
+- **N == 2**: two sequential AskUserQuestions, same option set.
+  Acceptable user friction.
+
+- **N > 2 (the batching path)**: one AskUserQuestion with summary
+  options that apply to all stuck markers:
+    - **"Re-dispatch all"** — clears all markers and includes each
+      finding in this run
+    - **"Skip all"** — leaves every marker; next run resurfaces them
+    - **"Walk one at a time"** — falls back to the per-marker prompt
+      (N consecutive AskUserQuestions, one per marker, same option
+      set as the N==1 case)
+    - **"Investigate manually"** — print all marker JSONs and stop
+  This caps user interruption at one prompt regardless of N — the
+  pre-fix flow with N=5 markers fired 5 sequential prompts before the
+  scan even started.
 
 This mirrors `/work-resume rule 0` (PR #79) and `/spec-backfill` C0 —
 any unacknowledged marker pre-empts the normal flow because it
@@ -1776,28 +1797,30 @@ items via Step 2.5 deprioritized below new findings.
 
 After the user is done (explored items, deferred, or noted for later):
 
-Update `.curate/curation-state.md` with **only the Scan State section**.
-The Review Log lives in `.curate/review-log.md` (append-only) and is
-managed exclusively via `curate-review-log.sh`. Writing the Review Log
-inline in curation-state.md would silently destroy prior rows on every
-run — that is the bug this design replaces.
+**`curate-scan.sh` already wrote `.curate/curation-state.md`** at the
+end of its run (lines 3190-3195). It's the canonical writer — Step 5
+is a no-op for this file. Format the script emits (verified
+2026-05-11):
 
-```markdown
-# Curation State
-
-## Scan State
+```
 Last scanned: <current HEAD SHA>
-Last scanned date: <YYYY-MM-DD>
-Window: <months used>
-Commits scanned: <N>
+Scan date: <YYYY-MM-DD>
+Commits: <N>
+Window: <months> months
 ```
 
-(The original Step 5 template emitted both Scan State and Review Log into
-this file, which is what destroyed the persistence guarantee. Do not
-re-introduce the Review Log section here.)
+Pre-2026-05-11 (MED #1 adversarial finding), Step 5 prescribed a
+DIFFERENT format with `# Curation State` / `## Scan State` headers
+and field names like `Last scanned date` / `Commits scanned` —
+overwriting the script's output every run with conflicting field
+names. Step 0's reader keys on `^Last scanned:` so basic functionality
+survived, but other consumers got inconsistent data. **Do not
+re-introduce the SKILL-side write.**
 
-After updating curation-state.md, do not write to review-log.md directly
-— Step 4 already appended every finding via `curate-review-log.sh append`.
+The Review Log lives in `.curate/review-log.md` (append-only) and is
+managed exclusively via `curate-review-log.sh`. Step 4 already
+appended every finding via `curate-review-log.sh append` — Step 5
+does not touch review-log.md either.
 
 ---
 

--- a/tests/scenario-curate-medium-cluster.sh
+++ b/tests/scenario-curate-medium-cluster.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Scenario: /curate + curate-scan.sh MEDIUM fixes from 2026-05-11
+# adversarial sweep.
+#
+# M1: Step 5 no longer overwrites curation-state.md with a conflicting
+#     schema; script remains the canonical writer.
+# M2: link-rot cache prunes URLs no longer referenced by any KB entry
+#     (cache no longer grows monotonically).
+# M3: Stuck-marker prompt batches when N > 2 markers exist.
+# M4: Analysis 28 tolerates both `.decisions/<slug>/adr.md` (grouped)
+#     and `.decisions/<slug>.md` (flat) layouts.
+#
+# Run from repo root: bash tests/scenario-curate-medium-cluster.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SCAN="$REPO_ROOT/scripts/curate-scan.sh"
+SKILL="$REPO_ROOT/skills/curate/SKILL.md"
+
+passed=0; failed=0; total=0
+pass() { ((passed++)) || true; ((total++)) || true; echo "  PASS  $1"; }
+fail() { ((failed++)) || true; ((total++)) || true; echo "  FAIL  $1"; [[ -n "${2:-}" ]] && echo "        $2"; }
+
+TEST_DIR="/tmp/vallorcine/scenario-curate-medium"
+cleanup() { rm -rf "$TEST_DIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo ""
+echo "scenario: /curate MEDIUM cluster"
+echo "────────────────────────────────────────────────"
+
+# ── M1: Step 5 doesn't write curation-state.md ─────────────────────────────
+
+echo ""
+echo "  M1 — Step 5 is no-op for curation-state.md (script is canonical)"
+echo "  ──────────────────────────────────────────────────────────"
+
+step5=$(awk '/^## Step 5 — Update curation state/{p=1} p; /^## Step 6/{exit}' "$SKILL")
+
+if echo "$step5" | tr '\n' ' ' | tr -s ' ' | grep -qE 'already wrote.*curation-state\.md|Step 5 is a no-op|canonical writer'; then
+    pass "Step 5 documented as no-op for curation-state.md"
+else
+    fail "Step 5 still prescribes a SKILL-side write"
+fi
+
+# The format documented should match the script's actual output
+if echo "$step5" | grep -qE 'Scan date:' && echo "$step5" | grep -qE '^Commits:'; then
+    pass "Step 5 documents the canonical (script) format"
+else
+    fail "Step 5 format doesn't match script output"
+fi
+
+# The pre-fix conflicting field names should NOT be in the prescribed template
+# (they may still appear as historical "do not re-introduce" note text)
+if echo "$step5" | grep -qE 'Last scanned date: <YYYY-MM-DD>'; then
+    fail "Step 5 still uses conflicting 'Last scanned date' field name"
+else
+    pass "Step 5 no longer prescribes 'Last scanned date' (script uses 'Scan date:')"
+fi
+
+# ── M2: link-rot cache prunes dead URLs ────────────────────────────────────
+
+echo ""
+echo "  M2 — link-rot cache prunes URLs not referenced in current scan"
+echo "  ────────────────────────────────────────────────────────────"
+
+# Find the cache-merge block
+cache_merge=$(awk '/Atomic cache write/,/Stable output ordering/' "$SCAN")
+
+if echo "$cache_merge" | grep -qE 'prune URLs no longer|LINK_ROT_SEEN.*URLs actually referenced|seen\[.+]'; then
+    pass "cache-merge logic intersects with LINK_ROT_SEEN"
+else
+    fail "cache-merge still adds without pruning"
+fi
+
+if echo "$cache_merge" | grep -qE 'unbounded.*link-rot-cache|grow.*monotonically'; then
+    pass "rationale documents the monotonic-growth bug"
+else
+    fail "rationale missing"
+fi
+
+# ── M3: Stuck-marker prompt batches when N > 2 ─────────────────────────────
+
+echo ""
+echo "  M3 — Stuck-marker prompt batches when N > 2 markers"
+echo "  ─────────────────────────────────────────────────"
+
+stuck_section=$(awk '/^\*\*Stuck-marker recovery/,/Display opening header/' "$SKILL")
+
+if echo "$stuck_section" | grep -qE 'Batch the prompt when N > 2|batching path'; then
+    pass "Stuck-marker section describes batching"
+else
+    fail "Stuck-marker section missing batching"
+fi
+
+# Three explicit branches: N==1, N==2, N>2
+for branch in "N == 1" "N == 2" "N > 2"; do
+    if echo "$stuck_section" | grep -qF -- "$branch"; then
+        pass "branch $branch documented"
+    else
+        fail "branch $branch missing"
+    fi
+done
+
+# N>2 path must offer "Re-dispatch all" / "Skip all" / "Walk one at a time"
+if echo "$stuck_section" | grep -qE 'Re-dispatch all'; then
+    pass "N>2 path offers 'Re-dispatch all'"
+else
+    fail "N>2 path missing 'Re-dispatch all'"
+fi
+if echo "$stuck_section" | grep -qE 'Skip all'; then
+    pass "N>2 path offers 'Skip all'"
+else
+    fail "N>2 path missing 'Skip all'"
+fi
+if echo "$stuck_section" | grep -qE 'Walk one at a time'; then
+    pass "N>2 path offers 'Walk one at a time' (per-marker fallback)"
+else
+    fail "N>2 path missing 'Walk one at a time'"
+fi
+
+# ── M4: Analysis 28 tolerates flat .decisions/<slug>.md layout ────────────
+
+echo ""
+echo "  M4 — Analysis 28 accepts flat .decisions/<slug>.md layout"
+echo "  ──────────────────────────────────────────────────────"
+
+# Find Analysis 28 decision_refs check
+a28_decision=$(awk '/decision_refs → \.decisions/,/done < <\(fm "\$sfile".*decision_refs/' "$SCAN")
+
+if echo "$a28_decision" | grep -qE '\.decisions/\$dref\.md'; then
+    pass "Analysis 28 also checks .decisions/<slug>.md (flat layout)"
+else
+    fail "Analysis 28 still hardcodes grouped layout only"
+fi
+
+# LIVE test: build a fixture with flat-layout ADR and assert Analysis 28
+# does NOT mark it as broken when referenced by a spec.
+cleanup
+mkdir -p "$TEST_DIR/.claude/scripts" "$TEST_DIR/.spec/registry" "$TEST_DIR/.spec/domains/test" "$TEST_DIR/.decisions" "$TEST_DIR/.curate"
+cp "$SCAN" "$TEST_DIR/.claude/scripts/"
+cp "$REPO_ROOT/scripts/spec-lib.sh" "$TEST_DIR/.claude/scripts/" 2>/dev/null || true
+
+# Flat-layout ADR
+cat > "$TEST_DIR/.decisions/flat-adr.md" <<'EOF'
+---
+status: accepted
+date: 2026-05-11
+---
+# Flat layout ADR
+EOF
+
+# Spec referencing the flat ADR
+cat > "$TEST_DIR/.spec/domains/test/foo.md" <<'EOF'
+---
+{"id":"test.foo","version":1,"state":"APPROVED","status":"ACTIVE","domains":["test"],"decision_refs":["flat-adr"],"kb_refs":[]}
+---
+
+# test.foo
+
+## Requirements
+R1. Test.
+
+---
+
+## Design Narrative
+.
+EOF
+
+# Manifest
+cat > "$TEST_DIR/.spec/registry/manifest.json" <<EOF
+{
+  "schema_version": 2,
+  "specs": [
+    {"id": "test.foo", "path": ".spec/domains/test/foo.md", "state": "APPROVED",
+     "domains": ["test"], "decision_refs": ["flat-adr"], "kb_refs": []}
+  ]
+}
+EOF
+
+# Git fixture
+cd "$TEST_DIR"
+git init -q
+git config user.email t@t.t
+git config user.name t
+git add -A
+git commit -q -m "init"
+
+# Run scan
+bash .claude/scripts/curate-scan.sh --init >/dev/null 2>&1
+
+# Check: Analysis 28 output should NOT list test.foo|decision_ref|flat-adr
+# (it would, pre-fix, because the script only looked for flat-adr/adr.md).
+if grep -q "SPEC_XREF.*flat-adr" .curate/scan-summary.md 2>/dev/null; then
+    fail "Analysis 28 false-positives on flat-layout ADR"
+else
+    pass "Analysis 28 accepts flat-layout ADR (no false positive)"
+fi
+
+cd "$REPO_ROOT"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Total: $total | Passed: $passed | Failed: $failed"
+echo ""
+
+[[ $failed -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

MED PR 3 of 3.

| # | Fix |
|---|-----|
| M1 | Step 5 no-op for curation-state.md (script is canonical writer); stop flipping between two field-name conventions per run |
| M2 | link-rot cache prunes URLs no longer referenced by any KB entry (cache no longer grows monotonically) |
| M3 | Stuck-marker prompt batches when N > 2 ("Re-dispatch all" / "Skip all" / "Walk one at a time" / "Investigate") |
| M4 | Analysis 28 accepts both `.decisions/<slug>/adr.md` (grouped) and `.decisions/<slug>.md` (flat) layouts (no false-positive SPEC_XREF on flat projects) |

## Tests

`tests/scenario-curate-medium-cluster.sh` — 14 checks. LIVE M4 test runs a real scan against a flat-layout fixture. No regressions: scenario-curate-scan (86/86), scenario-curate-high-cluster (11/11), test-install (74/74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)