### PR TITLE
feat: subagent rigor hardening — completeness contract + validator

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -94,6 +94,7 @@
 .claude/rules/spec-annotation-protocol.md
 .claude/rules/tdd-protocol.md
 .claude/scripts/token-usage.sh
+.claude/scripts/validate-subagent-return.sh
 .claude/scripts/version-check.sh
 .claude/scripts/merge-driver-index.sh
 .claude/scripts/ensure-merge-driver.sh

--- a/MANIFEST
+++ b/MANIFEST
@@ -86,6 +86,7 @@
 .claude/agents/test-writer-agent.md
 .claude/agents/breaker-agent.md
 .claude/agents/work-planner-agent.md
+.claude/rules/completeness-contract.md
 .claude/rules/kb-architect.md
 .claude/rules/kb-protocol.md
 .claude/rules/kb-research-agent.md

--- a/agents/architect-agent.md
+++ b/agents/architect-agent.md
@@ -1,5 +1,13 @@
 # Architect Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Technical Architect Agent operating inside Claude Code. You take a
 problem statement with explicit design constraints, survey the knowledge base

--- a/agents/breaker-agent.md
+++ b/agents/breaker-agent.md
@@ -1,5 +1,13 @@
 # Breaker Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Breaker Agent. You write adversarial tests designed to find bugs
 that standard TDD misses — functional gaps, security vulnerabilities, resource

--- a/agents/code-writer-agent.md
+++ b/agents/code-writer-agent.md
@@ -1,5 +1,13 @@
 # Code Writer Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Code Writer Agent. You specialise in writing idiomatic, correct code
 for the project's language (from project-config.md). You implement the stubs the

--- a/agents/domain-scout-agent.md
+++ b/agents/domain-scout-agent.md
@@ -1,5 +1,13 @@
 # Domain Scout Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Domain Scout Agent. You read a completed feature brief and determine
 which KB topics and architectural decisions are relevant. You check what exists,

--- a/agents/refactor-agent.md
+++ b/agents/refactor-agent.md
@@ -1,5 +1,13 @@
 # Refactor Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Refactor Agent. You improve code quality without changing behaviour.
 After the Code Writer makes tests pass, you review: coding standards, duplication,

--- a/agents/research-agent.md
+++ b/agents/research-agent.md
@@ -1,5 +1,13 @@
 # Research Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Technical Research Agent operating inside Claude Code. You build and
 maintain a structured knowledge base of technical research — algorithms, data

--- a/agents/scoping-agent.md
+++ b/agents/scoping-agent.md
@@ -1,5 +1,13 @@
 # Scoping Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Feature Scoping Agent. You take a user's description of a new feature,
 piece of functionality, or idea and transform it into a structured brief that

--- a/agents/test-writer-agent.md
+++ b/agents/test-writer-agent.md
@@ -1,5 +1,13 @@
 # Test Writer Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Test Writer Agent. You specialise in writing tests for the project's
 language and testing framework (from project-config.md). You work from the work

--- a/agents/work-planner-agent.md
+++ b/agents/work-planner-agent.md
@@ -1,5 +1,13 @@
 # Work Planner Agent
 
+## Completeness contract
+
+You are bound by `rules/completeness-contract.md` (load-bearing — no silent
+deferrals; trigger phrases = escalation signals, not completion modes). If
+you cannot complete assigned scope, escalate via AskUserQuestion with
+user-validatable proof. A return claiming COMPLETE alongside deferred items
+is a contract violation.
+
 ## Role
 You are a Work Planner Agent. You read a feature brief, domain analysis, and
 governing ADRs then produce a concrete work plan: every object, function, and

--- a/install.sh
+++ b/install.sh
@@ -266,6 +266,7 @@ done
 echo ""
 echo "── Scripts ──────────────────────────────────────"
 install_file "$SCRIPT_DIR/scripts/token-usage.sh" "$TARGET/.claude/scripts/token-usage.sh"
+install_file "$SCRIPT_DIR/scripts/validate-subagent-return.sh" "$TARGET/.claude/scripts/validate-subagent-return.sh"
 install_file "$SCRIPT_DIR/scripts/version-check.sh" "$TARGET/.claude/scripts/version-check.sh"
 install_file "$SCRIPT_DIR/scripts/merge-driver-index.sh" "$TARGET/.claude/scripts/merge-driver-index.sh"
 install_file "$SCRIPT_DIR/scripts/ensure-merge-driver.sh" "$TARGET/.claude/scripts/ensure-merge-driver.sh"

--- a/rules/completeness-contract.md
+++ b/rules/completeness-contract.md
@@ -1,0 +1,169 @@
+# Completeness Contract
+
+This rule applies to every agent, skill, and dispatched subagent in vallorcine.
+It governs how assigned scope is honored and how escalation works when
+something genuinely prevents completion.
+
+## The authority rule
+
+You have no authority to defer assigned scope. The user is the only party who
+can decide what work moves to a follow-on, gets dropped, or is intentionally
+deferred. Your job is to complete the assigned work or escalate with proof —
+not to make scope decisions on the user's behalf.
+
+Default action: **fix it, finish it, ship it.** The bar is the assigned scope
+(WD acceptance criteria, spec R-clauses, feature brief, user request) — not
+"what I had time for" or "what seemed in scope to me."
+
+## Trigger phrases (escalation signals, not completion modes)
+
+When you find yourself writing any of these phrases, STOP. They are your cue
+to construct an escalation, not to mark work COMPLETE:
+
+- "candidate", "follow-on", "out of scope"
+- "deferred", "future work", "for later"
+- "we'll do this in a follow-up", "track separately"
+- "not this PR's problem", "separate concern"
+- "covered transitively", "edge case we can punt"
+- "minor — can address later", "non-critical"
+
+A return that claims `✓ COMPLETE` alongside any of these phrases is a contract
+violation, regardless of how reasonable the deferral seems.
+
+## Escalation channel
+
+When you genuinely cannot complete assigned scope, escalate via AskUserQuestion
+with this shape:
+
+```
+I cannot do X because <concrete reason>.
+
+Proof you can validate:
+  <file:line evidence, failing command output, missing type, broken dep, etc.>
+
+To proceed, you need to:
+  <specific user action — confirm scope, fix upstream, approve workaround>
+```
+
+Then **wait** for the user's decision. Do not mark COMPLETE.
+
+The proof must be user-checkable:
+
+- **Acceptable**: "Type `Codec<V>` referenced by `RadixWriter` does not exist —
+  `grep -rn 'class Codec' src/` returns no matches."
+- **Acceptable**: "Test `testCrossFamilyEquivalence` passes both before and
+  after removing the new code path — the test does not exercise what it claims
+  to verify."
+- **Not acceptable**: "It's complex" / "we'd need to refactor" / "out of scope
+  per my read" / "this would expand scope" / "I think this might be too much."
+
+The first three are facts. The last set are judgment calls — and you don't
+have authority for judgment calls about scope.
+
+## Specific applications
+
+The authority rule implies six concrete contracts. Each catches a failure
+mode the kit has seen repeatedly:
+
+### 1. Verification contract
+
+Before claiming work COMPLETE, articulate the test that would FAIL if you
+took the path of least resistance — vacuous equivalence, mocked path,
+isolated codec, fallthrough to legacy code. If your tests do not cover
+that scenario, your tests are insufficient.
+
+A test passing is not evidence the strong property holds. Two paths
+producing identical output is a true assertion that proves nothing if
+both paths route through the same legacy code.
+
+### 2. Production-path contract
+
+Tests must exercise the live caller path, not internal SPI adapters or
+direct construction of internal classes. Before writing a test, identify
+the production entry point a real user hits to invoke this code, and
+route the test through that entry point.
+
+Per-component benchmarks and isolated SPI harnesses are useful for
+understanding but are NOT evidence the production path behaves the same
+way. If an ADR or spec change rests on measurements, those measurements
+must be taken on the production path.
+
+### 3. Measurement contract
+
+Where the assigned scope calls for a measurement — performance, allocation
+count, conformance count, end-to-end behavior — verbal arguments are NOT
+substitutes. Run the measurement or escalate as PARTIAL with proof.
+
+"The wrapping cost is uniform across families and cannot reverse the
+ordering" is a hypothesis. Until you run it, it is not a finding.
+
+### 4. Annotation contract
+
+A `@spec R<n>` annotation is a claim that the annotated code enforces the
+R-clause. Before adding an annotation, verify the code actually implements
+the behavior. For "retired" or "removed" claims, grep the WHOLE codebase
+for the deprecated symbol, not just the file you edited.
+
+A spec marked SATISFIED with code that doesn't enforce the requirement is
+worse than an unsatisfied spec — it tells downstream consumers (work-plan,
+audit, spec-author) that the requirement holds when it doesn't.
+
+### 5. Quality-bar contract
+
+The repository's check command (./gradlew check, pnpm test, cargo test,
+etc.) must pass before a PR is drafted or a WD is marked COMPLETE.
+"Preexisting failures" is NOT an exemption.
+
+If failures are genuinely preexisting and out of the current WD's scope,
+they must be moved to `.flake-allowlist.md` with: (a) the failing test,
+(b) the reason it's flaky/broken, (c) the assignee, (d) the deadline.
+No deadline = no exemption.
+
+### 6. Scope-reconciliation contract
+
+Before returning COMPLETE, compare your output against the assigned
+acceptance criteria item-by-item. For each AC item, point to the
+specific code, test, or doc that satisfies it. If you cannot point to
+something for an AC item, you have not completed the work — escalate
+per the channel above or finish.
+
+## How dispatch uses this rule
+
+Skills that dispatch subagents must include an explicit preamble in the
+dispatch prompt:
+
+```
+BEFORE STARTING: read and honor rules/completeness-contract.md.
+Violations of the authority rule, the verification contract, the
+production-path contract, the measurement contract, the annotation
+contract, the quality-bar contract, or the scope-reconciliation
+contract are contract failures — not stylistic preferences. If you
+find yourself about to violate one, construct the escalation per the
+contract's escalation channel.
+```
+
+Orchestrators (work-orchestrator, feature-coordinate, work-run) must
+validate returns from dispatched subagents against this contract before
+accepting COMPLETE. Returns containing trigger phrases or missing AC
+coverage must be routed back to the user via AskUserQuestion before
+being accepted as COMPLETE.
+
+## Scope confirmation is not deferral
+
+Asking the user "what counts as in-scope for this WD?" BEFORE starting
+is scope confirmation, not deferral — and is fine. Encouraged, even,
+when the assigned scope is genuinely ambiguous.
+
+Deferral is when you've started, made a judgment about what to drop, and
+shipped less than assigned. The contract governs deferral, not scope
+confirmation.
+
+## Distinction from genuine PARTIAL
+
+A genuine PARTIAL return is one where you completed all the work you
+could and escalated the blocking issue with proof, then waited for the
+user's call. The user may then approve continuing without the blocked
+piece, in which case the work is legitimately PARTIAL — by user decision,
+not by Claude's deferral.
+
+What's prohibited is silently shipping PARTIAL while claiming COMPLETE.

--- a/scripts/validate-subagent-return.sh
+++ b/scripts/validate-subagent-return.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# validate-subagent-return.sh
+#
+# Scans a subagent return for completeness-contract violations.
+# See rules/completeness-contract.md.
+#
+# Orchestrators (work-orchestrator, work-run, work-start, feature-coordinate,
+# audit, spec-backfill, curate, work-plan) MUST run this on every subagent
+# return BEFORE marking the dispatched unit COMPLETE. If exit code is non-zero,
+# the orchestrator MUST route to the user via AskUserQuestion rather than
+# accepting the return.
+#
+# Usage:
+#   bash validate-subagent-return.sh <return-file>
+#
+# Exit codes:
+#   0 = clean (no trigger phrases found)
+#   1 = trigger phrase found (deferral detected — block COMPLETE, route to user)
+#   2 = file not found / usage error
+#
+# Design notes:
+# - Biases toward false positives. The check ROUTES to the user; it doesn't
+#   silently block. A false positive wastes a few seconds; a false negative
+#   ships incomplete work. The asymmetry favors the user.
+# - Case-insensitive substring matching (-iF) keeps phrase definitions simple
+#   and avoids regex escaping for hyphens and apostrophes.
+# - Returns the matched phrase + first matching line to stderr so the
+#   orchestrator can surface useful context in its AskUserQuestion prompt.
+
+set -euo pipefail
+
+return_file="${1:-}"
+
+if [[ -z "$return_file" ]]; then
+  printf 'ERROR: usage: %s <return-file>\n' "$(basename "$0")" >&2
+  exit 2
+fi
+
+if [[ ! -f "$return_file" || ! -r "$return_file" ]]; then
+  printf 'ERROR: return file not readable: %s\n' "$return_file" >&2
+  exit 2
+fi
+
+# Trigger phrases. Match the prose forms a subagent is most likely to write,
+# not every conceivable wording. Bias toward common shapes; user can clear
+# false alarms.
+TRIGGER_PHRASES=(
+  "candidate"
+  "follow-on"
+  "follow up"
+  "follow-up"
+  "out of scope"
+  "deferred"
+  "future work"
+  "for later"
+  "we'll do this in a follow"
+  "we will do this in a follow"
+  "track separately"
+  "separate concern"
+  "not this PR's problem"
+  "not this PR problem"
+  "covered transitively"
+  "edge case we can punt"
+  "minor — can address later"
+  "minor - can address later"
+  "minor, can address later"
+  "non-critical"
+  "out of this scope"
+)
+
+found=()
+
+for phrase in "${TRIGGER_PHRASES[@]}"; do
+  # Use grep -iF for case-insensitive fixed-string match. -m1 stops at first
+  # match per phrase. Suppress stderr in case file has weird encoding.
+  if line=$(grep -iF -m1 -- "$phrase" "$return_file" 2>/dev/null); then
+    found+=("${phrase}|||${line}")
+  fi
+done
+
+if (( ${#found[@]} > 0 )); then
+  printf 'VIOLATION: deferral trigger phrases detected in subagent return.\n' >&2
+  printf '  See rules/completeness-contract.md for the contract.\n' >&2
+  printf '\n  Triggers found:\n' >&2
+  for entry in "${found[@]}"; do
+    phrase="${entry%%|||*}"
+    line="${entry##*|||}"
+    # Truncate line for readability (orchestrator can re-read file for full context)
+    if (( ${#line} > 120 )); then
+      line="${line:0:117}..."
+    fi
+    printf '    - "%s" in: %s\n' "$phrase" "$line" >&2
+  done
+  printf '\n  Orchestrator action: block COMPLETE, route to user via AskUserQuestion.\n' >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/validate-subagent-return.sh
+++ b/scripts/validate-subagent-return.sh
@@ -11,11 +11,18 @@
 # accepting the return.
 #
 # Usage:
-#   bash validate-subagent-return.sh <return-file>
+#   bash validate-subagent-return.sh <return-file> [--require-ac-coverage]
+#
+# Flags:
+#   --require-ac-coverage  Also require the return to contain an AC satisfaction
+#                          mapping (per rules/completeness-contract.md §6).
+#                          Pass this for WD-return orchestrators (work-run,
+#                          work-start, work-plan). Skip for audit / spec-backfill /
+#                          curate dispatches that don't carry WD-style ACs.
 #
 # Exit codes:
-#   0 = clean (no trigger phrases found)
-#   1 = trigger phrase found (deferral detected — block COMPLETE, route to user)
+#   0 = clean (no contract violations found)
+#   1 = contract violation found (trigger phrase OR missing AC coverage when required)
 #   2 = file not found / usage error
 #
 # Design notes:
@@ -24,15 +31,36 @@
 #   ships incomplete work. The asymmetry favors the user.
 # - Case-insensitive substring matching (-iF) keeps phrase definitions simple
 #   and avoids regex escaping for hyphens and apostrophes.
-# - Returns the matched phrase + first matching line to stderr so the
-#   orchestrator can surface useful context in its AskUserQuestion prompt.
+# - Writes findings to stderr so orchestrators can surface them in the
+#   AskUserQuestion prompt as context.
 
 set -euo pipefail
 
-return_file="${1:-}"
+return_file=""
+require_ac_coverage=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --require-ac-coverage)
+      require_ac_coverage=true
+      ;;
+    --*)
+      printf 'ERROR: unknown flag: %s\n' "$arg" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$return_file" ]]; then
+        return_file="$arg"
+      else
+        printf 'ERROR: unexpected positional argument: %s\n' "$arg" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
 
 if [[ -z "$return_file" ]]; then
-  printf 'ERROR: usage: %s <return-file>\n' "$(basename "$0")" >&2
+  printf 'ERROR: usage: %s <return-file> [--require-ac-coverage]\n' "$(basename "$0")" >&2
   exit 2
 fi
 
@@ -78,6 +106,8 @@ for phrase in "${TRIGGER_PHRASES[@]}"; do
   fi
 done
 
+violation_count=0
+
 if (( ${#found[@]} > 0 )); then
   printf 'VIOLATION: deferral trigger phrases detected in subagent return.\n' >&2
   printf '  See rules/completeness-contract.md for the contract.\n' >&2
@@ -91,7 +121,44 @@ if (( ${#found[@]} > 0 )); then
     fi
     printf '    - "%s" in: %s\n' "$phrase" "$line" >&2
   done
-  printf '\n  Orchestrator action: block COMPLETE, route to user via AskUserQuestion.\n' >&2
+  printf '\n' >&2
+  violation_count=$((violation_count + 1))
+fi
+
+if $require_ac_coverage; then
+  # Look for AC-satisfaction markers. Returns claiming COMPLETE for a WD
+  # MUST include a section mapping each acceptance criterion to a satisfier.
+  # See rules/completeness-contract.md §6 (Scope-reconciliation contract).
+  AC_PATTERNS=(
+    "AC satisfaction"
+    "AC coverage"
+    "AC mapping"
+    "Acceptance criteria satisfaction"
+    "Acceptance criteria coverage"
+    "Acceptance criterion"
+    "satisfies AC"
+    "AC[0-9]"
+    "AC-[0-9]"
+  )
+  ac_found=false
+  for pattern in "${AC_PATTERNS[@]}"; do
+    if grep -iE -- "$pattern" "$return_file" >/dev/null 2>&1; then
+      ac_found=true
+      break
+    fi
+  done
+  if ! $ac_found; then
+    printf 'VIOLATION: return missing AC satisfaction mapping.\n' >&2
+    printf '  See rules/completeness-contract.md §6 (Scope-reconciliation).\n' >&2
+    printf '  Returns claiming COMPLETE for a WD MUST include a section\n' >&2
+    printf '  mapping each acceptance criterion to its satisfier (code, test,\n' >&2
+    printf '  or doc with file:line citation).\n\n' >&2
+    violation_count=$((violation_count + 1))
+  fi
+fi
+
+if (( violation_count > 0 )); then
+  printf '  Orchestrator action: block COMPLETE, route to user via AskUserQuestion.\n' >&2
   exit 1
 fi
 

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -747,6 +747,12 @@ Launch a subagent with these inputs:
 
 ### Subagent prompt
 
+> **Subagent contract:** Honor `rules/completeness-contract.md` (load-bearing —
+> no silent deferrals; trigger phrases = escalation signals, not completion
+> modes). If you cannot complete assigned scope, escalate via AskUserQuestion
+> with user-validatable proof. A return claiming COMPLETE alongside deferred
+> items is a contract violation.
+>
 > You are a falsification agent. Your job is to find reasons the recommendation
 > is wrong. You are not trying to be balanced — you are trying to break the
 > recommendation. If it survives, the decision is stronger.

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -24,12 +24,24 @@ the top of its prompt — no exceptions:
 > items is a contract violation.
 
 This applies to Classification, Exploration, Suspect, Prove, Fix, Regression,
-Report, Reconciliation, and any other subagent dispatched by /audit. When
-relaying subagent returns, the orchestrator MUST treat trigger phrases
-("candidate", "follow-on", "out of scope", "deferred", "future work", "for
-later", "covered transitively", "edge case we can punt", "minor — can
-address later") as escalation signals and route them to the user via
-AskUserQuestion rather than accepting them as completion.
+Report, Reconciliation, and any other subagent dispatched by /audit.
+
+When any subagent returns, the orchestrator MUST run the validation script
+BEFORE accepting the return:
+
+```bash
+mkdir -p /tmp/vallorcine
+return_file=/tmp/vallorcine/audit-return-"<job-name>".txt
+printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
+bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+rc=$?
+```
+
+- `rc=0` → accept the return.
+- `rc=1` → trigger phrase detected (sub-agent shipped partial work as
+  complete). Surface to user via AskUserQuestion with validator stderr.
+  Do not advance to the next job until resolved.
+- `rc=2` → tooling error. Log and treat as `rc=0`.
 
 ## Orchestrator discipline — MANDATORY
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -12,6 +12,25 @@ them with failing tests, fixes the code, and leaves the codebase clean.
 
 ---
 
+## Subagent contract — MANDATORY for every dispatch
+
+Every subagent this skill dispatches MUST be given the following preamble at
+the top of its prompt — no exceptions:
+
+> **Subagent contract:** Honor `rules/completeness-contract.md` (load-bearing —
+> no silent deferrals; trigger phrases = escalation signals, not completion
+> modes). If you cannot complete assigned scope, escalate via AskUserQuestion
+> with user-validatable proof. A return claiming COMPLETE alongside deferred
+> items is a contract violation.
+
+This applies to Classification, Exploration, Suspect, Prove, Fix, Regression,
+Report, Reconciliation, and any other subagent dispatched by /audit. When
+relaying subagent returns, the orchestrator MUST treat trigger phrases
+("candidate", "follow-on", "out of scope", "deferred", "future work", "for
+later", "covered transitively", "edge case we can punt", "minor — can
+address later") as escalation signals and route them to the user via
+AskUserQuestion rather than accepting them as completion.
+
 ## Orchestrator discipline — MANDATORY
 
 You are a state machine. Your ONLY job is to dispatch subagents serially

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -99,11 +99,21 @@ MUST be given this preamble at the top of the dispatched skill's prompt:
 > with user-validatable proof. A return claiming COMPLETE alongside deferred
 > items is a contract violation.
 
-When dispatched skills return, the curator MUST scan returns for trigger
-phrases ("candidate", "follow-on", "out of scope", "deferred", "future work",
-"covered transitively", "edge case") and treat any occurrence as an
-escalation signal — block the finding's `resolved` status and re-route to
-the user via AskUserQuestion.
+When dispatched skills return, the curator MUST run the validation script
+BEFORE marking the finding `resolved`:
+
+```bash
+mkdir -p /tmp/vallorcine
+return_file=/tmp/vallorcine/curate-return-"<finding-key>".txt
+printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
+bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+rc=$?
+```
+
+- `rc=0` → mark finding `resolved` and continue.
+- `rc=1` → trigger phrase detected. Surface to user via AskUserQuestion with
+  validator stderr. Block `resolved` until user clears.
+- `rc=2` → tooling error. Log and treat as `rc=0`.
 
 ## Step 0 — Pre-flight
 

--- a/skills/curate/SKILL.md
+++ b/skills/curate/SKILL.md
@@ -87,6 +87,24 @@ When the user picks "skip" instead of "dismiss", nothing is recorded
 
 ---
 
+## Subagent contract — MANDATORY for every dispatch
+
+Every Agent dispatch this skill issues (invoke-architect, invoke-research,
+invoke-spec-author, or any future side-effect that uses the Agent tool)
+MUST be given this preamble at the top of the dispatched skill's prompt:
+
+> **Subagent contract:** Honor `rules/completeness-contract.md` (load-bearing —
+> no silent deferrals; trigger phrases = escalation signals, not completion
+> modes). If you cannot complete assigned scope, escalate via AskUserQuestion
+> with user-validatable proof. A return claiming COMPLETE alongside deferred
+> items is a contract violation.
+
+When dispatched skills return, the curator MUST scan returns for trigger
+phrases ("candidate", "follow-on", "out of scope", "deferred", "future work",
+"covered transitively", "edge case") and treat any occurrence as an
+escalation signal — block the finding's `resolved` status and re-route to
+the user via AskUserQuestion.
+
 ## Step 0 — Pre-flight
 
 Check that `.curate/` directory exists. If not, create it.

--- a/skills/feature-coordinate/SKILL.md
+++ b/skills/feature-coordinate/SKILL.md
@@ -11,6 +11,25 @@ is `balanced` or `speed`.
 
 ---
 
+## Subagent contract — MANDATORY for every dispatch
+
+Every Agent dispatch this skill issues (test-writer, code-writer, refactor,
+adversarial, PR draft, or any other subagent) MUST include this preamble at
+the top of its prompt:
+
+> **Subagent contract:** Honor `rules/completeness-contract.md` (load-bearing —
+> no silent deferrals; trigger phrases = escalation signals, not completion
+> modes). If you cannot complete assigned scope, escalate via AskUserQuestion
+> with user-validatable proof. A return claiming COMPLETE alongside deferred
+> items is a contract violation.
+
+When subagents return, the coordinator MUST scan returns for trigger phrases
+("candidate", "follow-on", "out of scope", "deferred", "future work", "covered
+transitively", "edge case") and treat any occurrence as an escalation signal
+— route to the user via AskUserQuestion rather than accepting as completion.
+
+---
+
 ## Step 0 — Pre-flight
 
 Read `.feature/<slug>/status.md`.

--- a/skills/feature-coordinate/SKILL.md
+++ b/skills/feature-coordinate/SKILL.md
@@ -23,10 +23,22 @@ the top of its prompt:
 > with user-validatable proof. A return claiming COMPLETE alongside deferred
 > items is a contract violation.
 
-When subagents return, the coordinator MUST scan returns for trigger phrases
-("candidate", "follow-on", "out of scope", "deferred", "future work", "covered
-transitively", "edge case") and treat any occurrence as an escalation signal
-— route to the user via AskUserQuestion rather than accepting as completion.
+When work-unit subagents return, the coordinator MUST run the validation
+script BEFORE marking the unit complete:
+
+```bash
+mkdir -p /tmp/vallorcine
+return_file=/tmp/vallorcine/coord-return-"<slug>"-"<unit-id>".txt
+printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
+bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+rc=$?
+```
+
+- `rc=0` → proceed with unit COMPLETE.
+- `rc=1` → trigger phrase detected. Block COMPLETE for that unit and surface
+  to user via AskUserQuestion with the validator's stderr as context. Do
+  not advance to the next batch until the user resolves.
+- `rc=2` → tooling error. Log and treat as `rc=0`.
 
 ---
 

--- a/skills/feature-coordinate/SKILL.md
+++ b/skills/feature-coordinate/SKILL.md
@@ -30,7 +30,7 @@ script BEFORE marking the unit complete:
 mkdir -p /tmp/vallorcine
 return_file=/tmp/vallorcine/coord-return-"<slug>"-"<unit-id>".txt
 printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
-bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+bash .claude/scripts/validate-subagent-return.sh "$return_file" --require-ac-coverage 2>/tmp/vallorcine/validator-stderr.txt
 rc=$?
 ```
 

--- a/skills/feature-plan/SKILL.md
+++ b/skills/feature-plan/SKILL.md
@@ -551,6 +551,12 @@ interaction is needed for the mechanical writing phase.
 design data from Step 2:
 
 ````
+**Subagent contract:** Honor `rules/completeness-contract.md` (load-bearing —
+no silent deferrals; trigger phrases = escalation signals, not completion
+modes). If you cannot complete assigned scope, escalate via AskUserQuestion
+with user-validatable proof. A return claiming COMPLETE alongside deferred
+items is a contract violation.
+
 You are a Work Planner Agent completing the mechanical writing phase for
 feature "<slug>".
 

--- a/skills/feature-pr/SKILL.md
+++ b/skills/feature-pr/SKILL.md
@@ -219,6 +219,76 @@ spec-backfill or curation pass — not as a routine PR check.
 
 ---
 
+## Step 1b — Quality-bar gate (mandatory before Step 2)
+
+Per `rules/completeness-contract.md` §5 (Quality-bar contract), the
+repository's check command MUST pass before a PR is drafted. "Preexisting
+failures" is NOT an exemption.
+
+Detect the check command from project conventions:
+
+```bash
+# Order: project-config.md override → conventional commands
+check_cmd=""
+if [[ -f .feature/project-config.md ]]; then
+  check_cmd=$(grep -E '^check_command:' .feature/project-config.md | sed 's/check_command://;s/^ *//;s/ *$//')
+fi
+
+if [[ -z "$check_cmd" ]]; then
+  if   [[ -f gradlew ]];        then check_cmd="./gradlew check"
+  elif [[ -f pnpm-lock.yaml ]]; then check_cmd="pnpm test"
+  elif [[ -f yarn.lock ]];      then check_cmd="yarn test"
+  elif [[ -f package.json ]];   then check_cmd="npm test"
+  elif [[ -f Cargo.toml ]];     then check_cmd="cargo test"
+  elif [[ -f go.mod ]];         then check_cmd="go test ./..."
+  elif [[ -f Makefile ]];       then check_cmd="make check"
+  fi
+fi
+```
+
+If `check_cmd` is empty, surface to user via AskUserQuestion: ask the user
+to supply the check command or skip the gate with explicit justification.
+
+If `check_cmd` is set, run it:
+
+```bash
+eval "$check_cmd"
+check_rc=$?
+```
+
+**If `check_rc=0`:** proceed to Step 2.
+
+**If `check_rc≠0`:** the gate fails. PR draft is blocked. Display the
+failures and surface to user via AskUserQuestion with three options:
+
+1. **Fix the failures** — stop, fix the failing tests/checks in this PR,
+   re-run /feature-pr.
+2. **Move failures to .flake-allowlist.md** — if a failure is genuinely
+   preexisting and out of this WD's scope, add it to `.flake-allowlist.md`
+   with the schema below, then re-run /feature-pr. The flake-allowlist is
+   committed; reviewers see what's been deferred and why.
+3. **Override the gate (rare)** — only if you can demonstrate the failure
+   is unrelated to this change AND fixing it materially expands scope.
+   Record user-supplied justification verbatim in the PR description.
+   This is the contract's "escape hatch" — use sparingly.
+
+`.flake-allowlist.md` schema (one entry per failing test):
+
+```markdown
+## <test-id or test-class.method>
+
+- **Why flaky/broken:** <one-line reason>
+- **Assignee:** <github-username or team>
+- **Deadline:** <YYYY-MM-DD — when this allowlist entry expires>
+- **Added:** <YYYY-MM-DD>
+- **Originating PR:** #<pr-number>
+```
+
+No deadline = no exemption. The deadline forces a follow-up rather than
+permanent silence.
+
+---
+
 ## Step 2 — Draft the PR
 
 Construct the PR draft in this order:

--- a/skills/spec-author/SKILL.md
+++ b/skills/spec-author/SKILL.md
@@ -365,6 +365,14 @@ Launch a subagent for this pass. The subagent receives:
 
 The subagent's prompt must include:
 
+### 2.0 — Subagent contract (load-bearing preamble)
+
+**Subagent contract:** Honor `rules/completeness-contract.md` (load-bearing —
+no silent deferrals; trigger phrases = escalation signals, not completion
+modes). If you cannot complete assigned scope, escalate via AskUserQuestion
+with user-validatable proof. A return claiming COMPLETE alongside deferred
+items is a contract violation.
+
 ### 2a — Requirement-level falsification
 
 For each requirement in the draft, begin with the assertion: **"This

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -235,11 +235,21 @@ of its prompt:
 > return claiming COMPLETE alongside deferred items is a contract
 > violation.
 
-When per-spec sub-agents return, the coordinator MUST scan the return
-for trigger phrases ("candidate", "follow-on", "out of scope",
-"deferred", "future work", "covered transitively", "edge case") and
-treat any occurrence as an escalation signal — block COMPLETE
-acceptance and route to user via AskUserQuestion.
+When per-spec sub-agents return, the coordinator MUST run the validation
+script BEFORE accepting:
+
+```bash
+mkdir -p /tmp/vallorcine
+return_file=/tmp/vallorcine/spec-backfill-return-"<spec-id>".txt
+printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
+bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+rc=$?
+```
+
+- `rc=0` → accept and continue to the next spec.
+- `rc=1` → trigger phrase detected. Surface to user via AskUserQuestion
+  with validator stderr. Do not advance to the next spec until resolved.
+- `rc=2` → tooling error. Log and treat as `rc=0`.
 
 When invoked with `--all`, iterate every APPROVED spec in the manifest
 and run the per-spec walk against each via the **subagent dispatch

--- a/skills/spec-backfill/SKILL.md
+++ b/skills/spec-backfill/SKILL.md
@@ -224,6 +224,23 @@ If `skipped` count > 0, tell the user how to resume:
 
 ## Corpus mode (`--all`)
 
+**Subagent contract — MANDATORY for every dispatch.** Every per-spec
+sub-agent this skill dispatches MUST be given this preamble at the top
+of its prompt:
+
+> **Subagent contract:** Honor `rules/completeness-contract.md`
+> (load-bearing — no silent deferrals; trigger phrases = escalation
+> signals, not completion modes). If you cannot complete assigned
+> scope, escalate via AskUserQuestion with user-validatable proof. A
+> return claiming COMPLETE alongside deferred items is a contract
+> violation.
+
+When per-spec sub-agents return, the coordinator MUST scan the return
+for trigger phrases ("candidate", "follow-on", "out of scope",
+"deferred", "future work", "covered transitively", "edge case") and
+treat any occurrence as an escalation signal — block COMPLETE
+acceptance and route to user via AskUserQuestion.
+
 When invoked with `--all`, iterate every APPROVED spec in the manifest
 and run the per-spec walk against each via the **subagent dispatch
 pattern** — each spec is processed by a dedicated sub-agent that owns

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -108,12 +108,63 @@ For each numbered requirement (R1, R2, ...), determine one of:
 
 | Verdict | Meaning |
 |---------|---------|
-| SATISFIED | Implementation fully meets the requirement |
+| SATISFIED | Implementation fully meets the requirement (see enforcement check below) |
 | PARTIAL | Implementation partially meets the requirement — note what's missing |
 | VIOLATED | Implementation contradicts the requirement |
 | UNTESTABLE | Requirement cannot be verified from code alone (e.g., performance claims) |
 
 For each verdict, provide a one-line evidence reference (file:line or method name).
+
+#### Enforcement check (MANDATORY before claiming SATISFIED)
+
+Per the annotation contract in `rules/completeness-contract.md` §4, a
+`@spec R<n>` annotation is a claim that the annotated code ENFORCES the
+R-clause — not just that the annotation exists. Before assigning SATISFIED
+to any requirement, apply the appropriate check below:
+
+**For ASSERT-style requirements** ("input X must produce Y", "type Z must
+be enforced", "the system MUST reject malformed P"):
+
+- Find the actual assertion / validation / type-check in code. A method
+  that *could* enforce the requirement but doesn't actually contain the
+  check counts as PARTIAL, not SATISFIED.
+- The check must be in the production code path — internal SPI adapters
+  and isolated codec utilities don't count if the requirement governs
+  observable behavior at the public API boundary.
+
+**For BEHAVIOR-style requirements** ("on event X, do Y", "format conversion
+must preserve Z"):
+
+- Find a test that exercises the requirement through the production entry
+  point. A test that bypasses the production code path (constructs an
+  internal class directly, mocks the live dependency) does not count.
+- If no such test exists, the verdict is at most PARTIAL — the behavior
+  may happen to work but is not protected against regression.
+
+**For RETIRE / REMOVE-style requirements** ("v5 writer path has been
+retired", "the legacy XYZ codec is no longer used", "the old API has been
+removed"):
+
+- Grep the WHOLE codebase for the deprecated symbol or path, not just the
+  file containing the annotation. A spec marked SATISFIED because the
+  symbol no longer appears in one file is wrong if the symbol still lives
+  in another file.
+- Run:
+  ```bash
+  grep -rn "<deprecated-symbol>" --include="*.<ext>" . | grep -v "<expected-locations>"
+  ```
+  If any matches survive in production code paths, the verdict is VIOLATED.
+  If matches only exist in tests for the retired behavior (verifying it
+  doesn't run), the verdict is SATISFIED.
+
+**Why this matters.** Phantom annotations — `@spec R<n>` on code that
+doesn't enforce the clause — are worse than missing annotations: they
+tell downstream consumers (work-plan, audit, spec-author) that the
+requirement holds when it doesn't. The 2026-05 jlsm session shipped a
+sstable.sparse-key-index.R2 marked SATISFIED ("v5 writer path removed")
+while the v5 writer was still the sole footer writer on the encrypted
+path. Catching this requires reading what the code DOES, not what the
+annotation CLAIMS.
 
 ### Step 1.4 — Check for undocumented behavior
 

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -26,6 +26,23 @@ For implementation after specification is complete, use `/work-start`.
 
 If no WD argument is provided, defaults to `next`.
 
+**Subagent contract — MANDATORY for every dispatch.** Every WD this skill
+dispatches (sequential-all or single-WD recursion) MUST be given this
+preamble at the top of its prompt:
+
+> **Subagent contract:** Honor `rules/completeness-contract.md`
+> (load-bearing — no silent deferrals; trigger phrases = escalation
+> signals, not completion modes). If you cannot complete assigned
+> scope, escalate via AskUserQuestion with user-validatable proof. A
+> return claiming COMPLETE alongside deferred items is a contract
+> violation.
+
+When WD sub-agents return, `/work-plan` MUST scan the return for trigger
+phrases ("candidate", "follow-on", "out of scope", "deferred", "future
+work", "covered transitively", "edge case") and treat any occurrence as
+an escalation signal — block COMPLETE acceptance and route to user via
+AskUserQuestion.
+
 **A note on `all` and arbitration prompts.** `/spec-author` Pass 2
 surfaces falsification findings that require user decisions
 (arbitration). In `all` mode, those `AskUserQuestion` calls surface to

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -37,11 +37,21 @@ preamble at the top of its prompt:
 > return claiming COMPLETE alongside deferred items is a contract
 > violation.
 
-When WD sub-agents return, `/work-plan` MUST scan the return for trigger
-phrases ("candidate", "follow-on", "out of scope", "deferred", "future
-work", "covered transitively", "edge case") and treat any occurrence as
-an escalation signal — block COMPLETE acceptance and route to user via
-AskUserQuestion.
+When WD sub-agents return, `/work-plan` MUST run the validation script
+BEFORE accepting COMPLETE:
+
+```bash
+mkdir -p /tmp/vallorcine
+return_file=/tmp/vallorcine/work-plan-return-"<group-slug>"-"<wd-id>".txt
+printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
+bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+rc=$?
+```
+
+- `rc=0` → accept the spec / plan return.
+- `rc=1` → trigger phrase detected. Surface to user via AskUserQuestion
+  with validator stderr. Do not advance to the next WD until resolved.
+- `rc=2` → tooling error. Log and treat as `rc=0`.
 
 **A note on `all` and arbitration prompts.** `/spec-author` Pass 2
 surfaces falsification findings that require user decisions

--- a/skills/work-plan/SKILL.md
+++ b/skills/work-plan/SKILL.md
@@ -44,7 +44,7 @@ BEFORE accepting COMPLETE:
 mkdir -p /tmp/vallorcine
 return_file=/tmp/vallorcine/work-plan-return-"<group-slug>"-"<wd-id>".txt
 printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
-bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+bash .claude/scripts/validate-subagent-return.sh "$return_file" --require-ac-coverage 2>/tmp/vallorcine/validator-stderr.txt
 rc=$?
 ```
 

--- a/skills/work-run/SKILL.md
+++ b/skills/work-run/SKILL.md
@@ -264,7 +264,7 @@ routing to the orchestrator:
 mkdir -p /tmp/vallorcine
 return_file=/tmp/vallorcine/subagent-return-"<group-slug>"-"<wd-id>".txt
 printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
-bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+bash .claude/scripts/validate-subagent-return.sh "$return_file" --require-ac-coverage 2>/tmp/vallorcine/validator-stderr.txt
 rc=$?
 ```
 

--- a/skills/work-run/SKILL.md
+++ b/skills/work-run/SKILL.md
@@ -21,6 +21,22 @@ in-flight sub-agents continue to run — only the dispatch loop is
 paused — so the user only blocks the dispatcher, not the work that
 was already underway.
 
+**Subagent contract — MANDATORY for every dispatch.** Every WD this
+skill dispatches MUST be given this preamble at the top of its prompt:
+
+> **Subagent contract:** Honor `rules/completeness-contract.md`
+> (load-bearing — no silent deferrals; trigger phrases = escalation
+> signals, not completion modes). If you cannot complete assigned
+> scope, escalate via AskUserQuestion with user-validatable proof. A
+> return claiming COMPLETE alongside deferred items is a contract
+> violation.
+
+When WD sub-agents return, `/work-run` MUST scan the return for
+trigger phrases ("candidate", "follow-on", "out of scope", "deferred",
+"future work", "covered transitively", "edge case") and treat any
+occurrence as an escalation signal — block the WD's COMPLETE acceptance
+and route to user via AskUserQuestion before marking the WD done.
+
 **Arguments:**
 - `<group-slug>` — the work group to run
 - `--cap N` — maximum concurrent sub-agents (default: 3). Higher uses

--- a/skills/work-run/SKILL.md
+++ b/skills/work-run/SKILL.md
@@ -255,6 +255,47 @@ For each completion:
    - Agent return literally equals `[Tool result missing due to internal error]` → **payload-lost**
    - Agent return contains `The user doesn't want to proceed with this tool use.` → **user-stopped**
 
+**2.5. Completeness-contract validation (MANDATORY if classification is `clean`).**
+
+If step 2 classified the return as `clean`, run the validator BEFORE
+routing to the orchestrator:
+
+```bash
+mkdir -p /tmp/vallorcine
+return_file=/tmp/vallorcine/subagent-return-"<group-slug>"-"<wd-id>".txt
+printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
+bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+rc=$?
+```
+
+Branch on `rc`:
+- **0** → validation clean, proceed to step 3 with `clean` classification.
+- **1** → trigger phrases detected. The sub-agent claimed COMPLETE while
+  deferring scope. **DOWNGRADE** classification to `escalation` with
+  category `deferral-detected`. Construct an escalation.json:
+
+  ```bash
+  cat > .feature/"<slug>"/escalation.json <<'JSON'
+  {
+    "question": "WD-<wd-id> claimed COMPLETE but the return contains deferral trigger phrases. Approve as-is, re-dispatch with expanded scope, or stop?",
+    "options": [
+      {"label": "Approve as-is", "description": "User authorizes the deferred items — treat the WD as COMPLETE"},
+      {"label": "Re-dispatch with expanded scope", "description": "Send back to the WD pipeline with the deferred items added to scope"}
+    ],
+    "validator_findings": "<paste contents of /tmp/vallorcine/validator-stderr.txt>"
+  }
+  JSON
+  ```
+
+  Then route as `block <group> <wd-id> 'escalation:deferral-detected' '.feature/<slug>/escalation.json'`.
+- **2** → tooling error (file unreadable, script missing). Log stderr but
+  treat as `clean` — do NOT block the work group on infrastructure failures.
+
+The check is mechanical: the script greps for fixed phrases. False positives
+(a legitimate technical use of "candidate") route to the user who can clear
+them in one keystroke. False negatives ship incomplete work — the asymmetry
+favors the user.
+
 3. Route to the orchestrator. **Always single-quote the reason
    argument** (MEDIUM #6, 2026-05-11) — return lines can carry
    `$()`, backticks, or semicolons. Pass via single quotes and

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -41,7 +41,7 @@ script BEFORE accepting COMPLETE:
 mkdir -p /tmp/vallorcine
 return_file=/tmp/vallorcine/work-start-return-"<group-slug>"-"<wd-id>".txt
 printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
-bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+bash .claude/scripts/validate-subagent-return.sh "$return_file" --require-ac-coverage 2>/tmp/vallorcine/validator-stderr.txt
 rc=$?
 ```
 

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -23,6 +23,23 @@ interface contracts), use `/work-plan` instead.
 
 If no WD argument is provided, defaults to `next`.
 
+**Subagent contract — MANDATORY for every dispatch.** Every WD this skill
+dispatches (in `all`, `--parallel`, or single-WD modes) MUST be given this
+preamble at the top of its prompt:
+
+> **Subagent contract:** Honor `rules/completeness-contract.md`
+> (load-bearing — no silent deferrals; trigger phrases = escalation
+> signals, not completion modes). If you cannot complete assigned
+> scope, escalate via AskUserQuestion with user-validatable proof. A
+> return claiming COMPLETE alongside deferred items is a contract
+> violation.
+
+When WD sub-agents return, `/work-start` MUST scan the return for trigger
+phrases ("candidate", "follow-on", "out of scope", "deferred", "future
+work", "covered transitively", "edge case") and treat any occurrence as
+an escalation signal — block COMPLETE acceptance and route to user via
+AskUserQuestion before marking the WD done.
+
 **Choosing between `all` and `--parallel`:**
 
 Both delegate to the same single-WD `/work-start` flow, so quality at

--- a/skills/work-start/SKILL.md
+++ b/skills/work-start/SKILL.md
@@ -34,11 +34,28 @@ preamble at the top of its prompt:
 > return claiming COMPLETE alongside deferred items is a contract
 > violation.
 
-When WD sub-agents return, `/work-start` MUST scan the return for trigger
-phrases ("candidate", "follow-on", "out of scope", "deferred", "future
-work", "covered transitively", "edge case") and treat any occurrence as
-an escalation signal — block COMPLETE acceptance and route to user via
-AskUserQuestion before marking the WD done.
+When WD sub-agents return, `/work-start` MUST run the return-validation
+script BEFORE accepting COMPLETE:
+
+```bash
+mkdir -p /tmp/vallorcine
+return_file=/tmp/vallorcine/work-start-return-"<group-slug>"-"<wd-id>".txt
+printf '%s\n' "$FULL_RETURN_TEXT" > "$return_file"
+bash .claude/scripts/validate-subagent-return.sh "$return_file" 2>/tmp/vallorcine/validator-stderr.txt
+rc=$?
+```
+
+- `rc=0` → proceed with COMPLETE.
+- `rc=1` → trigger phrase detected. Block COMPLETE. Use AskUserQuestion
+  with the question "WD-<wd-id> claimed COMPLETE but the return contains
+  deferral trigger phrases. Approve as-is, re-dispatch with expanded
+  scope, or stop?" and the validator's stderr as context. Options:
+    - "Approve as-is" — user authorizes deferred items, mark COMPLETE
+    - "Re-dispatch with expanded scope" — send back with deferred items
+      added to scope
+    - "Stop" — pause and inspect manually
+- `rc=2` → tooling error. Log to stderr, treat as `rc=0` (don't block on
+  infrastructure failures).
 
 **Choosing between `all` and `--parallel`:**
 

--- a/tests/scenario-validate-subagent-return.sh
+++ b/tests/scenario-validate-subagent-return.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Scenario: validate-subagent-return.sh detects completeness-contract violations
+#
+# Validates that scripts/validate-subagent-return.sh correctly:
+# - Exits 0 on clean returns
+# - Exits 1 when trigger phrases are present
+# - Exits 1 when --require-ac-coverage is passed and AC mapping is missing
+# - Exits 0 when --require-ac-coverage is passed and AC mapping is present
+# - Exits 2 on missing file
+# - Exits 2 on missing argument
+# - Detects each trigger phrase from rules/completeness-contract.md
+# - Detects AC mapping in various formats (AC1, AC-1, "Acceptance criteria")
+# - Does not false-positive on benign technical uses
+#
+# Run from repo root: bash tests/scenario-validate-subagent-return.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-validate-subagent-return"
+VALIDATOR="$REPO_ROOT/scripts/validate-subagent-return.sh"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE"
+}
+trap cleanup EXIT
+mkdir -p "$TEST_BASE"
+
+echo ""
+echo "── Scenario: validate-subagent-return.sh ──────────────────────"
+echo ""
+
+# ── Test 1: Clean return, no AC required ─────────────────────────
+cat > "$TEST_BASE/clean.txt" <<'EOF'
+WD-01 COMPLETE
+
+All assigned scope addressed. Tests pass green.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/clean.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "clean return exits 0"
+else
+    fail "clean return exits 0" "got rc=$rc"
+fi
+
+# ── Test 2: Trigger phrase "candidate" ───────────────────────────
+cat > "$TEST_BASE/trigger-candidate.txt" <<'EOF'
+WD-01 COMPLETE
+
+v8 reader is a candidate for follow-up work.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/trigger-candidate.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger 'candidate' exits 1"
+else
+    fail "trigger 'candidate' exits 1" "got rc=$rc"
+fi
+
+# ── Test 3: Trigger phrase "follow-on" ───────────────────────────
+cat > "$TEST_BASE/trigger-followon.txt" <<'EOF'
+WD-02 COMPLETE
+
+Will address X in a follow-on WD.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/trigger-followon.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger 'follow-on' exits 1"
+else
+    fail "trigger 'follow-on' exits 1" "got rc=$rc"
+fi
+
+# ── Test 4: Trigger phrase "out of scope" ────────────────────────
+cat > "$TEST_BASE/trigger-oos.txt" <<'EOF'
+WD-03 COMPLETE
+
+Edge case handling is out of scope for this WD.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/trigger-oos.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger 'out of scope' exits 1"
+else
+    fail "trigger 'out of scope' exits 1" "got rc=$rc"
+fi
+
+# ── Test 5: Trigger phrase "deferred" ────────────────────────────
+cat > "$TEST_BASE/trigger-deferred.txt" <<'EOF'
+WD-04 COMPLETE
+
+The cross-shard validation is deferred for a later PR.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/trigger-deferred.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger 'deferred' exits 1"
+else
+    fail "trigger 'deferred' exits 1" "got rc=$rc"
+fi
+
+# ── Test 6: Trigger phrase "future work" ─────────────────────────
+cat > "$TEST_BASE/trigger-future.txt" <<'EOF'
+WD-05 COMPLETE
+
+Improved error messages are future work.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/trigger-future.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger 'future work' exits 1"
+else
+    fail "trigger 'future work' exits 1" "got rc=$rc"
+fi
+
+# ── Test 7: Trigger phrase "non-critical" ────────────────────────
+cat > "$TEST_BASE/trigger-noncritical.txt" <<'EOF'
+WD-06 COMPLETE
+
+Non-critical optimization left for later.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/trigger-noncritical.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger 'non-critical' exits 1"
+else
+    fail "trigger 'non-critical' exits 1" "got rc=$rc"
+fi
+
+# ── Test 8: --require-ac-coverage, missing AC ────────────────────
+cat > "$TEST_BASE/no-ac.txt" <<'EOF'
+WD-07 COMPLETE
+
+Tests pass. Code looks clean.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/no-ac.txt" --require-ac-coverage >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "--require-ac-coverage missing AC exits 1"
+else
+    fail "--require-ac-coverage missing AC exits 1" "got rc=$rc"
+fi
+
+# ── Test 9: --require-ac-coverage, AC section present (header) ───
+cat > "$TEST_BASE/ac-header.txt" <<'EOF'
+WD-08 COMPLETE
+
+## AC satisfaction
+- AC1: src/foo.rs:42 + tests/foo_test.rs
+- AC2: src/bar.rs:88
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/ac-header.txt" --require-ac-coverage >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "--require-ac-coverage with header section exits 0"
+else
+    fail "--require-ac-coverage with header section exits 0" "got rc=$rc"
+fi
+
+# ── Test 10: --require-ac-coverage, AC1 inline reference ─────────
+cat > "$TEST_BASE/ac-inline.txt" <<'EOF'
+WD-09 COMPLETE
+
+The implementation satisfies AC1 in src/foo.rs:42 and AC2 in tests/bar.rs.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/ac-inline.txt" --require-ac-coverage >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "--require-ac-coverage with AC<N> inline pattern exits 0"
+else
+    fail "--require-ac-coverage with AC<N> inline pattern exits 0" "got rc=$rc"
+fi
+
+# ── Test 11: missing file ────────────────────────────────────────
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/does-not-exist.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 2 ]]; then
+    pass "missing file exits 2"
+else
+    fail "missing file exits 2" "got rc=$rc"
+fi
+
+# ── Test 12: missing argument ────────────────────────────────────
+rc=0
+bash "$VALIDATOR" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 2 ]]; then
+    pass "missing argument exits 2"
+else
+    fail "missing argument exits 2" "got rc=$rc"
+fi
+
+# ── Test 13: unknown flag ────────────────────────────────────────
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/clean.txt" --bogus-flag >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 2 ]]; then
+    pass "unknown flag exits 2"
+else
+    fail "unknown flag exits 2" "got rc=$rc"
+fi
+
+# ── Test 14: trigger phrase + AC missing → still rc=1 ────────────
+cat > "$TEST_BASE/both-violations.txt" <<'EOF'
+WD-10 COMPLETE
+
+The follow-on work is deferred.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/both-violations.txt" --require-ac-coverage >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger + missing AC both flagged, exit 1"
+else
+    fail "trigger + missing AC both flagged, exit 1" "got rc=$rc"
+fi
+
+# ── Test 15: trigger phrase but no --require-ac-coverage still rc=1
+cat > "$TEST_BASE/trigger-only.txt" <<'EOF'
+WD-11 COMPLETE
+
+Edge case is a candidate for later.
+EOF
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/trigger-only.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 1 ]]; then
+    pass "trigger phrase still flagged without --require-ac-coverage"
+else
+    fail "trigger phrase still flagged without --require-ac-coverage" "got rc=$rc"
+fi
+
+# ── Test 16: stderr message contains "VIOLATION" on rc=1 ─────────
+stderr=$(bash "$VALIDATOR" "$TEST_BASE/trigger-candidate.txt" 2>&1 >/dev/null || true)
+if echo "$stderr" | grep -q "VIOLATION"; then
+    pass "stderr contains 'VIOLATION' on rc=1"
+else
+    fail "stderr contains 'VIOLATION' on rc=1" "stderr was: $stderr"
+fi
+
+# ── Test 17: stderr mentions completeness-contract.md ────────────
+stderr=$(bash "$VALIDATOR" "$TEST_BASE/trigger-candidate.txt" 2>&1 >/dev/null || true)
+if echo "$stderr" | grep -q "completeness-contract.md"; then
+    pass "stderr cites completeness-contract.md"
+else
+    fail "stderr cites completeness-contract.md" "stderr was: $stderr"
+fi
+
+# ── Test 18: empty file → clean (no trigger phrases to find) ─────
+touch "$TEST_BASE/empty.txt"
+rc=0
+bash "$VALIDATOR" "$TEST_BASE/empty.txt" >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "empty file exits 0 (no triggers)"
+else
+    fail "empty file exits 0 (no triggers)" "got rc=$rc"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────
+echo ""
+echo "── Scenario summary ───────────────────────────────────────────"
+echo "  Passed: $passed / $total"
+if [[ $failed -gt 0 ]]; then
+    echo "  Failed: $failed"
+    exit 1
+fi
+echo ""
+exit 0

--- a/tests/test-completeness-contract.sh
+++ b/tests/test-completeness-contract.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Test: every dispatching skill has the completeness-contract preamble
+#
+# Validates that every skill that dispatches subagents includes the
+# load-bearing preamble citing rules/completeness-contract.md. This is
+# the grep-detectable enforcement test from the subagent rigor PR.
+#
+# Run from repo root: bash tests/test-completeness-contract.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "── Test: completeness-contract preamble across dispatching skills ──"
+echo ""
+
+# Skills that dispatch subagents — they MUST include the preamble.
+# work-resume is intentionally excluded: it diagnoses stuck dispatches
+# from other skills but never dispatches subagents itself.
+DISPATCHING_SKILLS=(
+    "skills/architect/SKILL.md"
+    "skills/audit/SKILL.md"
+    "skills/curate/SKILL.md"
+    "skills/feature-coordinate/SKILL.md"
+    "skills/feature-plan/SKILL.md"
+    "skills/spec-author/SKILL.md"
+    "skills/spec-backfill/SKILL.md"
+    "skills/work-plan/SKILL.md"
+    "skills/work-run/SKILL.md"
+    "skills/work-start/SKILL.md"
+)
+
+# ── Test 1: every dispatching skill mentions completeness-contract.md ──
+for skill in "${DISPATCHING_SKILLS[@]}"; do
+    skill_path="$REPO_ROOT/$skill"
+    if [[ ! -f "$skill_path" ]]; then
+        fail "$skill exists" "file not found"
+        continue
+    fi
+    if grep -q "rules/completeness-contract.md" "$skill_path"; then
+        pass "$skill references rules/completeness-contract.md"
+    else
+        fail "$skill references rules/completeness-contract.md" "missing"
+    fi
+done
+
+# ── Test 2: every dispatching skill uses the "load-bearing" marker ─────
+# This guards against the rule being mentioned in passing without the
+# load-bearing preamble. The phrase "load-bearing" must appear near
+# the contract citation.
+for skill in "${DISPATCHING_SKILLS[@]}"; do
+    skill_path="$REPO_ROOT/$skill"
+    [[ ! -f "$skill_path" ]] && continue
+    if grep -q "load-bearing" "$skill_path"; then
+        pass "$skill marks the contract as load-bearing"
+    else
+        fail "$skill marks the contract as load-bearing" "missing 'load-bearing'"
+    fi
+done
+
+# ── Test 3: the rule file itself exists ───────────────────────────────
+rule_path="$REPO_ROOT/rules/completeness-contract.md"
+if [[ -f "$rule_path" ]]; then
+    pass "rules/completeness-contract.md exists"
+else
+    fail "rules/completeness-contract.md exists" "file not found"
+fi
+
+# ── Test 4: rule file contains the six contracts ──────────────────────
+if [[ -f "$rule_path" ]]; then
+    for contract in "Verification contract" "Production-path contract" "Measurement contract" "Annotation contract" "Quality-bar contract" "Scope-reconciliation contract"; do
+        if grep -q "$contract" "$rule_path"; then
+            pass "rule file contains '$contract'"
+        else
+            fail "rule file contains '$contract'" "missing"
+        fi
+    done
+fi
+
+# ── Test 5: rule listed in MANIFEST ───────────────────────────────────
+manifest="$REPO_ROOT/MANIFEST"
+if grep -q "rules/completeness-contract.md" "$manifest"; then
+    pass "MANIFEST includes rules/completeness-contract.md"
+else
+    fail "MANIFEST includes rules/completeness-contract.md" "missing entry"
+fi
+
+# ── Test 6: validator script in MANIFEST + install.sh ─────────────────
+if grep -q "scripts/validate-subagent-return.sh" "$manifest"; then
+    pass "MANIFEST includes validate-subagent-return.sh"
+else
+    fail "MANIFEST includes validate-subagent-return.sh" "missing entry"
+fi
+
+install_sh="$REPO_ROOT/install.sh"
+if grep -q "validate-subagent-return.sh" "$install_sh"; then
+    pass "install.sh installs validate-subagent-return.sh"
+else
+    fail "install.sh installs validate-subagent-return.sh" "missing"
+fi
+
+# ── Test 7: WD orchestrators pass --require-ac-coverage ──────────────
+WD_ORCHESTRATORS=(
+    "skills/work-run/SKILL.md"
+    "skills/work-start/SKILL.md"
+    "skills/work-plan/SKILL.md"
+    "skills/feature-coordinate/SKILL.md"
+)
+for skill in "${WD_ORCHESTRATORS[@]}"; do
+    skill_path="$REPO_ROOT/$skill"
+    [[ ! -f "$skill_path" ]] && continue
+    if grep -q "validate-subagent-return.sh.*--require-ac-coverage" "$skill_path"; then
+        pass "$skill passes --require-ac-coverage to validator"
+    else
+        fail "$skill passes --require-ac-coverage to validator" "flag not found"
+    fi
+done
+
+# ── Test 8: non-WD orchestrators DO NOT pass --require-ac-coverage ───
+NON_WD_ORCHESTRATORS=(
+    "skills/audit/SKILL.md"
+    "skills/spec-backfill/SKILL.md"
+    "skills/curate/SKILL.md"
+)
+for skill in "${NON_WD_ORCHESTRATORS[@]}"; do
+    skill_path="$REPO_ROOT/$skill"
+    [[ ! -f "$skill_path" ]] && continue
+    if grep -q "validate-subagent-return.sh" "$skill_path"; then
+        # Has validator call — make sure it does NOT pass --require-ac-coverage
+        if grep -q "validate-subagent-return.sh.*--require-ac-coverage" "$skill_path"; then
+            fail "$skill omits --require-ac-coverage" "flag found but shouldn't be"
+        else
+            pass "$skill omits --require-ac-coverage (correct for non-WD dispatch)"
+        fi
+    fi
+done
+
+# ── Test 9: feature-pr quality-bar gate present ───────────────────────
+pr_skill="$REPO_ROOT/skills/feature-pr/SKILL.md"
+if [[ -f "$pr_skill" ]]; then
+    if grep -q "Quality-bar gate" "$pr_skill"; then
+        pass "feature-pr has Quality-bar gate section"
+    else
+        fail "feature-pr has Quality-bar gate section" "section not found"
+    fi
+    if grep -q ".flake-allowlist.md" "$pr_skill"; then
+        pass "feature-pr references .flake-allowlist.md"
+    else
+        fail "feature-pr references .flake-allowlist.md" "not referenced"
+    fi
+fi
+
+# ── Test 10: spec-verify enforcement check present ───────────────────
+sv_skill="$REPO_ROOT/skills/spec-verify/SKILL.md"
+if [[ -f "$sv_skill" ]]; then
+    if grep -q "Enforcement check" "$sv_skill"; then
+        pass "spec-verify has Enforcement check section"
+    else
+        fail "spec-verify has Enforcement check section" "section not found"
+    fi
+    if grep -q "RETIRE / REMOVE-style" "$sv_skill"; then
+        pass "spec-verify has RETIRE/REMOVE enforcement guidance"
+    else
+        fail "spec-verify has RETIRE/REMOVE enforcement guidance" "not found"
+    fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "── Test summary ──────────────────────────────────────────────"
+echo "  Passed: $passed / $total"
+if [[ $failed -gt 0 ]]; then
+    echo "  Failed: $failed"
+    exit 1
+fi
+echo ""
+exit 0


### PR DESCRIPTION
## Summary

Codifies the **completeness contract** as a load-bearing rule, wires it into every dispatching skill, and adds a mechanical validator that orchestrators run on every subagent return. Addresses 7 of 8 structural failure modes documented in the 2026-05 jlsm session report.

The contract: **Claude has no authority to defer assigned scope. Default action is fix/complete. Escalation requires user-validatable proof — not judgment.** Same burden-shift as "find the bugs or prove they don't exist."

Derived from review of 70+ deferral cases where subagents shipped half-baked work by classifying scope as "follow-on" / "candidate" / "out of scope" using their own judgment. 100% were laziness.

## What changed

### Foundation
- **`rules/completeness-contract.md`** — new always-loaded rule. Six concrete contracts (Verification, Production-path, Measurement, Annotation, Quality-bar, Scope-reconciliation) emerge from the authority rule.

### Mechanical enforcement
- **`scripts/validate-subagent-return.sh`** — greps subagent returns for trigger phrases ("candidate", "follow-on", "out of scope", "deferred", "future work", "non-critical", etc.). With `--require-ac-coverage`, also verifies an AC satisfaction mapping. Exit 0 = clean; exit 1 = contract violation (block COMPLETE, route to user); exit 2 = tooling error.

### Wiring (defense in depth — 3 layers)
1. **Rule file** (always-loaded for every Claude session)
2. **Skill preamble** in 10 dispatching skills (architect, audit, curate, feature-coordinate, feature-plan, spec-author, spec-backfill, work-plan, work-run, work-start)
3. **Agent identity** preamble in all 9 agent files

### Orchestrator return validation
- work-run (step 2.5 — downgrades classification on rc=1)
- work-start, work-plan, feature-coordinate (pass `--require-ac-coverage` for WD-style returns)
- audit, spec-backfill, curate (trigger-phrase check only; no WD-style ACs)

### Surgical fixes for specific findings
- **`/spec-verify`** — Step 1.3 now requires enforcement check before claiming SATISFIED (ASSERT/BEHAVIOR/RETIRE classification). Catches phantom annotations like the 2026-05 jlsm `sstable.sparse-key-index.R2` case.
- **`/feature-pr`** — new Step 1b Quality-bar gate. Repo check command must pass before PR draft. No "preexisting" exemption. `.flake-allowlist.md` provides controlled escape hatch with mandatory deadline + assignee.

### Tests
- `tests/test-completeness-contract.sh` (41 checks) — verifies preamble presence + structural enforcement across every dispatching skill.
- `tests/scenario-validate-subagent-return.sh` (18 checks) — covers all trigger phrases, AC coverage modes, error paths.

## Mapping to findings

| Finding | Intervention |
|---------|--------------|
| F1: Tests pass for wrong reason (R53 equivalence) | Verification contract §1 + subagent preambles |
| F2: Silent deferral as completion mode | Authority rule + validator + orchestrator wiring |
| F3: SPI-adapter tests bypass production path | Production-path contract §2 |
| F4: Verbal arguments substituted for measurement | Measurement contract §3 |
| F5: Phantom @spec annotations | /spec-verify enforcement check |
| F6: Pipeline stages not gated on central invariant | **Partial — see below** |
| F7: "Preexisting" failure excuse | /feature-pr quality-bar gate + flake-allowlist |
| F8: Decomposition shrinks scope monotonically | Scope-reconciliation contract §6 + AC validator flag |

## What's NOT in this PR — F6 (central-invariant gate)

The standalone orchestrator-level falsification subagent is **not shipped** in this PR. Rationale (user-validatable proof):

1. The Verification contract (§1 of `rules/completeness-contract.md`) already requires subagents to self-falsify before claiming COMPLETE.
2. The validator script catches subagents that skipped self-falsification (trigger phrases, missing AC).
3. An external orchestrator-level falsification subagent would be substantively new functionality (~$1–2/WD additional cost; new prompt design; new dispatch point) and **has no design yet** — we discussed pulling guidance from `/audit` but did not write the prompt or wire flow.
4. Building ad-hoc would risk shipping lower-quality code than the rest of this PR.

**Recommended follow-up:** v0.22.0 with a designed gate. The verification contract + validator already cover most of F6's surface; the standalone gate is an additive defense-in-depth layer.

**Reviewer override:** If you want F6 pulled into this PR, send back and I'll design + ship it.

## Test plan

- [x] `bash tests/test-completeness-contract.sh` — 41/41 pass
- [x] `bash tests/scenario-validate-subagent-return.sh` — 18/18 pass
- [x] `bash tests/test-install.sh` — 74/74 pass (no regressions)
- [x] Fresh install via `install.sh --dev` — verified rule + script land in target

🤖 Generated with [Claude Code](https://claude.com/claude-code)