### PR TITLE
feat: central-invariant gate + memory→KB design (v0.22.0)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -75,6 +75,7 @@
 .claude/prompts/audit/reconcile-cards.js
 .claude/prompts/audit/reconcile-cards.sh
 .claude/prompts/audit/reconcile-cards-wrapper.sh
+.claude/prompts/feature-pr/central-invariant-falsify.md
 .claude/scripts/audit-budget.sh
 .claude/scripts/extract-findings.sh
 .claude/agents/architect-agent.md

--- a/designs/central-invariant-gate.md
+++ b/designs/central-invariant-gate.md
@@ -1,0 +1,404 @@
+# Central-invariant gate
+
+**Status:** proposed → implementing (v0.22.0)
+**Originating signal:** Finding 6 from 2026-05 jlsm session report —
+"pipeline stages aren't gated on the central invariant." Deferred from
+v0.21.0 PR #104 because no design existed.
+
+---
+
+## Problem
+
+The v0.21.0 hardening pass (PR #104) added:
+
+1. The completeness contract requires subagents to self-falsify before
+   claiming COMPLETE (Verification contract §1).
+2. The validator script catches subagents that wrote trigger phrases or
+   skipped AC mapping.
+
+What's still missing: **external falsification.** A subagent that
+self-falsifies in good faith can still miss the central invariant — the
+load-bearing claim the WD makes. Validators catch betrayal phrases, not
+shallow reasoning.
+
+The 2026-05 jlsm `R53 cross-family equivalence` case is the canonical
+example: the subagent wrote a test that asserted iterator equivalence
+across families. The test passed. The subagent claimed COMPLETE in good
+faith. But the test was vacuously satisfied — both iteration paths
+routed through the same legacy code, so identical output proved nothing
+about whether the new code path was even being exercised.
+
+No trigger phrase. AC mapping present. Validator clean. Bug shipped.
+
+The fix is structural: **a fresh subagent, given the WD's central
+claim + the diff, tries to falsify it.** Same burden-shift as
+`/audit` — "find the bug or prove it doesn't exist." But scoped to one
+WD's central claim, not the corpus.
+
+---
+
+## Goal
+
+Before `/feature-pr` drafts a PR for a completed WD, a falsifier
+subagent reviews:
+
+- The WD's acceptance criteria
+- The diff (changes since base)
+- Relevant spec R-clauses (from spec-coverage.md)
+
+The falsifier returns one of:
+
+- **✓ Invariant holds** — with specific evidence
+- **✗ Invariant fails** — with the concrete failure scenario
+- **? Unclear** — with the specific obstacles to falsification
+
+`/feature-pr` proceeds only on ✓. ✗ and ? block the PR draft and
+route to the user via AskUserQuestion with the falsifier's verdict as
+context.
+
+---
+
+## Non-goals
+
+- **Multi-pass analysis.** `/audit` already does the heavy
+  multi-pass+lens analysis. The gate is single-pass, single-WD.
+- **Corpus-wide review.** The gate scopes to ONE WD's diff. The user
+  can run `/audit` for cross-WD work.
+- **Replacing the verification contract.** The contract still requires
+  subagent self-falsification. The gate is a second, independent
+  falsification — defense in depth, not replacement.
+- **Free.** The gate adds ~$0.50–$2 per WD in subagent dispatch cost.
+  Cheaper than `/audit`, but not free.
+- **Auto-fixing.** If the gate finds ✗, it surfaces to user. It does
+  not automatically dispatch a fix.
+
+---
+
+## Design
+
+### Placement
+
+`/feature-pr` is the natural home. The skill already runs gates
+(Step 1a spec-coverage, Step 1b quality-bar) before drafting. The
+central-invariant gate becomes **Step 1c**, after the quality-bar
+gate and before Step 2 (Draft the PR).
+
+Rationale for `/feature-pr` placement (not `/feature-coordinate`):
+
+- Per-WD scope. `/feature-pr` runs once per WD; coordinate runs once
+  per batch of work units within a WD.
+- Diff is freshest. By Step 1c, all implementation + refactor commits
+  are present.
+- Quality-bar adjacency. Co-located with other pre-draft gates.
+- Single-WD perspective. The falsifier looks at *this WD's central
+  invariant*, not the work-unit-level invariants the coordinator
+  manages.
+
+### Inputs to the falsifier subagent
+
+1. **WD reference** — the originating `.work/<group>/WD-<id>.md` (if
+   the feature was launched via `/work-start`). If the feature is
+   standalone (`/feature` directly), the falsifier uses
+   `.feature/<slug>/brief.md` as the WD analog.
+2. **Diff** — `git diff <base>..HEAD` where base is the branch this
+   WD was carved from.
+3. **Spec coverage map** — `.feature/<slug>/spec-coverage.md` (already
+   present from Step 1a) — gives the R-clauses this WD touches.
+4. **Spec bodies** — for each R-clause in the coverage map, the source
+   spec markdown.
+5. **The completeness contract** — `rules/completeness-contract.md`
+   (always-loaded).
+
+### Subagent prompt structure
+
+The falsifier prompt (separate file at `prompts/feature-pr/central-invariant-falsify.md`)
+contains:
+
+```
+You are the Central Invariant Falsifier for /feature-pr. Your only job
+is to find reasons this WD/feature does NOT ship its central goal.
+
+You are NOT trying to be balanced. You are trying to falsify the claim
+"this branch ships the assigned scope." If the claim survives, the PR
+is safer to draft.
+
+[completeness contract preamble inserted at top]
+
+## Inputs
+
+- WD acceptance criteria (or feature brief): {{paste from .work or .feature}}
+- Diff: {{paste of git diff base..HEAD, capped at 200K characters}}
+- Spec R-clauses touched: {{from spec-coverage.md}}
+- Spec bodies for touched R-clauses: {{paste}}
+
+## Method
+
+1. **Identify THE central invariant.** What is the ONE load-bearing
+   claim this WD/feature makes? (E.g., "the v8 reader correctly parses
+   all family-id-1 files", "the audit pipeline finds bugs in the
+   target file", "this refactor preserves observable behavior").
+   State it in one sentence.
+
+2. **Trace the production code path.** Find the entry point a real
+   caller hits to invoke the changed code. NOT the internal SPI
+   adapter, NOT the unit test's direct-construction path. Read the
+   live code path end-to-end.
+
+3. **Construct the falsifier test.** Describe (in pseudocode or
+   plain prose) a test that would FAIL if the central invariant
+   doesn't hold but the WD's submitted tests still pass. Examples
+   of falsifier shapes:
+   - Vacuous equivalence: write a test that strips the new code
+     path entirely and run the existing tests. Do they still pass?
+   - Mocked-vs-live: replace the SPI adapter with the production
+     dependency. Does the behavior change?
+   - End-to-end vs unit: run the existing assertion via the public
+     API instead of internal construction. Does the assertion still
+     hold?
+
+4. **Check the falsifier against the diff.** Is the falsifier test
+   in the diff? If not, the WD has at least one weakness.
+
+5. **Render verdict:**
+   - ✓ HOLDS — the central invariant is supported by tests that
+     route through the production path and would fail under the
+     falsifier scenario. Cite specific test+file evidence.
+   - ✗ FAILS — describe the concrete way the invariant fails.
+     Include the failing scenario and the code/test gap that
+     allows it.
+   - ? UNCLEAR — describe what would need to be true to give a ✓
+     or ✗ verdict, and what's currently missing (insufficient
+     context, unreadable code, etc.).
+
+## Output format
+
+Single block at end of response:
+
+VERDICT: <HOLDS | FAILS | UNCLEAR>
+INVARIANT: <the one-sentence central invariant>
+EVIDENCE: <one-paragraph evidence — test files, line refs, falsifier
+           description, or specific failure scenario>
+```
+
+### Orchestrator branching
+
+`/feature-pr` Step 1c:
+
+```
+1. Identify the WD (or feature brief) and the base branch
+2. Dispatch the falsifier subagent with inputs above
+3. Parse VERDICT line from return
+4. On ✓ HOLDS:
+   - Display the invariant + evidence one-line summary
+   - Proceed to Step 2 (Draft the PR)
+5. On ✗ FAILS:
+   - Display verdict + evidence
+   - AskUserQuestion: "Falsifier found a central-invariant failure.
+                       [evidence]. How to proceed?"
+     Options:
+       - Stop and fix — pause the pipeline; user investigates
+       - Override gate (record verdict in PR description) — proceed
+         with the falsifier's verdict captured in the PR's "Notes
+         for reviewer" section. Reserved for cases where the user
+         disagrees with the falsifier's analysis and wants to ship.
+       - Stop entirely — exit /feature-pr
+6. On ? UNCLEAR:
+   - Display verdict + obstacles
+   - AskUserQuestion: "Falsifier could not reach a verdict because
+                       [obstacles]. How to proceed?"
+     Options:
+       - Re-dispatch with more context — let the user specify the
+         missing piece (a file path, a spec ID, a clarifying note)
+         that the falsifier needs
+       - Proceed anyway (record uncertainty in PR description)
+       - Stop and inspect manually
+```
+
+The override paths are intentional — the user is the ultimate
+authority on whether to ship. The gate's job is to surface the
+question, not to block.
+
+### Subagent contract enforcement
+
+The falsifier's return is itself subject to the completeness
+contract. After the falsifier returns, `/feature-pr` runs:
+
+```bash
+bash .claude/scripts/validate-subagent-return.sh \
+    /tmp/vallorcine/falsifier-return-<slug>.txt
+```
+
+If `rc=1` (trigger phrases in the falsifier's own return), block
+and route to user — the falsifier itself shouldn't be deferring.
+
+### Cost model
+
+Per dispatch:
+- ~5K tokens input (WD + diff snippets + R-clauses) at Sonnet rates
+- ~2–5K tokens output (verdict + evidence)
+- ~$0.05–$0.20 per call at Sonnet 4.6 prices
+
+Worst case (Opus 4.7, large diff capped at 200K chars):
+- ~50K tokens input + 10K output = ~$2 per call
+
+Compared to /audit (~$13/bug found), the gate is 5–10× cheaper and
+runs per-WD instead of per-corpus-audit.
+
+### Skipping the gate
+
+Some WDs don't have a meaningful central invariant beyond their AC
+mapping — e.g., a pure refactor WD or a docs-only WD. For these,
+the contract preamble + validator + spec-coverage gate are
+sufficient.
+
+`/feature-pr` Step 1c can be skipped by setting
+`central_invariant_gate: skip` in `.feature/<slug>/status.md` BEFORE
+running `/feature-pr`. The skill displays a prominent notice that
+the gate was skipped and records the skip in the PR description's
+"Notes for reviewer" section.
+
+Skip is opt-in per feature. Default is to run the gate.
+
+---
+
+## Edge cases
+
+**EC1 — Standalone feature (no .work directory).** If the feature
+was launched via `/feature "<description>"` directly (not via
+/work-start), there's no WD file. The falsifier uses
+`.feature/<slug>/brief.md` as the source of the central invariant.
+
+**EC2 — Empty diff.** A `/feature-pr` invocation on a feature with
+no changes shouldn't run the gate. Detect via
+`git diff --quiet base..HEAD` and skip.
+
+**EC3 — Diff exceeds 200K characters.** For large diffs (rare but
+possible for major refactors), the falsifier receives a summary +
+the most-changed files. The truncation note appears in the
+falsifier's evidence so the user knows verdict was on a sampled
+diff.
+
+**EC4 — Spec coverage map missing.** If `.feature/<slug>/spec-coverage.md`
+doesn't exist (older features predating spec-coverage), the
+falsifier proceeds without R-clauses. Verdict quality is lower but
+still useful.
+
+**EC5 — Falsifier dispatch fails / times out.** The gate is
+advisory; if the dispatch itself errors, log the failure and
+proceed to Step 2 with a note in the PR description. Do not
+silently re-dispatch.
+
+**EC6 — Falsifier's verdict is wrong.** The user is the ultimate
+authority. Override paths exist for both ✗ and ?. The PR
+description records what the gate said and what the user did,
+which provides a trail for retrospectives.
+
+---
+
+## Open questions
+
+**OQ1 — Sonnet vs Opus for the falsifier?** Sonnet 4.6 is fast and
+cheap; Opus 4.7 is more rigorous. Recommendation: Sonnet for default,
+Opus when the user explicitly requests deep analysis (a future
+`--rigorous` flag). Need empirical data on Sonnet's false-negative
+rate before locking in.
+
+**OQ2 — Diff cap at 200K or smaller?** 200K is roughly half of
+Claude's effective working window. Larger diffs sample less of the
+context but are rare. Could lower to 100K to leave more room for
+falsifier reasoning. Pick after first 10 real dispatches.
+
+**OQ3 — Where does the falsifier prompt live?** Two options:
+  (a) `prompts/feature-pr/central-invariant-falsify.md` — colocated
+      with feature-pr skill, installed via install.sh prompts loop
+  (b) `prompts/audit/central-invariant-falsify.md` — colocated with
+      other adversarial prompts under audit
+  Recommendation: (a) — the gate is part of /feature-pr's surface,
+  and the audit/ prompts are scoped to the /audit pipeline.
+
+**OQ4 — Should the gate also run before /feature-complete?**
+`/feature-complete` is the final-archive stage. A second gate there
+would catch cases where the user pushes a PR and merges without
+re-running /feature-pr. But /feature-complete typically runs after
+PR merge — adding a gate would be after-the-fact. Punt to v0.23 if
+we see the gap.
+
+**OQ5 — Multi-WD features.** A feature can encompass several work
+units. Currently /feature-pr drafts one PR for the whole feature.
+The central invariant is the *feature's* invariant, not per-WU. The
+gate operates at feature scope, which is correct. But: if the work
+plan has 5 WUs each with their own invariants, the falsifier might
+miss WU-specific bugs. Mitigation: the WU-level verification
+contract (subagent self-falsification per the rules) catches those.
+The gate is the feature-level final check.
+
+---
+
+## Rejected alternatives
+
+**RA1 — Run the gate inside /feature-coordinate.** Too early — the
+diff isn't final until refactor finishes. /feature-pr is the
+natural latest-and-greatest read.
+
+**RA2 — Make the gate a separate /feature-falsify skill.** Adds a
+manual step the user has to remember. Defense in depth requires
+the gate to be automatic, not opt-in. (Skip-via-status.md is the
+escape hatch.)
+
+**RA3 — Use the same /audit pipeline for the gate.** /audit is
+$13/bug and multi-pass. The gate is $1/WD and single-pass. They
+serve different purposes; conflating them inflates cost and
+dilutes the gate's per-WD focus.
+
+**RA4 — Auto-fix on ✗ verdict.** Auto-fixing erodes user authority.
+The user decides whether the falsifier's analysis is correct and
+how to address it.
+
+**RA5 — Skip the validator on the falsifier's return.** Subagents
+can ship trigger phrases even when asked to find bugs. Running the
+validator on the falsifier's return is consistent with the
+contract — no exemptions.
+
+---
+
+## Implementation plan
+
+**P1 — Subagent prompt** (~1 session)
+- Write `prompts/feature-pr/central-invariant-falsify.md`
+- Test prompt manually against a known case (the R53 equivalence
+  bug if reproducible, otherwise a synthetic one)
+
+**P2 — /feature-pr Step 1c wiring** (~1 session)
+- Add Step 1c to `skills/feature-pr/SKILL.md` after Step 1b
+  quality-bar gate
+- Branching logic for ✓ / ✗ / ?
+- Skip-via-status.md detection
+- AskUserQuestion calls for ✗ and ?
+- Validator pass on falsifier's own return
+
+**P3 — Tests + install plumbing** (~0.5 session)
+- `tests/test-central-invariant-gate.sh` — structural checks (Step
+  1c present, prompt installed, MANIFEST entry)
+- MANIFEST entry for new prompt file
+- install.sh entry for new prompt file
+- Run full test suite to confirm no regressions
+
+**P4 — Docs + changelog** (~0.5 session)
+- CHANGELOG entry for v0.22.0
+- README mention (one line in the "what /feature-pr does" section
+  if any)
+- Cross-reference from `rules/completeness-contract.md` to the gate
+  as an example of defense in depth
+
+---
+
+## Success criteria
+
+- ✓ verdict is the common case for well-built WDs (target: ≥80% of
+  /feature-pr invocations)
+- ✗ verdict surfaces real bugs (false-positive rate: monitor for
+  first 20 real dispatches)
+- ? verdict is rare (<10% — indicates obstacles in the inputs)
+- Cost stays under $2/WD at Sonnet rates
+- The gate catches at least one bug the validator + spec-coverage
+  miss in the first 10 dispatches (proof-of-concept threshold)

--- a/designs/memory-to-kb-migration.md
+++ b/designs/memory-to-kb-migration.md
@@ -1,0 +1,421 @@
+# Memory → KB migration
+
+**Status:** proposed — 2026-05-17
+**Originating signal:** session feedback during v0.21.0 work — durable
+auto-memory entries (70+ in current user's vallorcine memory) hold
+high-signal content that dispatched subagents cannot see, because
+memory lives under `~/.claude/projects/<hash>/memory/` and is not part
+of the project's loaded context.
+
+---
+
+## Problem
+
+Auto-memory accumulates content in three rough categories:
+
+1. **Behavioral feedback** ("don't suggest stopping", "stream large
+   files line-by-line") — applies to how Claude works, not what the
+   project does.
+2. **Project tendencies** ("this project's audits cost ~$13/bug",
+   "spec violations must be fixed inline") — durable observations about
+   the project that should shape future decisions.
+3. **Session state** ("WD-04 is in IMPLEMENTING", "next session: review
+   jlsm KB outputs") — ephemeral.
+
+Today, all three sit in the same `~/.claude/projects/<hash>/memory/`
+directory. This causes two structural problems:
+
+### Problem 1 — Memory is invisible to subagents
+
+When a skill dispatches a subagent via the Agent tool, the subagent
+inherits the project's environment: `rules/*.md`, `.kb/`, `.decisions/`,
+`CLAUDE.md` files. It does **not** inherit the parent's memory entries.
+
+That means a subagent doing TDD work in a project where the user has
+30 memory entries about "this project's testing tendencies" sees none
+of them. Behavioral patterns recorded across sessions stay stuck in
+the main-session orbit.
+
+### Problem 2 — Memory rots
+
+Memory entries are point-in-time observations. Old entries reference
+files or symbols that may have been renamed or removed; the
+`fix_now_not_defer.md` memory I superseded in v0.21.0 was 25 days old
+and the framing had drifted. Without a curation mechanism, memory
+accumulates without a forgetting mechanism.
+
+The KB has structural advantages memory lacks:
+
+- **Visible to subagents.** `.kb/` is part of the project tree.
+- **Curated.** `/curate` runs structural checks; `/kb` provides query
+  surfaces.
+- **Has frontmatter + cross-refs.** Entries can be discovered via tag
+  overlap, applies_to globs, related links.
+- **Repair-friendly.** `/curate` already detects stale entries and
+  surfaces them for review.
+
+---
+
+## Goal
+
+Durable, project-relevant memory content migrates to `.kb/` so:
+
+- Dispatched subagents can pull it via `/kb` search.
+- `/curate` can detect when entries go stale.
+- Cross-refs between memories and KB entries work both directions.
+
+Ephemeral memory (session state, current-task tracking) stays in
+memory — that's the right home for it.
+
+---
+
+## Non-goals
+
+- **Auto-migrate everything.** Migration is a user-approved per-entry
+  decision via `/curate` or a dedicated skill. Bulk auto-migration
+  would corrupt the KB with session noise.
+- **Delete memory once migrated.** Migrated entries leave a memory
+  stub pointing at the KB entry, so prior cross-refs (e.g., other
+  memories that reference the migrated one by filename) keep working.
+  Stub deletion is a separate user action.
+- **Make memory unnecessary.** Memory still hosts the right
+  categories (session state, user-profile, ephemeral observations).
+  Migration is targeted, not wholesale.
+- **Replace `/kb` lifecycle.** KB entries continue to follow the
+  existing `/kb` and `/curate` mechanics. Migrated entries become
+  ordinary KB entries.
+
+---
+
+## Categorization
+
+Three categories, three handling rules:
+
+### Promote to KB
+
+- **Type:** `feedback` (behavioral guidance with broad applicability)
+- **Type:** `project` (durable project tendencies, not session state)
+- **Type:** `reference` (pointers to external systems — same role as
+  KB but more discoverable in KB form)
+
+**Signal markers:**
+- Mentions `tendency`, `gotcha`, `pattern`, `principle`
+- Cross-applies across multiple sessions (referenced by other
+  memories)
+- Describes the project itself, not the user's day
+
+**Examples (from current state):**
+- `feedback_stream_large_files.md` — behavioral tendency → promote
+- `project_audit_scorecard.md` — durable project measurement → promote
+- `feedback_efficiency_as_laziness.md` — design principle → promote
+- `reference_jlsm_repo.md` — external pointer → promote
+
+### Keep in memory
+
+- **Type:** `user` (user-profile data — not project-relevant)
+- **Type:** `project` BUT session-state ("current focus", "next steps")
+- Entries referencing in-progress work that will be irrelevant after
+  the work completes
+
+**Signal markers:**
+- Mentions dates that will pass ("starting 2026-04-02")
+- Tracks WIP, not knowledge
+- References specific sessions, not patterns
+
+**Examples (from current state):**
+- `project_next_session_naming.md` — session priority → keep
+- `project_jlsm_release_prep.md` — has a date → keep
+- `feedback_branch_workflow.md` — user habit → keep
+
+### Delete
+
+- Entries already superseded
+- Entries that turned out to be wrong
+- Entries describing problems that were solved (the solution is in
+  code; the memory is now noise)
+
+**Examples (from current state):**
+- `project_dashboard_intent.md` — dashboard retired; observation now
+  irrelevant → delete on next curation
+- `feedback_fix_now_not_defer.md` — superseded by
+  `feedback_fix_or_prove_cant.md`; could be deleted after a
+  deprecation window
+
+---
+
+## Migration mechanism
+
+### Option A — Extend `/curate` with a `memory-to-kb` mode
+
+Pros:
+- Reuses existing curation surface
+- Already has user-approved finding flow (numbered pick list)
+- Lifecycle already handled (review-log, scan state)
+
+Cons:
+- /curate is already a heavy skill with many modes
+- Memory access requires the skill to read outside the project tree
+  (`~/.claude/projects/<hash>/memory/`) — new permission surface
+
+### Option B — New skill `/memory-promote`
+
+Pros:
+- Single-purpose; easier to reason about
+- Clean separation: /curate handles project artifacts, /memory-promote
+  handles personal memory
+
+Cons:
+- Adds a kit surface to maintain
+- Users have to remember a new command
+
+### Option C — Hook into `/ideate continue` startup
+
+Pros:
+- Runs naturally at session start when memory is already being read
+- No new user-facing command
+- Catches stale memory immediately when it would be relevant
+
+Cons:
+- Tied to /ideate flow (user-facing); not available outside that flow
+- Mixes session orientation with migration housekeeping
+
+### Recommendation: Option A (extend `/curate`)
+
+Migrate as `/curate memory-promote` sub-mode:
+
+```
+/curate memory-promote
+```
+
+Runs a scan over `~/.claude/projects/<hash>/memory/` and
+classifies each entry into:
+
+1. **Promote candidates** — entries matching the "promote to KB"
+   signal markers (type: feedback/project/reference, durable language,
+   project-applicable).
+2. **Keep candidates** — entries matching "keep in memory" markers.
+3. **Delete candidates** — entries flagged as superseded or
+   ephemeral-state.
+
+Surfaces findings via the existing /curate numbered-pick-list
+pattern. User picks per-entry: Promote, Keep, Delete, Skip.
+
+Why /curate is the right home:
+- The classification rules above are exactly the kind of pattern
+  detection /curate already does for ADR drift, KB rot, spec
+  coverage, etc.
+- The user already invokes /curate when they want to clean up; memory
+  hygiene fits the same workflow.
+- The review-log already handles "user-approved this finding" state,
+  so promoting an entry leaves a trail.
+
+---
+
+## Format mapping
+
+When promoting a memory entry to a KB entry:
+
+| Memory field | KB field | Notes |
+|--------------|----------|-------|
+| `name:` frontmatter | `title:` frontmatter | One-line description |
+| `description:` frontmatter | `summary:` frontmatter | Used for /kb search |
+| `type: feedback` | `category: behavioral` | Naming convention shift |
+| `type: project` | `category: project-tendency` | |
+| `type: reference` | `category: external-reference` | |
+| Body content | Body content | Direct transfer |
+| `**Why:**` section | `## Why` heading | Promote inline section to heading |
+| `**How to apply:**` section | `## How to apply` heading | Same |
+| (none) | `tags:` frontmatter | Derived from memory content via NLP or user input |
+| (none) | `applies_to:` frontmatter | User-supplied during promotion (glob or path) |
+| (none) | `related:` frontmatter | Cross-refs to other KB entries |
+
+The user supplies the `tags` and `applies_to` interactively during the
+/curate flow — they're the user's call, not the script's. The
+`related:` field is auto-populated by scanning for existing KB entries
+with overlapping tags.
+
+The migrated memory file becomes a stub:
+
+```markdown
+---
+name: Stub — see KB entry
+description: Migrated to .kb/<category>/<slug>.md on 2026-05-17
+type: <original-type>
+---
+
+**Migrated to KB:** `.kb/<category>/<slug>.md`
+
+Original content preserved at `.kb/<category>/<slug>.md`. This stub
+exists so existing cross-references (other memory entries citing this
+file by name) continue to resolve.
+
+Safe to delete this stub after 30 days if no cross-refs remain.
+```
+
+---
+
+## Deduplication and conflict resolution
+
+When `/curate memory-promote` identifies a promote candidate, it
+first checks the KB for existing entries on the same topic:
+
+1. **Same name/title match:** existing entry wins; memory entry is
+   shown as "superseded — delete memory?".
+2. **Same applies_to + overlapping content:** offer merge — user
+   picks which version's text to keep.
+3. **Same tags but different content:** offer "create as related
+   entry" — promote with explicit `related:` link.
+4. **No match:** straight promotion.
+
+The /curate scan-result format includes a "duplicate of" field when
+match (1) is detected.
+
+---
+
+## Repair flow
+
+When `/curate` finds that an existing KB entry has the same content
+as a memory entry (e.g., promoted-then-forgotten), the repair option
+is:
+
+```
+This memory entry duplicates KB entry .kb/<x>/<y>.md.
+  - Delete memory entry (KB is canonical)
+  - Convert memory to stub pointing at KB
+  - Keep both (false alarm)
+```
+
+This is the standard /curate finding shape — user picks the action.
+
+---
+
+## Subagent access patterns
+
+Once an entry lives in `.kb/`, dispatched subagents can find it via:
+
+- **`/kb` search** — the existing pull-model query surface. Subagents
+  invoke `/kb "term"` and get matching entries.
+- **Tag overlap** — `kb-search.sh` already supports tag-based search.
+- **applies_to globs** — entries flagged with `applies_to: src/parser/*`
+  surface automatically when the subagent's work touches matching
+  paths.
+
+No new subagent integration needed — the existing `/kb` mechanics
+handle it. The migration just makes the right content visible.
+
+---
+
+## Open questions
+
+**OQ1 — Should the migration include user-type memories?**
+"user" type entries describe the user's role and preferences. They
+shape Claude's interaction style with the user but are not
+project-relevant. Probably keep in memory. But: if multiple users
+collaborate on a project, the user-profile becomes project-shared
+context. v1 stays user-private.
+
+**OQ2 — Cross-project memory promotion?**
+Some memories (e.g., `feedback_stream_large_files.md`) apply to ALL
+projects, not just vallorcine. Promoting to vallorcine's `.kb/` makes
+the memory invisible to subagents in jlsm. Two options:
+  (a) Promote to a shared `~/.claude/kb/` location loaded by all
+      projects (new mechanism)
+  (b) Per-project: promote separately when the same insight applies
+      in jlsm
+  Recommendation: (b) for v1. Cross-project KB sharing is a separate
+  design.
+
+**OQ3 — How to detect ephemeral session state?**
+Heuristic markers like "current focus", date-stamps, and "next session"
+phrases work for obvious cases. Edge cases need user judgment. The
+/curate flow surfaces candidates with a confidence score so users see
+the easy cases auto-classified and the ambiguous ones flagged for
+review.
+
+**OQ4 — Memory deletion lifecycle?**
+Once promoted-and-stub-replaced, when does the stub itself get
+deleted? Proposal: 30-day window, then /curate offers delete. Too
+short risks breaking cross-refs; too long accumulates stubs.
+
+**OQ5 — Should `/kb` queries auto-include current memory?**
+A simpler alternative to migration: extend `/kb` to also search
+memory at query time. Subagents would call `/kb` and get KB +
+memory results.
+  Pros: no migration needed; existing memory becomes immediately
+        useful to subagents.
+  Cons: cross-project memory unsharable; doesn't solve rot; doesn't
+        introduce structural curation.
+  Recommendation: REJECT for v1. Migration is the right long-term
+  shape. /kb augmentation papers over the visibility problem without
+  solving rot.
+
+---
+
+## Rejected alternatives
+
+**RA1 — Auto-migrate all memory at install time.** Too aggressive;
+ships project-irrelevant content (user profile, session state) into
+KB. User judgment is required per-entry.
+
+**RA2 — Symlink memory into the project tree.** Makes memory visible
+but doesn't solve rot, doesn't get the /kb search surface, exposes
+user data into the repo.
+
+**RA3 — New memory category specifically for "promoteable" entries.**
+Adds a fourth memory type (user/feedback/project/reference →
++kb-promote-candidate). Increases complexity for marginal benefit.
+
+**RA4 — Promote in reverse direction (KB → memory).** Wrong direction
+— memory is the bottleneck for subagent visibility, KB is the
+canonical store.
+
+---
+
+## Implementation plan
+
+This is a 4-PR sequence, each independently mergeable.
+
+**P1 — Classification rules + dry-run reporter** (~1 session)
+- Write `scripts/memory-classify.sh` that reads
+  `~/.claude/projects/<hash>/memory/*.md` and emits a JSONL
+  classification for each entry: `{file, type, category, signal, confidence}`
+- Output goes to `.curate/memory-classification.jsonl`
+- No mutations yet — this is the scanner
+
+**P2 — `/curate memory-promote` sub-mode** (~1–2 sessions)
+- Add `memory-promote` argument handling to `skills/curate/SKILL.md`
+- Wire up the numbered pick list, integrating with the existing
+  /curate flow
+- AskUserQuestion per entry: Promote / Keep / Delete / Skip
+- For Promote: AskUserQuestion for tags and applies_to
+
+**P3 — Migration mechanics** (~1 session)
+- Write `scripts/memory-to-kb.sh` that takes a memory file path +
+  KB target path + frontmatter args → produces the KB entry + memory
+  stub
+- Wire up MANIFEST entries
+- Handle deduplication checks (Step 4 above)
+- Append to `.curate/review-log.md` with status
+
+**P4 — Stub lifecycle + tests** (~0.5 session)
+- Add 30-day stub expiration to /curate scan
+- Test scenarios:
+  - Promote-then-stub flow
+  - Duplicate-detection paths
+  - Stub-deletion after expiration
+- Update `tests/test-completeness-contract.sh` to verify the new
+  prompt and scripts are wired
+
+---
+
+## Success criteria
+
+- Pick 5 high-signal memory entries from the user's current memory and
+  migrate them to vallorcine `.kb/` via /curate memory-promote
+- Verify a subagent dispatched by /audit can find those entries via
+  /kb query
+- Verify stale-promoted-memory detection works on at least one case
+- /curate scan time grows by less than 15% (this is a structural test
+  to ensure the new sub-mode doesn't bloat the existing scan)
+- User reports they no longer manually copy-paste memory content into
+  subagent prompts (qualitative — first 3 sessions post-merge)

--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,14 @@ for f in "$SCRIPT_DIR"/prompts/audit/*.md "$SCRIPT_DIR"/prompts/audit/*.py "$SCR
     install_file "$f" "$TARGET/.claude/prompts/audit/$(basename "$f")"
 done
 
+echo ""
+echo "── feature-pr prompts ─────────────────────────────"
+mkdir -p "$TARGET/.claude/prompts/feature-pr"
+for f in "$SCRIPT_DIR"/prompts/feature-pr/*.md; do
+    [[ -f "$f" ]] || continue
+    install_file "$f" "$TARGET/.claude/prompts/feature-pr/$(basename "$f")"
+done
+
 # ── Scripts ───────────────────────────────────────────────────────────────────
 
 echo ""

--- a/prompts/feature-pr/central-invariant-falsify.md
+++ b/prompts/feature-pr/central-invariant-falsify.md
@@ -1,0 +1,210 @@
+# Central Invariant Falsifier — /feature-pr Step 1c
+
+**Subagent contract:** Honor `rules/completeness-contract.md` (load-bearing —
+no silent deferrals; trigger phrases = escalation signals, not completion
+modes). If you cannot reach a verdict, return `VERDICT: UNCLEAR` with
+specific obstacles — do not invent a verdict to satisfy the form.
+
+---
+
+## Your role
+
+You are the Central Invariant Falsifier for `/feature-pr`. Your only job is
+to find reasons this WD/feature does **NOT** ship its central goal. You are
+not trying to be balanced. You are not trying to find every bug. You are
+trying to falsify the claim "this branch ships the assigned scope."
+
+If the claim survives a serious falsification attempt, the PR is safer to
+draft. If it doesn't survive, the user needs to know before the PR opens.
+
+You operate independently of the subagent(s) that wrote the implementation.
+They self-falsified per the Verification contract. You falsify externally —
+no inheritance of their reasoning. Read the diff and the AC, then attack
+the central claim.
+
+---
+
+## Inputs you will receive
+
+Your invoking skill (`/feature-pr` Step 1c) passes you:
+
+1. **WD acceptance criteria** (or feature brief, if standalone). The
+   bar this work was meant to clear.
+2. **Diff** — `git diff <base>..HEAD` for the feature branch. Capped at
+   200K characters; if truncated, the dispatcher tells you.
+3. **Spec coverage map** — the R-clauses this work touches.
+4. **Spec bodies** — the source markdown for each touched R-clause.
+5. **Feature/WD slug** — identifier for naming output files if needed.
+
+Read these carefully BEFORE attacking. The central invariant is encoded in
+the AC + spec R-clauses, not in the diff. The diff is what you attack
+against.
+
+---
+
+## Method
+
+### Step 1 — Identify THE central invariant
+
+What is the ONE load-bearing claim this WD/feature makes? Examples:
+
+- "The v8 reader correctly parses all family-id-1 files end-to-end."
+- "The audit pipeline finds bugs in the target file via topology clustering."
+- "This refactor preserves observable behavior on all existing tests."
+- "The new spec-author Pass 2 produces falsifiable requirements."
+
+State it in ONE sentence. If you cannot identify a single central invariant
+because the WD is genuinely multi-load-bearing (e.g., a major feature with
+3 independent claims), enumerate them and falsify each.
+
+### Step 2 — Trace the production code path
+
+Find the entry point a real caller hits to invoke the changed code. This
+is critical because the path-of-least-resistance failure mode (R53
+equivalence pattern) is to write a test that exercises an internal SPI
+adapter or directly constructs an internal class, bypassing the real
+caller path.
+
+- **Public API**: what method/function does a downstream user call?
+- **Live integration**: what happens when the production system invokes
+  the changed code? (Not what a unit test sets up — what the live system does.)
+- **Routing**: does the diff change the routing? Did the new code path
+  actually get hooked in, or is it sitting unused alongside the legacy
+  path?
+
+Read the live code path end-to-end. Note any branches where the new code
+might NOT be exercised by the production path.
+
+### Step 3 — Construct the falsifier scenario
+
+Describe (in pseudocode, prose, or a concrete example) a test that would
+**FAIL** if the central invariant doesn't hold but the WD's submitted
+tests still pass.
+
+Falsifier patterns that catch common failure modes:
+
+**Pattern A — Vacuous equivalence (R53):**
+Identify the test that asserts equivalence between paths. Mentally strip
+the NEW code path entirely. Do the existing tests still pass? If yes,
+the test is vacuous — it proves nothing about the new code being exercised.
+
+**Pattern B — Mocked-vs-live:**
+Identify tests that mock the production dependency. Replace the mock with
+the live dependency. Does the behavior change? If yes, the test was
+testing the mock, not the production behavior.
+
+**Pattern C — End-to-end vs unit:**
+Identify the strongest assertion in the test suite. Re-route it through
+the public API instead of internal construction. Does the assertion still
+hold? If no, the assertion was relying on internal state the production
+path doesn't expose.
+
+**Pattern D — Verbal argument for measurement:**
+If the AC includes a performance, allocation, or conformance claim, check
+whether the diff includes a MEASUREMENT (benchmark, allocation counter,
+conformance test). If only verbal arguments support the claim, that's
+not evidence — that's a hypothesis the falsifier rejects.
+
+**Pattern E — Phantom annotation:**
+If the AC references a "retired" or "removed" symbol/path, grep the
+WHOLE codebase for the deprecated identifier. If it survives in any
+production code path, the "retired" claim is false.
+
+### Step 4 — Check the falsifier against the diff
+
+Is the falsifier scenario already in the diff (as a test, an assertion,
+or a measurement)?
+
+- **Yes, falsifier addressed**: the central invariant has external support.
+  Verdict tilts ✓.
+- **No, falsifier addresses an actual gap**: the central invariant is
+  vulnerable. Verdict tilts ✗ — describe the specific gap.
+- **Cannot determine from diff alone**: missing context. Verdict tilts ?.
+
+### Step 5 — Render verdict
+
+Pick exactly one verdict. Be honest. The user has override paths for
+both ✗ and ? — your job is to surface what you found, not to be safe.
+
+- **✓ HOLDS** — the central invariant is supported by tests/code that
+  route through the production path AND would fail under the falsifier
+  scenario. Cite specific test files, line numbers, and the falsifier
+  scenario you confirmed is covered.
+- **✗ FAILS** — describe the concrete falsifier scenario that the diff
+  does NOT defend against. Include: the failing input/state, the code
+  or test gap that allows it, and the production path that would
+  exercise the gap.
+- **? UNCLEAR** — describe what would need to be true to give a ✓ or
+  ✗ verdict, and what's currently missing. Acceptable obstacles:
+  insufficient context (e.g., a spec body not provided), unreadable
+  code (e.g., a binary file in the diff), or a genuinely novel
+  pattern with no prior falsifier shape. Not acceptable: "the diff is
+  large" or "I'd need more time."
+
+---
+
+## Output format
+
+End your response with **EXACTLY** this block:
+
+```
+VERDICT: <HOLDS | FAILS | UNCLEAR>
+INVARIANT: <the one-sentence central invariant from Step 1>
+EVIDENCE: <one or two paragraphs: cite test files / line refs / falsifier
+           scenario / specific failure mode>
+```
+
+If you identified multiple central invariants in Step 1, render the
+verdict for each:
+
+```
+VERDICT[1]: <HOLDS | FAILS | UNCLEAR>
+INVARIANT[1]: <first invariant>
+EVIDENCE[1]: <evidence for first>
+
+VERDICT[2]: <...>
+INVARIANT[2]: <...>
+EVIDENCE[2]: <...>
+```
+
+The orchestrator parses the highest-severity verdict (FAILS > UNCLEAR >
+HOLDS) and routes accordingly. Be precise — your verdict drives the
+routing.
+
+---
+
+## Anti-patterns (do not do these)
+
+- **Do not** soften ✗ to ? to "be polite." If the diff clearly fails
+  the falsifier, say so.
+- **Do not** mark ✓ to "be helpful." A false positive blocks the user
+  from learning the gate works.
+- **Do not** propose fixes. Your role ends at verdict + evidence. The
+  user decides what to do next.
+- **Do not** add deferral phrases ("the next sprint", "follow-up",
+  "candidate for later") — the validator will catch them and downgrade
+  your return to a contract violation.
+- **Do not** treat the contract preamble as decorative. You ARE bound
+  by it.
+
+---
+
+## Examples (for calibration)
+
+**Example 1 — vacuous equivalence (✗ FAILS):**
+
+> VERDICT: FAILS
+> INVARIANT: The RadixKeyIndex reader correctly handles family-id-1 files end-to-end.
+> EVIDENCE: tests/cross_family_equivalence_test.rs asserts that iterator output matches across families. But the production read path in SSTableReaders::open() routes family-id-1 through SparseKeyReader::read_legacy when the new RadixKeyReader is not wired in (src/sstable/readers.rs:142). The test as written would pass even if RadixKeyReader were entirely removed. Falsifier: rip out RadixKeyReader; re-run tests/cross_family_equivalence_test.rs. Diff does not include an assertion that the production path actually constructs a RadixKeyReader instance (e.g., via reflection or assertInstanceOf), which is what would close this gap.
+
+**Example 2 — clean ✓:**
+
+> VERDICT: HOLDS
+> INVARIANT: The /work-decompose Phase A correctly identifies dependency seams between WDs.
+> EVIDENCE: tests/scenario-decompose-high-cluster.sh asserts 15 specific Phase A behaviors including cross-WD dependency propagation, seam detection on shared types, and the "no orphan WD" invariant. The test routes through the production /work-decompose binary, not internal helpers (verified in tests/scenario-decompose-high-cluster.sh:48-67). Falsifier patterns A and C both checked — the assertions hold when routed through the public API. No evidence of mocking or path bypass in the diff.
+
+**Example 3 — UNCLEAR:**
+
+> VERDICT: UNCLEAR
+> INVARIANT: The /spec-verify enforcement check correctly catches phantom annotations.
+> EVIDENCE: The diff adds new prose instructions to spec-verify SKILL.md but does not include a mechanical test verifying the instructions are honored by Claude when executing the skill. To falsify, I would need either (a) a synthetic spec with a known phantom annotation and a recorded /spec-verify run showing the gap is detected, or (b) a structural test that the SKILL.md changes are present (which test-completeness-contract.sh already does — but it doesn't verify Claude actually follows them). The gap is at the prompt-execution level, not the structural level. Recommend the user verify the behavior manually on one real case before merging.

--- a/skills/feature-pr/SKILL.md
+++ b/skills/feature-pr/SKILL.md
@@ -289,6 +289,146 @@ permanent silence.
 
 ---
 
+## Step 1c — Central-invariant gate (mandatory before Step 2)
+
+Per `designs/central-invariant-gate.md` and the Verification contract in
+`rules/completeness-contract.md` §1, run an external falsification pass
+on the completed work before drafting the PR. This catches the
+"vacuous equivalence" failure mode (R53 pattern) and other cases where
+self-falsification missed the central claim.
+
+### Skip detection
+
+First check `.feature/<slug>/status.md` for an explicit skip:
+
+```bash
+if grep -q "^central_invariant_gate: skip$" .feature/<slug>/status.md 2>/dev/null; then
+    skipped=true
+fi
+```
+
+If `skipped=true`, display a prominent notice and record the skip in the
+PR description's "Notes for reviewer" section. Proceed to Step 2. Skip is
+opt-in per feature (default: run the gate).
+
+### Empty-diff detection
+
+```bash
+if git diff --quiet "$BASE_BRANCH"..HEAD; then
+    # No changes — gate has nothing to falsify
+    skipped=true
+    skip_reason="empty diff"
+fi
+```
+
+If empty, treat like skip with reason recorded.
+
+### Dispatch the falsifier
+
+```bash
+mkdir -p /tmp/vallorcine
+diff_file=/tmp/vallorcine/falsifier-diff-"<slug>".txt
+ac_file=/tmp/vallorcine/falsifier-ac-"<slug>".txt
+
+# Capture diff (cap at 200K chars to fit context)
+git diff "$BASE_BRANCH"..HEAD | head -c 200000 > "$diff_file"
+
+# Source of AC: WD file if exists, else brief
+if [[ -f .work/<group>/<wd-id>.md ]]; then
+    cp .work/<group>/<wd-id>.md "$ac_file"
+elif [[ -f .feature/<slug>/brief.md ]]; then
+    cp .feature/<slug>/brief.md "$ac_file"
+fi
+```
+
+Then dispatch a subagent via the Agent tool with these inputs and
+instruct it to read `.claude/prompts/feature-pr/central-invariant-falsify.md`
+for the complete falsifier protocol.
+
+The subagent prompt MUST include the standard subagent-contract preamble
+citing `rules/completeness-contract.md` (load-bearing).
+
+### Validate the falsifier's own return
+
+After the falsifier returns, run the validator on its return text:
+
+```bash
+falsifier_return_file=/tmp/vallorcine/falsifier-return-"<slug>".txt
+printf '%s\n' "$FALSIFIER_RETURN_TEXT" > "$falsifier_return_file"
+bash .claude/scripts/validate-subagent-return.sh "$falsifier_return_file" 2>/tmp/vallorcine/validator-stderr.txt
+val_rc=$?
+```
+
+If `val_rc=1` (trigger phrases in the falsifier's return), the falsifier
+itself violated the contract. Surface to user via AskUserQuestion before
+trusting the verdict.
+
+### Parse the verdict
+
+Extract the `VERDICT:` line from the falsifier's return:
+
+```bash
+verdict=$(grep -E '^VERDICT(\[[0-9]+\])?:' "$falsifier_return_file" | head -1 | sed 's/^VERDICT[^:]*: *//')
+```
+
+Multiple-invariant returns (VERDICT[1], VERDICT[2], ...) are parsed for
+the **highest severity** verdict — FAILS > UNCLEAR > HOLDS.
+
+### Branch on verdict
+
+**On ✓ HOLDS:**
+- Display the one-line invariant + evidence summary
+- Proceed to Step 2
+
+**On ✗ FAILS:**
+- Display the verdict + evidence
+- Use AskUserQuestion:
+  > Title: "Falsifier found a central-invariant failure for <slug>"
+  > Options:
+  >   1. **Stop and fix** — pause the pipeline; the user investigates the
+  >      gap and either fixes it (re-run /feature-pr after) or returns
+  >      to choose another option.
+  >   2. **Override gate (record verdict in PR)** — proceed with the
+  >      falsifier's verdict captured verbatim in the PR description's
+  >      "Notes for reviewer" section. Reserved for cases where the user
+  >      disagrees with the falsifier's analysis.
+  >   3. **Stop entirely** — exit /feature-pr without drafting.
+
+**On ? UNCLEAR:**
+- Display the verdict + obstacles
+- Use AskUserQuestion:
+  > Title: "Falsifier could not reach a verdict for <slug>"
+  > Options:
+  >   1. **Re-dispatch with more context** — let the user specify the
+  >      missing piece (file path, spec ID, clarifying note) and re-run
+  >      Step 1c.
+  >   2. **Proceed anyway (record uncertainty in PR)** — capture the
+  >      UNCLEAR verdict + obstacles in the PR description's "Notes for
+  >      reviewer" section.
+  >   3. **Stop and inspect manually** — pause for user investigation.
+
+### Dispatch failure / timeout
+
+If the Agent dispatch itself errors (subagent crashed, payload-lost,
+internal error), the gate is advisory — log the failure to stderr and
+proceed to Step 2 with a note in the PR description: "Central-invariant
+gate dispatch failed; see <log location> for details." Do not silently
+re-dispatch; let the user re-run /feature-pr if they want a fresh
+attempt.
+
+### Cost expectation
+
+Per gate dispatch:
+- Sonnet 4.6 (default): ~$0.05–$0.20
+- Opus 4.7 (large diffs): up to ~$2
+
+The gate runs ONCE per /feature-pr invocation. Idempotency rule (Step 1a)
+means re-running /feature-pr re-runs the gate; this is intentional —
+the gate is cheap enough to re-run, and the verdict should reflect the
+current diff state.
+
+---
+
 ## Step 2 — Draft the PR
 
 Construct the PR draft in this order:

--- a/tests/test-central-invariant-gate.sh
+++ b/tests/test-central-invariant-gate.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Test: /feature-pr Step 1c central-invariant gate is wired correctly
+#
+# Validates that the v0.22.0 central-invariant gate has the structural
+# pieces in place: skill step, falsifier prompt, install plumbing, MANIFEST
+# entry.
+#
+# Run from repo root: bash tests/test-central-invariant-gate.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+echo ""
+echo "── Test: /feature-pr Step 1c central-invariant gate ─────────────"
+echo ""
+
+# ── Test 1: design doc exists ─────────────────────────────────────────
+design_path="$REPO_ROOT/designs/central-invariant-gate.md"
+if [[ -f "$design_path" ]]; then
+    pass "designs/central-invariant-gate.md exists"
+else
+    fail "designs/central-invariant-gate.md exists" "file not found"
+fi
+
+# ── Test 2: falsifier prompt exists ───────────────────────────────────
+prompt_path="$REPO_ROOT/prompts/feature-pr/central-invariant-falsify.md"
+if [[ -f "$prompt_path" ]]; then
+    pass "prompts/feature-pr/central-invariant-falsify.md exists"
+else
+    fail "prompts/feature-pr/central-invariant-falsify.md exists" "file not found"
+fi
+
+# ── Test 3: prompt opens with subagent contract preamble ──────────────
+if [[ -f "$prompt_path" ]]; then
+    if head -10 "$prompt_path" | grep -q "Subagent contract"; then
+        pass "falsifier prompt opens with Subagent contract preamble"
+    else
+        fail "falsifier prompt opens with Subagent contract preamble" "preamble missing in top 10 lines"
+    fi
+    if grep -q "rules/completeness-contract.md" "$prompt_path"; then
+        pass "falsifier prompt cites rules/completeness-contract.md"
+    else
+        fail "falsifier prompt cites rules/completeness-contract.md" "citation missing"
+    fi
+fi
+
+# ── Test 4: prompt enumerates required output format ─────────────────
+if [[ -f "$prompt_path" ]]; then
+    for marker in "VERDICT:" "INVARIANT:" "EVIDENCE:"; do
+        if grep -q "$marker" "$prompt_path"; then
+            pass "falsifier prompt requires '$marker' output"
+        else
+            fail "falsifier prompt requires '$marker' output" "marker missing"
+        fi
+    done
+fi
+
+# ── Test 5: prompt covers all 5 falsifier patterns ───────────────────
+if [[ -f "$prompt_path" ]]; then
+    for pattern in "Vacuous equivalence" "Mocked-vs-live" "End-to-end vs unit" "Verbal argument" "Phantom annotation"; do
+        if grep -q "$pattern" "$prompt_path"; then
+            pass "falsifier prompt covers '$pattern' pattern"
+        else
+            fail "falsifier prompt covers '$pattern' pattern" "missing"
+        fi
+    done
+fi
+
+# ── Test 6: feature-pr SKILL.md has Step 1c section ──────────────────
+skill_path="$REPO_ROOT/skills/feature-pr/SKILL.md"
+if [[ -f "$skill_path" ]]; then
+    if grep -q "Step 1c — Central-invariant gate" "$skill_path"; then
+        pass "feature-pr SKILL.md has Step 1c section"
+    else
+        fail "feature-pr SKILL.md has Step 1c section" "section header missing"
+    fi
+fi
+
+# ── Test 7: Step 1c references the falsifier prompt path ─────────────
+if [[ -f "$skill_path" ]]; then
+    if grep -q "prompts/feature-pr/central-invariant-falsify.md" "$skill_path"; then
+        pass "Step 1c references the falsifier prompt path"
+    else
+        fail "Step 1c references the falsifier prompt path" "path not referenced"
+    fi
+fi
+
+# ── Test 8: Step 1c branches on verdict (HOLDS, FAILS, UNCLEAR) ──────
+if [[ -f "$skill_path" ]]; then
+    for verdict in "HOLDS" "FAILS" "UNCLEAR"; do
+        if grep -q "$verdict" "$skill_path"; then
+            pass "Step 1c handles '$verdict' verdict"
+        else
+            fail "Step 1c handles '$verdict' verdict" "verdict not referenced"
+        fi
+    done
+fi
+
+# ── Test 9: Step 1c has skip detection ────────────────────────────────
+if [[ -f "$skill_path" ]]; then
+    if grep -q "central_invariant_gate: skip" "$skill_path"; then
+        pass "Step 1c supports central_invariant_gate: skip"
+    else
+        fail "Step 1c supports central_invariant_gate: skip" "skip marker missing"
+    fi
+fi
+
+# ── Test 10: Step 1c has empty-diff detection ────────────────────────
+if [[ -f "$skill_path" ]]; then
+    if grep -q "empty diff\|empty-diff\|git diff --quiet" "$skill_path"; then
+        pass "Step 1c handles empty-diff case"
+    else
+        fail "Step 1c handles empty-diff case" "empty-diff handling missing"
+    fi
+fi
+
+# ── Test 11: Step 1c validates the falsifier's own return ────────────
+if [[ -f "$skill_path" ]]; then
+    # The step should run validate-subagent-return.sh on the falsifier's return
+    if grep -A 5 "Step 1c" "$skill_path" 2>/dev/null | head -200 > /tmp/step1c.txt && \
+       grep -B 200 "## Step 2" "$skill_path" > /tmp/before-step2.txt && \
+       grep -A 100 "Step 1c" /tmp/before-step2.txt | grep -q "validate-subagent-return.sh"; then
+        pass "Step 1c validates the falsifier's own return"
+    else
+        fail "Step 1c validates the falsifier's own return" "validator call missing in Step 1c"
+    fi
+    rm -f /tmp/step1c.txt /tmp/before-step2.txt
+fi
+
+# ── Test 12: install.sh installs the falsifier prompt ────────────────
+install_sh="$REPO_ROOT/install.sh"
+if grep -q "prompts/feature-pr" "$install_sh"; then
+    pass "install.sh installs prompts/feature-pr/"
+else
+    fail "install.sh installs prompts/feature-pr/" "not installed"
+fi
+
+# ── Test 13: MANIFEST includes the falsifier prompt ──────────────────
+manifest="$REPO_ROOT/MANIFEST"
+if grep -q "prompts/feature-pr/central-invariant-falsify.md" "$manifest"; then
+    pass "MANIFEST includes central-invariant-falsify.md"
+else
+    fail "MANIFEST includes central-invariant-falsify.md" "missing entry"
+fi
+
+# ── Test 14: design doc enumerates rejected alternatives ─────────────
+if [[ -f "$design_path" ]]; then
+    if grep -q "Rejected alternatives" "$design_path"; then
+        pass "design doc enumerates rejected alternatives"
+    else
+        fail "design doc enumerates rejected alternatives" "section missing"
+    fi
+fi
+
+# ── Test 15: design doc enumerates open questions ────────────────────
+if [[ -f "$design_path" ]]; then
+    if grep -q "Open questions" "$design_path"; then
+        pass "design doc enumerates open questions"
+    else
+        fail "design doc enumerates open questions" "section missing"
+    fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "── Test summary ────────────────────────────────────────────────"
+echo "  Passed: $passed / $total"
+if [[ $failed -gt 0 ]]; then
+    echo "  Failed: $failed"
+    exit 1
+fi
+echo ""
+exit 0


### PR DESCRIPTION
## Summary

Implements the **central-invariant gate** (Finding 6 from the 2026-05 jlsm session report) — explicitly deferred from v0.21.0 PR #104 because no design existed. Also includes the **memory → KB migration design** (review-only, no implementation in this PR).

## What changed

### 1. Central-invariant gate — `/feature-pr` Step 1c

A per-WD adversarial falsifier subagent runs after the quality-bar gate (Step 1b) and before PR draft (Step 2). The falsifier:

- Identifies THE central invariant the WD/feature claims
- Traces the production code path (not internal SPI shortcuts)
- Constructs a falsifier scenario from 5 patterns: vacuous equivalence (R53), mocked-vs-live, end-to-end vs unit, verbal argument for measurement, phantom annotation
- Returns one of: ✓ HOLDS / ✗ FAILS / ? UNCLEAR with concrete evidence

`/feature-pr` proceeds only on ✓. ✗ and ? block PR draft and route to user via AskUserQuestion. Override paths exist for both — user is final authority.

What this catches that v0.21.0 didn't:
- Tests that pass for the wrong reason (R53 cross-family equivalence)
- Mock/live behavior divergence
- Assertions that hold via internal construction but not the public API
- Verbal arguments where measurements were required

The v0.21.0 validator catches *betrayal phrases* in returns. The central-invariant gate catches *shallow reasoning* — they're complementary defense in depth.

**Files:**
- `designs/central-invariant-gate.md` — full design (placement, inputs, output format, edge cases, 5 open questions, 5 rejected alternatives)
- `prompts/feature-pr/central-invariant-falsify.md` — falsifier subagent prompt
- `skills/feature-pr/SKILL.md` — Step 1c wiring with branching, skip detection, empty-diff handling, validator pass on falsifier return
- `MANIFEST` + `install.sh` — install plumbing
- `tests/test-central-invariant-gate.sh` — 24 structural checks

**Cost expectations:**
- Sonnet 4.6 (default): ~$0.05–$0.20 per dispatch
- Opus 4.7 (large diffs with 200K cap): up to ~$2 worst-case

**Skip path:** `central_invariant_gate: skip` in status.md for refactors / doc-only features with no meaningful central invariant. Empty-diff auto-skipped.

### 2. Memory → KB migration design (review-only)

`designs/memory-to-kb-migration.md` proposes how to migrate durable memory content into `.kb/` so dispatched subagents can find it.

Problem: dispatched subagents inherit project context (`rules/`, `.kb/`, `.decisions/`, CLAUDE.md) but NOT the user's `~/.claude/projects/<hash>/memory/`. 70+ accumulated memory entries with project tendencies and design principles are invisible to the subagents that would benefit most. Plus memory rots — we already shipped one superseded memory entry in v0.21.0.

Three handling rules:
- **Promote to KB**: feedback/project/reference types with durable project-applicable signal
- **Keep in memory**: user-profile, session-state, in-progress work tracking
- **Delete**: superseded entries, solved-problem observations

Migration via `/curate memory-promote` sub-mode (Option A from the design — Option B new skill and Option C /ideate hook were rejected with rationale). User-approved per-entry. Format mapping documented (memory frontmatter → KB frontmatter, body sections promoted to `##` headings, tags + applies_to user-supplied).

5 open questions, 4 rejected alternatives, 4-PR implementation sequence.

**No implementation in this PR** — design only. Implementation queued for a future release once design is approved.

## Test plan

- [x] `bash tests/test-central-invariant-gate.sh` — 24/24 pass
- [x] `bash tests/test-completeness-contract.sh` — 41/41 pass (no regression)
- [x] `bash tests/scenario-validate-subagent-return.sh` — 18/18 pass (no regression)
- [x] `bash tests/test-install.sh` — 74/74 pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)