### PR TITLE
feat: status:DEPRECATED contract + audit-trail-before-deletion (v0.23.0)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -88,6 +88,7 @@
 .claude/agents/breaker-agent.md
 .claude/agents/work-planner-agent.md
 .claude/rules/completeness-contract.md
+.claude/rules/deprecation-discipline.md
 .claude/rules/kb-architect.md
 .claude/rules/kb-protocol.md
 .claude/rules/kb-research-agent.md

--- a/designs/deprecated-state.md
+++ b/designs/deprecated-state.md
@@ -1,6 +1,6 @@
 # DEPRECATED spec state — pre-release deprecation discipline
 
-**Status:** proposed (revision 2) — 2026-05-17
+**Status:** approved (revision 3) — 2026-05-17 — implementation in flight
 **Originating signal:** jlsm session proposed a pre-release format-deprecation
 discipline that introduces a `DEPRECATED` state between `APPROVED` and
 `INVALIDATED`. Most of the proposal is jlsm-specific (Java annotations,
@@ -12,7 +12,34 @@ domain specifics stay in `.feature/project-config.md` so other languages
 (Rust, Python, Go, TS) and other artifact types (algorithms, protocols)
 can plug in.
 
-**Revision 2 changes** (after Nathan's review of revision 1):
+**Revision 3 changes** (after Nathan's second review):
+
+1. **The deprecation marker is `status: DEPRECATED`, not a new `state`
+   value.** Discovered while scoping implementation: vallorcine already
+   has a two-field model — `state` (DRAFT|APPROVED|INVALIDATED, the
+   verification dimension) and `status` (DRAFT|ACTIVE|STABLE|DEPRECATED,
+   the lifecycle dimension). `status: DEPRECATED` already exists in the
+   enum; `/curate` already flags `status: DEPRECATED` while still
+   `state: APPROVED` as a structural inconsistency. The natural fit is
+   to **legitimize that combination** as the marker, not to introduce a
+   parallel state value. The mental state machine
+   (DRAFT → APPROVED → DEPRECATED → INVALIDATED) is now expressed via
+   the `(state, status)` pair:
+   - `(state=DRAFT, status=DRAFT)` — authoring
+   - `(state=APPROVED, status=ACTIVE)` or `STABLE` — live
+   - `(state=APPROVED, status=DEPRECATED)` — load-bearing, alternative
+     exists (THE deprecated case)
+   - `(state=INVALIDATED, status=DEPRECATED)` — retired with audit trail
+
+2. **No age-based escalation.** Tier 2 WARNING fires only on
+   version-based and displaced_by-state triggers. The
+   `deprecation_age_threshold_days` field is removed — version is the
+   natural decay axis; age is redundant.
+
+3. **OQ2 resolved — loose coverage for v1.** Tag/domain/applies_to
+   overlap is the v1 default. Strict mode revisits later.
+
+**Revision 2 changes** (after Nathan's first review):
 1. `removal_scheduled_in` is now a **semver version string**, not a
    WD-ID. Removals and WDs aren't strictly related — a version is the
    natural deprecation cycle marker, and SemVer projects already think
@@ -134,62 +161,94 @@ alternative is real.
 
 ## Design
 
-### State machine
+### State machine (expressed via the existing `(state, status)` pair)
 
 ```
-DRAFT ──→ APPROVED ──→ DEPRECATED ──→ INVALIDATED
-                              │
-                              └──→ (resolves required_state: APPROVED)
-                                   resolver checks displaced_by;
-                                   may warn or stay silent based on
-                                   whether alternative covers the
-                                   dependent's domain
+(state=DRAFT,      status=DRAFT)          ──→ authoring
+       │
+       ▼
+(state=APPROVED,   status=ACTIVE|STABLE)  ──→ live, no successor
+       │
+       ▼ (mark deprecated — alternative exists)
+(state=APPROVED,   status=DEPRECATED)     ──→ load-bearing + has alternative
+       │                                        │
+       │                                        └──→ resolves required_state: APPROVED;
+       │                                             resolver checks displaced_by and version
+       │
+       ▼ (audit-trail-before-deletion contract)
+(state=INVALIDATED, status=DEPRECATED)    ──→ retired with audit trail
 ```
 
-| State | Meaning | Satisfies `required_state: APPROVED`? |
+| (state, status) | Meaning | Satisfies `required_state: APPROVED`? |
 |---|---|---|
-| `DRAFT` | Authoring in progress | No |
-| `APPROVED` | Settled and load-bearing, no successor | Yes |
-| `DEPRECATED` | Still load-bearing, but alternative exists — prefer alternative | **Yes** (resolver-aware) |
-| `INVALIDATED` | No longer in force, preserved for history | No |
+| `(DRAFT, DRAFT)` | Authoring in progress | No |
+| `(APPROVED, ACTIVE)` | Live, freshly approved | Yes |
+| `(APPROVED, STABLE)` | Live, settled, no expected churn | Yes |
+| `(APPROVED, DEPRECATED)` | Live, but alternative exists — prefer alternative | **Yes** (resolver-aware) |
+| `(INVALIDATED, *)` | No longer in force, preserved for history | No |
+
+The (state, status) split keeps the verification dimension (state) and
+lifecycle dimension (status) orthogonal, which is the existing
+vallorcine model. The DEPRECATED marker lives in `status` because it's
+a lifecycle event (succession), not a verification event (load-bearing-
+ness).
 
 **Transitions allowed:**
-- `DRAFT → APPROVED` (existing)
-- `DRAFT → INVALIDATED` (existing, for never-shipped specs)
-- `APPROVED → DEPRECATED` (new)
-- `DEPRECATED → INVALIDATED` (new, with audit-trail contract)
-- `APPROVED → INVALIDATED` (existing — direct retirement, no displacement)
+- `(DRAFT, DRAFT) → (APPROVED, ACTIVE)` (existing)
+- `(DRAFT, *) → (INVALIDATED, *)` (existing, for never-shipped specs)
+- `(APPROVED, ACTIVE|STABLE) → (APPROVED, DEPRECATED)` (**new — mark deprecated**)
+- `(APPROVED, DEPRECATED) → (INVALIDATED, DEPRECATED)` (**new — retire with audit trail**)
+- `(APPROVED, ACTIVE|STABLE) → (INVALIDATED, *)` (existing — direct retirement, no displacement)
 
 **Transitions disallowed:**
-- `DEPRECATED → APPROVED` (no rescind)
-- `DEPRECATED → DRAFT` (no rescind)
-- `INVALIDATED → anything` (terminal)
+- `(APPROVED, DEPRECATED) → (APPROVED, ACTIVE|STABLE)` — no rescind
+- `(APPROVED, DEPRECATED) → (DRAFT, *)` — no rescind
+- `(INVALIDATED, *) → anything` — terminal
 
 ### DEPRECATED frontmatter (validator-enforced)
 
-When `state: "DEPRECATED"`, these fields are REQUIRED:
+When `status: "DEPRECATED"`, these fields are REQUIRED:
 
 ```yaml
-state: "DEPRECATED"
-displaced_by: "<spec-id>"          # the spec that supersedes this one.
-                                   # MUST exist and be at state APPROVED.
-                                   # This is the "alternative" — the
-                                   # whole reason DEPRECATED exists.
-deprecation_reason: "..."          # one-line rationale. Often "superseded
-                                   # by <displaced_by>"; may add context.
+state: "APPROVED"                  # still load-bearing
+status: "DEPRECATED"               # the marker — alternative exists
+displaced_by: ["<spec-id>", ...]   # array of specs that supersede this
+                                   # one. MUST be non-empty. Each target
+                                   # MUST exist, be state:APPROVED, and
+                                   # NOT itself be status:DEPRECATED.
+                                   # (Field already exists; multi-displacement
+                                   # is already supported.)
+displacement_reason: "..."         # one-line rationale. Often "superseded
+                                   # by <displaced_by[0]>"; may add context.
+                                   # (Field already exists; promoted from
+                                   # WARNING to required-when-DEPRECATED.)
 removal_scheduled_in: "0.23.0"     # semver version string for the planned
                                    # removal. MUST be > current VERSION.
                                    # NOT tied to a specific WD — removals
                                    # may span multiple WDs or merge across
-                                   # versions.
-deprecation_date: "2026-05-17"     # ISO date when DEPRECATED state set.
-                                   # used for resolver context (e.g.,
-                                   # "deprecated 60 days ago") and
-                                   # /curate aging displays.
+                                   # versions. (New field.)
+deprecation_date: "2026-05-17"     # ISO date when status:DEPRECATED was
+                                   # set. Used for /curate aging displays.
+                                   # (New field.)
 ```
 
-The validator (`spec-validate.sh`) refuses a DEPRECATED spec missing
-any of these fields.
+**Field reuse note:** `displaced_by` and `displacement_reason` already
+exist in the spec frontmatter. Current convention: they're set at
+state:INVALIDATED time. The DEPRECATED-status work **extends** their
+use earlier in the lifecycle — they're now also set when status:DEPRECATED
+is applied at state:APPROVED. The fields carry forward from APPROVED+
+DEPRECATED to INVALIDATED+DEPRECATED naturally; no migration needed.
+
+The validator (`spec-validate.sh`) refuses a spec with `status: DEPRECATED`
+missing any of these fields.
+
+The spec MUST be `state: APPROVED` to take `status: DEPRECATED` — you
+cannot deprecate a DRAFT spec (deprecation means "load-bearing AND has
+alternative"; DRAFT means "not yet load-bearing"). A spec at
+`state: INVALIDATED` with `status: DEPRECATED` is the retired-with-
+audit-trail terminal — the required fields above no longer apply at
+that point (they were enforced during the APPROVED+DEPRECATED phase
+and may be preserved for history).
 
 **Why a version, not a WD-ID** (changed from revision 1):
 
@@ -249,10 +308,9 @@ When a WD's `artifact_deps` references a DEPRECATED spec X:
 
 **Tier 2 — WARNING:**
 - Current VERSION is at or one-minor-bump below `removal_scheduled_in`
-- OR `displaced_by` is not yet APPROVED (still DRAFT) — alternative
-  isn't ready yet, scheduling looks off
-- OR `deprecation_date` is more than `deprecation_age_threshold_days`
-  (default 90) old AND `displaced_by` has not been touched recently
+- OR `displaced_by` resolves to a spec NOT at `state: APPROVED`
+  (still DRAFT, or has been INVALIDATED) — alternative isn't ready
+  or has itself been retired, scheduling looks off
 - Output:
   ```
   [resolve] WARNING: WD <wd-id> depends on <spec-id> which is DEPRECATED
@@ -279,18 +337,10 @@ but the message is severity ERROR rather than ADVISORY, surfacing in
 **Coverage heuristic notes:**
 
 The "covers the dependent's needs" check is a heuristic, not a
-guarantee. The kit's default check uses tag/domain/applies_to overlap.
-Projects can override with a stricter check in
-`.feature/project-config.md`:
-
-```yaml
-displacement_coverage:
-  strict: true  # require explicit displaced_by → dependent mapping
-                # in the migration metadata, not just tag overlap
-```
-
-For v1, default to heuristic (tag/domain overlap). Strict mode is a
-future enhancement.
+guarantee. The kit's check uses tag/domain/applies_to overlap. This
+loose default is fine for v1 (Nathan-confirmed). A strict mode
+(explicit displaced_by → dependent mapping in migration metadata) is
+a future enhancement when real cases prove it's needed.
 
 ### Audit-trail-before-deletion contract (DEPRECATED → INVALIDATED)
 
@@ -467,16 +517,19 @@ directly with displacement_reason.
 
 ## Open questions
 
-**OQ1 — Default `deprecation_age_threshold_days`?** Proposing 90 as
-the default for Tier 2 warning escalation. Long enough that small
-projects don't trip warnings on every routine deprecation; short
-enough that aging deprecations surface within a quarter. User can
-override in project-config. Confirm 90 is the right starting point.
+**OQ1 — Default `deprecation_age_threshold_days`?** ~~Proposing 90 as
+the default for Tier 2 warning escalation.~~ **RESOLVED rev 3:** no
+age-based escalation. Version-based triggers (current VERSION
+approaching `removal_scheduled_in`; current VERSION reaching it) are
+sufficient. The `deprecation_age_threshold_days` field is removed
+entirely from the design. Age is redundant with version on a
+SemVer-tracking project.
 
-**OQ2 — Coverage heuristic for `displaced_by`.** Default v1 is
+**OQ2 — Coverage heuristic for `displaced_by`.** ~~Default v1 is
 tag/domain/applies_to overlap. Strict mode (explicit displaced_by →
-dependent mapping) is a future enhancement. Confirm the loose
-default is fine for v1.
+dependent mapping) is a future enhancement.~~ **RESOLVED rev 3:** loose
+(tag/domain/applies_to overlap) for v1. Strict mode revisits later if
+real cases emerge.
 
 **OQ3 — Should `removal_scheduled_in` allow a version *range*?**
 E.g., `removal_scheduled_in: "0.23.0..0.25.0"` meaning "any time
@@ -562,26 +615,28 @@ keeps the kit language-agnostic per `project_multi_language_intent.md`.
 This is a 5-PR sequence, each independently mergeable. Total ~3–5
 sessions depending on pace.
 
-**P1 — Spec state machine + validator basics** (~1 session)
-- Add `DEPRECATED` to the state enum in `scripts/spec-validate.sh`
-- Required-field validation: `displaced_by`, `deprecation_reason`,
-  `removal_scheduled_in`, `deprecation_date`
-- `displaced_by` resolution: spec must exist, be APPROVED, and not
-  be DEPRECATED itself (EC1, EC2, EC3)
+**P1 — Validator extensions for `status: DEPRECATED`** (~1 session)
+- Required-field validation when `status: DEPRECATED`: `displaced_by`,
+  `deprecation_reason`, `removal_scheduled_in`, `deprecation_date`
+- `displaced_by` resolution: spec must exist, be `state: APPROVED`,
+  and not itself be `status: DEPRECATED` (EC1, EC2, EC3)
 - `removal_scheduled_in` validation: well-formed semver, strictly
   greater than current VERSION (EC4)
-- Forbid `DEPRECATED → APPROVED` transition (no rescind)
-- Refuse `DEPRECATED` state on DRAFT spec (EC9)
-- Tests: `tests/scenario-deprecated-state-validate.sh`
+- Forbid `status: DEPRECATED` on a `state: DRAFT` spec (EC9 — can't
+  deprecate something not yet load-bearing)
+- Forbid `status: DEPRECATED → ACTIVE|STABLE` reverse transition (no
+  rescind) by tracking previous status via git or by adding a
+  monotonicity check
+- Tests: `tests/scenario-deprecated-status-validate.sh`
 
-**P2 — Resolver tiered warnings** (~1 session)
+**P2 — Resolver tiered messages** (~1 session)
 - Resolver emits Tier 0 SILENT when displaced_by covers + version far
 - Tier 1 ADVISORY when WD genuinely needs deprecated surface
-- Tier 2 WARNING when approaching `removal_scheduled_in` or
-  `displaced_by` is DRAFT or `deprecation_date` is over threshold
+- Tier 2 WARNING when approaching `removal_scheduled_in` OR
+  `displaced_by` is not `state: APPROVED`
 - Tier 3 ERROR when current VERSION >= `removal_scheduled_in`
-- Coverage heuristic (tag/domain/applies_to overlap)
-- `deprecation_age_threshold_days` configurable via project-config
+- Coverage heuristic (tag/domain/applies_to overlap) — loose default
+- No age-based escalation (per rev 3 — removed)
 - Tests: `tests/scenario-deprecated-resolver.sh`
 
 **P3 — Audit-trail-before-deletion contract (DEPRECATED → INVALIDATED)**

--- a/rules/deprecation-discipline.md
+++ b/rules/deprecation-discipline.md
@@ -1,0 +1,237 @@
+# Deprecation Discipline
+
+How vallorcine handles deprecation and removal of spec contracts in
+pre-release and released projects. Language-agnostic. Enforced by
+`spec-validate.sh` and `work_check_spec_dep` in `work-lib.sh`.
+
+See `designs/deprecated-state.md` for the design rationale and
+rejected alternatives.
+
+---
+
+## The state-status pair
+
+vallorcine specs carry two independent lifecycle fields:
+
+- **`state`** — verification dimension: `DRAFT | APPROVED | INVALIDATED`
+- **`status`** — lifecycle dimension: `DRAFT | ACTIVE | STABLE | DEPRECATED`
+
+The four common combinations:
+
+| `(state, status)` | Meaning |
+|---|---|
+| `(DRAFT, DRAFT)` | Authoring in progress |
+| `(APPROVED, ACTIVE)` | Live, recently approved |
+| `(APPROVED, STABLE)` | Live, settled, no expected churn |
+| `(APPROVED, DEPRECATED)` | **Still load-bearing, alternative exists** |
+| `(INVALIDATED, *)` | No longer in force; preserved for history |
+
+The mental state machine `DRAFT → APPROVED → DEPRECATED → INVALIDATED`
+is expressed via the `(state, status)` pair.
+
+---
+
+## What `status: DEPRECATED` means
+
+> "Still active, but alternatives exist — prefer the alternative."
+
+A `status: DEPRECATED` spec:
+
+- Still **satisfies** `required_state: APPROVED` dependencies (the
+  verification dimension is unchanged)
+- **Names a successor** (`displaced_by`) so consumers know where to
+  migrate
+- **Has a scheduled removal version** so the deprecation isn't
+  open-ended
+- **Is one-way** — no rescind back to ACTIVE/STABLE. Once you've
+  declared alternatives exist, that's a downstream-visible commitment.
+
+If you intended "this spec is being retired with no successor," use
+`state: INVALIDATED` directly (no audit-trail-before-deletion contract).
+
+---
+
+## Required fields when `status: DEPRECATED`
+
+Set on the deprecated spec's frontmatter (validator-enforced):
+
+```yaml
+state: "APPROVED"                  # still load-bearing
+status: "DEPRECATED"               # the marker
+displaced_by: ["<spec-id>", ...]   # non-empty; targets must exist
+                                   # and be state:APPROVED, not
+                                   # themselves status:DEPRECATED
+displacement_reason: "..."         # one-line rationale
+removal_scheduled_in: "0.23.0"     # valid semver, > current VERSION
+deprecation_date: "YYYY-MM-DD"     # ISO date the spec was deprecated
+```
+
+The validator refuses the deprecation if any of these is missing,
+malformed, or contradictory. See `tests/scenario-deprecated-status-validate.sh`
+for the full enforcement matrix.
+
+---
+
+## Resolver tier escalation
+
+When a WD's `artifact_deps` references a `status: DEPRECATED` spec,
+the resolver emits a tiered message on stderr:
+
+- **Tier 0 (SILENT)** — Spec is `APPROVED + ACTIVE/STABLE`. No
+  deprecation involvement. Nothing emitted.
+- **Tier 1 (ADVISORY)** — Spec is `DEPRECATED`. Removal version is
+  far away (>1 minor bump). Background awareness.
+- **Tier 2 (WARNING)** — Current VERSION is within 1 minor bump of
+  `removal_scheduled_in`, OR `displaced_by` target is not
+  `state: APPROVED`. Migration is needed soon.
+- **Tier 3 (ERROR)** — Current VERSION has reached or passed
+  `removal_scheduled_in`. The marker spec is overdue for INVALIDATION.
+
+All tiers leave the dep **SATISFIED** (rc=0). The resolver doesn't
+block in-flight work on deprecation alone — warnings raise awareness,
+not bars.
+
+---
+
+## Audit-trail-before-deletion contract
+
+When a spec transitions to `state: INVALIDATED` AND has non-empty
+`displaced_by`, the validator requires three artifacts before
+accepting the INVALIDATION:
+
+1. **`displacement_reason`** — one-line rationale (already a vallorcine
+   convention; promoted from WARN to ERROR when `displaced_by` is set).
+
+2. **`reproducer` frontmatter** — pointer to forensic recovery code:
+   ```yaml
+   reproducer:
+     type: "synthesizer"       # synthesizer | reference-impl | protocol-replay | other
+     path: "src/legacy/V5FileSynthesizer.java"
+     description: "v5 byte-stream synthesizer for forensic tests"
+   ```
+   The path must exist (relative to project root).
+
+3. **KB archaeology article** at `.kb/_legacy/<spec-id>.md` with
+   frontmatter:
+   ```yaml
+   ---
+   {
+     "type": "legacy-archaeology",
+     "spec_ref": "<spec-id>",
+     "removed_in": "<version>",
+     "removed_at": "YYYY-MM-DD"
+   }
+   ---
+   ```
+   Article body documents: what it was (byte layout / algorithm /
+   protocol), why it existed, why it was removed, how to reproduce.
+
+Specs invalidated **without** `displaced_by` (direct retirement of an
+unused contract, no successor) bypass this gate — the audit-trail
+captures what was lost when a successor exists; direct retirement
+needs no reproducer.
+
+---
+
+## Code-level marker (loose)
+
+The validator emits a WARNING (not block) when a `status: DEPRECATED +
+state: APPROVED` spec has `@spec` annotations in source files that
+don't contain a `deprecat*` substring. This catches the common case
+where the spec is marked DEPRECATED but the implementation forgot to
+add a code-level deprecation marker:
+
+- Java: `@Deprecated(forRemoval = true)`
+- Rust: `#[deprecated(since = "...", note = "...")]`
+- Python: `warnings.warn(DeprecationWarning(...))`
+- Go: `// Deprecated: ...`
+- TypeScript: `@deprecated <spec-id>`
+
+The check is intentionally loose — substring matching keeps it
+language-agnostic. Per-language strict patterns (with `.feature/project-config.md`
+declarations) are a future enhancement when real cases emerge.
+
+---
+
+## Transitions allowed and disallowed
+
+**Allowed:**
+- `(DRAFT, DRAFT) → (APPROVED, ACTIVE)`
+- `(DRAFT, *) → (INVALIDATED, *)` (never-shipped specs)
+- `(APPROVED, ACTIVE|STABLE) → (APPROVED, DEPRECATED)` — **mark deprecated**
+- `(APPROVED, DEPRECATED) → (INVALIDATED, DEPRECATED)` — **retire with audit trail**
+- `(APPROVED, ACTIVE|STABLE) → (INVALIDATED, *)` — **direct retire, no successor**
+
+**Disallowed (validator refuses):**
+- `(APPROVED, DEPRECATED) → (APPROVED, ACTIVE|STABLE)` — **no rescind**
+- `(APPROVED, DEPRECATED) → (DRAFT, *)` — no rescind
+- `(INVALIDATED, *) → anything` — terminal
+- `(DRAFT, *) → (*, DEPRECATED)` — can't deprecate a non-load-bearing spec
+
+The "no rescind" rule is intentional. Declaring "alternatives exist"
+is a downstream-visible commitment. If the alternative turns out
+insufficient, AMEND the alternative or write a third spec — don't
+un-deprecate. Discipline forces honest scheduling: only DEPRECATE
+when the alternative is real.
+
+---
+
+## Workflow
+
+To deprecate a spec:
+
+1. Verify the successor exists and is `state: APPROVED + status: ACTIVE/STABLE`.
+2. Edit the spec's frontmatter to set:
+   - `status: "DEPRECATED"`
+   - `displaced_by: ["<successor-id>"]`
+   - `displacement_reason: "..."`
+   - `removal_scheduled_in: "<future-version>"`
+   - `deprecation_date: "<today-ISO>"`
+3. Run `bash .claude/scripts/spec-validate.sh <spec-file>` to verify.
+4. Add a code-level marker to the implementation referencing the spec
+   (language-appropriate; see "Code-level marker" above).
+5. Commit and PR.
+
+To finalize removal (transition to INVALIDATED):
+
+1. Write the reproducer (synthesizer / reference-impl / protocol-replay)
+   in test-only code.
+2. Write the KB archaeology article at `.kb/_legacy/<spec-id>.md`.
+3. Edit the spec's frontmatter to set:
+   - `state: "INVALIDATED"`
+   - `reproducer: { type: "...", path: "...", description: "..." }`
+   - (keep `displaced_by` + `displacement_reason` from the deprecation)
+4. Delete the implementation code that the spec governed (the
+   reproducer remains as test-only).
+5. Run `bash .claude/scripts/spec-validate.sh <spec-file>` to verify
+   the audit-trail-before-deletion contract.
+6. Commit and PR.
+
+---
+
+## Why no rescind
+
+A deprecation marker is a downstream-visible commitment. Consumers
+start migrating; code markers go in; ADRs may cite the displacement.
+Un-deprecating that work erodes trust in the discipline.
+
+If your alternative turns out to be insufficient:
+- AMEND the alternative spec to cover the missing case, OR
+- Write a NEW spec that subsumes both the old and the alternative,
+  invalidating both.
+
+The old spec stays DEPRECATED. Its history is preserved honestly —
+"we tried to migrate to X, X had a gap, we fixed X" is a better
+audit trail than "we un-deprecated Y when X didn't work."
+
+---
+
+## Related rules and designs
+
+- `designs/deprecated-state.md` — design rationale, edge cases,
+  rejected alternatives
+- `rules/spec-annotation-protocol.md` — `@spec` annotation conventions
+  that drive the code-marker check
+- `rules/completeness-contract.md` — the audit-trail-before-deletion
+  contract is in the same family as the Scope-reconciliation contract
+  (both refuse-on-incompleteness)

--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -202,6 +202,108 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
     fi
   fi
 
+  # ── Check 7f: status:DEPRECATED requires the deprecation discipline contract
+  #
+  # When status:DEPRECATED is set, the spec is asserting "still load-bearing
+  # but alternative exists." That assertion requires:
+  #   - state:APPROVED (or state:INVALIDATED for the terminal phase — no
+  #     extra fields enforced there)
+  #   - non-empty displaced_by (the alternative)
+  #   - each displaced_by target is state:APPROVED and not status:DEPRECATED
+  #   - displacement_reason (the rationale)
+  #   - removal_scheduled_in (semver string, > current VERSION)
+  #   - deprecation_date (ISO date)
+  #
+  # See designs/deprecated-state.md and rules/deprecation-discipline.md.
+  if [[ "$STATUS" == "DEPRECATED" ]]; then
+
+    # 7f.1 — state must be APPROVED (load-bearing) or INVALIDATED (terminal)
+    if [[ "$STATE" != "APPROVED" && "$STATE" != "INVALIDATED" ]]; then
+      ERRORS+=("status:DEPRECATED requires state:APPROVED (load-bearing) or state:INVALIDATED (retired); got state:$STATE")
+    fi
+
+    # The required-fields contract applies during the APPROVED phase only.
+    # Once INVALIDATED, the fields were enforced previously and may have
+    # carried forward — they're informational, not gated.
+    if [[ "$STATE" == "APPROVED" ]]; then
+
+      # 7f.2 — displaced_by must be non-empty
+      if [[ "$DISPLACED_BY_COUNT" == "0" || "$DISPLACED_BY_COUNT" == "null" ]]; then
+        ERRORS+=("status:DEPRECATED requires non-empty displaced_by (the alternative spec — without one, this is just being retired, use state:INVALIDATED directly)")
+      else
+        # 7f.3 — each displaced_by target must be state:APPROVED and not
+        # status:DEPRECATED (chained deprecations create confusion)
+        if [[ -f "$MANIFEST" ]]; then
+          while IFS= read -r dby; do
+            [[ -z "$dby" ]] && continue
+            dby_file=$(spec_file_for_id "$MANIFEST" "$dby")
+            [[ -z "$dby_file" || ! -f "$dby_file" ]] && continue  # 7b already flagged
+            dby_state=$(fm "$dby_file" '.state // ""')
+            dby_status=$(fm "$dby_file" '.status // ""')
+            if [[ "$dby_state" != "APPROVED" ]]; then
+              ERRORS+=("displaced_by target '$dby' has state:$dby_state — must be state:APPROVED to displace a DEPRECATED spec (alternative must be live)")
+            fi
+            if [[ "$dby_status" == "DEPRECATED" ]]; then
+              ERRORS+=("displaced_by target '$dby' is itself status:DEPRECATED — chain deprecations create confusion; point directly to the live successor")
+            fi
+          done < <(fm "$FILE" '.displaced_by // [] | .[]')
+        fi
+      fi
+
+      # 7f.4 — displacement_reason required
+      DISP_REASON_NOW=$(fm "$FILE" '.displacement_reason // ""')
+      if [[ -z "$DISP_REASON_NOW" ]]; then
+        ERRORS+=("status:DEPRECATED requires displacement_reason (one-line rationale; often 'superseded by <displaced_by[0]>')")
+      fi
+
+      # 7f.5 — removal_scheduled_in required, semver, > current VERSION
+      RSI=$(fm "$FILE" '.removal_scheduled_in // ""')
+      if [[ -z "$RSI" ]]; then
+        ERRORS+=("status:DEPRECATED requires removal_scheduled_in (semver version string, e.g. '0.23.0', must be > current VERSION)")
+      else
+        # Semver pattern: X.Y.Z optionally followed by -prerelease or +build
+        semver_re='^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'
+        if ! [[ "$RSI" =~ $semver_re ]]; then
+          ERRORS+=("removal_scheduled_in '$RSI' is not a well-formed semver (expected X.Y.Z or X.Y.Z-suffix)")
+        elif [[ -f "$PROJECT_ROOT/VERSION" ]]; then
+          CUR_VERSION=$(cat "$PROJECT_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]')
+          if [[ -n "$CUR_VERSION" ]]; then
+            # Use sort -V for semver comparison; sort -uV with both values
+            # and check if RSI comes after CUR_VERSION. If equal, that's
+            # already "removal version reached" — disallow at marking time.
+            if [[ "$RSI" == "$CUR_VERSION" ]]; then
+              ERRORS+=("removal_scheduled_in '$RSI' equals current VERSION — must be strictly greater (schedule a future version)")
+            else
+              sorted=$(printf '%s\n%s\n' "$CUR_VERSION" "$RSI" | sort -V | head -1)
+              if [[ "$sorted" != "$CUR_VERSION" ]]; then
+                # current sorts AFTER scheduled — means scheduled is in the past
+                ERRORS+=("removal_scheduled_in '$RSI' is below current VERSION '$CUR_VERSION' — must be strictly greater")
+              fi
+            fi
+          fi
+        fi
+      fi
+
+      # 7f.6 — deprecation_date required, ISO format
+      DEP_DATE=$(fm "$FILE" '.deprecation_date // ""')
+      if [[ -z "$DEP_DATE" ]]; then
+        ERRORS+=("status:DEPRECATED requires deprecation_date (ISO date, e.g. '2026-05-17')")
+      elif ! [[ "$DEP_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+        ERRORS+=("deprecation_date '$DEP_DATE' is not a valid ISO date (expected YYYY-MM-DD)")
+      fi
+    fi
+  fi
+
+  # ── Check 7g: status:DEPRECATED cannot apply to a state:DRAFT spec
+  #
+  # Deprecation means "load-bearing AND has alternative." A DRAFT spec
+  # isn't load-bearing yet, so it can't be deprecated. If you no longer
+  # want a DRAFT spec, delete it or transition DRAFT → INVALIDATED
+  # directly with displacement_reason.
+  if [[ "$STATUS" == "DEPRECATED" && "$STATE" == "DRAFT" ]]; then
+    ERRORS+=("status:DEPRECATED on a state:DRAFT spec is not allowed — deprecation requires the spec to have been load-bearing (state:APPROVED) at some point")
+  fi
+
   # ── Check 8: decision_refs resolve (warning, not error)
   while IFS= read -r ref; do
     [[ -z "$ref" ]] && continue

--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -304,6 +304,104 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
     ERRORS+=("status:DEPRECATED on a state:DRAFT spec is not allowed — deprecation requires the spec to have been load-bearing (state:APPROVED) at some point")
   fi
 
+  # ── Check 7i: code-marker presence for status:DEPRECATED + state:APPROVED
+  #
+  # Code carrying behavior governed by a DEPRECATED spec SHOULD have a
+  # code-level deprecation marker (Java @Deprecated, Rust #[deprecated],
+  # Python warnings.warn, Go // Deprecated:, TS @deprecated, etc.).
+  #
+  # The kit performs a loose grep-based check: for each @spec annotation
+  # referencing this spec in the codebase, check whether the same file
+  # contains "deprecat" (case-insensitive substring covering all common
+  # language conventions). Emit WARNING per file lacking the marker —
+  # NEVER block the validation.
+  #
+  # This is intentionally loose. Per-language strict checks are out of
+  # scope for v1 — a future enhancement reads .feature/project-config.md
+  # for per-language patterns. The substring "deprecat" catches the
+  # 5 common languages cheaply.
+  #
+  # Skipped when:
+  #   - $PROJECT_ROOT/.git doesn't exist (test/sandbox environments)
+  #   - the spec is not status:DEPRECATED + state:APPROVED (terminal
+  #     phase doesn't care about markers anymore)
+  if [[ "$STATUS" == "DEPRECATED" && "$STATE" == "APPROVED" ]]; then
+    SELF_ID_CM=$(fm "$FILE" '.id // ""')
+    if [[ -n "$SELF_ID_CM" && -d "$PROJECT_ROOT/.git" ]]; then
+      # Find files annotated with @spec <SELF_ID_CM> (with or without R-clause).
+      # Use git grep for speed; fall back to grep -r if not a git repo.
+      annotation_re="@spec[[:space:]]+${SELF_ID_CM//./\\.}"
+      annotated_files=$(cd "$PROJECT_ROOT" && git grep -l -E "$annotation_re" 2>/dev/null || true)
+      if [[ -n "$annotated_files" ]]; then
+        while IFS= read -r afile; do
+          [[ -z "$afile" ]] && continue
+          [[ "$afile" == *"$FILE"* ]] && continue  # skip the spec file itself
+          # Check for any case-insensitive substring of "deprecat" in the file
+          if ! grep -qi "deprecat" "$PROJECT_ROOT/$afile" 2>/dev/null; then
+            echo "  WARN: code file '$afile' carries @spec $SELF_ID_CM annotation but no deprecation marker (no 'deprecat*' substring found) — consider adding language-appropriate marker (Java @Deprecated, Rust #[deprecated], Python warnings.warn, Go // Deprecated:, TS @deprecated)" >&2
+          fi
+        done <<< "$annotated_files"
+      fi
+    fi
+  fi
+
+  # ── Check 7h: audit-trail-before-deletion contract
+  #
+  # When state:INVALIDATED AND displaced_by is non-empty, the spec has
+  # been retired with a successor. The kit requires three artifacts to
+  # land alongside this transition so the removed work is forensically
+  # recoverable:
+  #   1. displacement_reason (already enforced via 7e warning; promoted
+  #      to ERROR here when displaced_by is non-empty AND state:INVALIDATED)
+  #   2. reproducer frontmatter — type + path; path must exist
+  #   3. KB archaeology article at .kb/_legacy/<spec-id>.md
+  #
+  # Specs invalidated WITHOUT displacement (direct retire, no successor)
+  # bypass this check — the audit-trail captures what was lost when a
+  # successor exists; direct retirement of an unused contract doesn't
+  # need a reproducer.
+  #
+  # See designs/deprecated-state.md §"Audit-trail-before-deletion contract".
+  if [[ "$STATE" == "INVALIDATED" \
+        && "$DISPLACED_BY_COUNT" != "0" \
+        && "$DISPLACED_BY_COUNT" != "null" ]]; then
+
+    # 7h.1 — displacement_reason required (promote 7e warning to error)
+    DISP_REASON_INV=$(fm "$FILE" '.displacement_reason // ""')
+    if [[ -z "$DISP_REASON_INV" ]]; then
+      ERRORS+=("INVALIDATED spec with displaced_by requires displacement_reason (audit-trail-before-deletion contract)")
+    fi
+
+    # 7h.2 — reproducer frontmatter (type + path)
+    REPRO_TYPE=$(fm "$FILE" '.reproducer.type // ""')
+    REPRO_PATH=$(fm "$FILE" '.reproducer.path // ""')
+    if [[ -z "$REPRO_TYPE" || -z "$REPRO_PATH" ]]; then
+      ERRORS+=("INVALIDATED spec with displaced_by requires reproducer frontmatter (type + path) — see audit-trail-before-deletion contract")
+    elif [[ ! -e "$PROJECT_ROOT/$REPRO_PATH" ]]; then
+      ERRORS+=("reproducer path does not exist: $REPRO_PATH (relative to project root)")
+    fi
+
+    # 7h.3 — KB archaeology article at .kb/_legacy/<spec-id>.md
+    SELF_ID=$(fm "$FILE" '.id // ""')
+    if [[ -n "$SELF_ID" ]]; then
+      # Default path: .kb/_legacy/<spec-id>.md (dot-separated ID kept as-is)
+      KB_LEGACY_PATH="$PROJECT_ROOT/.kb/_legacy/${SELF_ID}.md"
+      if [[ ! -f "$KB_LEGACY_PATH" ]]; then
+        ERRORS+=("missing KB archaeology article: .kb/_legacy/${SELF_ID}.md (audit-trail-before-deletion contract requires forensic record of removed contracts)")
+      else
+        # 7h.4 — KB article frontmatter sanity check
+        KB_TYPE=$(fm "$KB_LEGACY_PATH" '.type // ""')
+        KB_SPEC_REF=$(fm "$KB_LEGACY_PATH" '.spec_ref // ""')
+        if [[ "$KB_TYPE" != "legacy-archaeology" ]]; then
+          ERRORS+=("KB article $KB_LEGACY_PATH missing type:legacy-archaeology (got '$KB_TYPE')")
+        fi
+        if [[ "$KB_SPEC_REF" != "$SELF_ID" ]]; then
+          ERRORS+=("KB article $KB_LEGACY_PATH spec_ref ('$KB_SPEC_REF') does not match this spec's ID ('$SELF_ID')")
+        fi
+      fi
+    fi
+  fi
+
   # ── Check 8: decision_refs resolve (warning, not error)
   while IFS= read -r ref; do
     [[ -z "$ref" ]] && continue

--- a/scripts/work-lib.sh
+++ b/scripts/work-lib.sh
@@ -381,7 +381,118 @@ work_check_spec_dep() {
     return 1
   fi
 
+  # ── Deprecation discipline (rules/deprecation-discipline.md) ──────────────
+  # If the resolved spec has status:DEPRECATED, the dep is still SATISFIED
+  # (state:APPROVED is the load-bearing dimension), but emit a tiered
+  # message on stderr so callers / users can act on the upcoming removal.
+  #
+  # Tiers (severity ascending — version-based only; no age threshold):
+  #   Tier 0 SILENT  — displaced_by covers and removal version is far away
+  #   Tier 1 ADVISORY — uses the deprecated surface; removal not yet imminent
+  #   Tier 2 WARNING — current VERSION is approaching removal_scheduled_in,
+  #                    OR displaced_by target is not state:APPROVED
+  #   Tier 3 ERROR   — current VERSION >= removal_scheduled_in (overdue)
+  #
+  # All tiers leave the dep SATISFIED (return 0). The resolver doesn't block
+  # in-flight work on deprecation alone; warnings raise awareness.
+  local found_status
+  found_status=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$found_file" \
+    | jq -r '.status // ""' 2>/dev/null || true)
+  if [[ "$found_status" == "DEPRECATED" && "$found_state" == "APPROVED" ]]; then
+    work_emit_deprecation_message "$project_root" "$found_file" "$spec_path" >&2
+  fi
+
   return 0
+}
+
+# ── Emit a tiered deprecation message for a DEPRECATED spec ──────────────────
+# Inputs:
+#   $1  project_root  — needed for VERSION lookup
+#   $2  spec_file     — the resolved DEPRECATED spec
+#   $3  spec_path     — the human-readable reference the caller used
+#
+# Writes one line to stdout in the format:
+#   [deprecation:TIER] <message>
+# where TIER ∈ {SILENT, ADVISORY, WARNING, ERROR}. SILENT writes nothing.
+#
+# The caller redirects to stderr or wherever the message should surface.
+# See designs/deprecated-state.md §"Resolver behavior".
+work_emit_deprecation_message() {
+  local project_root="$1"
+  local spec_file="$2"
+  local spec_path="$3"
+
+  # Read the DEPRECATED spec's frontmatter fields
+  local rsi displaced_by_count displaced_first
+  rsi=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$spec_file" \
+    | jq -r '.removal_scheduled_in // ""' 2>/dev/null || echo "")
+  displaced_by_count=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$spec_file" \
+    | jq -r '(.displaced_by // []) | length' 2>/dev/null || echo "0")
+  displaced_first=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$spec_file" \
+    | jq -r '(.displaced_by // [""])[0]' 2>/dev/null || echo "")
+
+  # Read current VERSION (graceful fallback if missing)
+  local cur_version=""
+  if [[ -f "$project_root/VERSION" ]]; then
+    cur_version=$(cat "$project_root/VERSION" 2>/dev/null | tr -d '[:space:]')
+  fi
+
+  # Tier 3 ERROR — current VERSION >= removal_scheduled_in
+  if [[ -n "$cur_version" && -n "$rsi" ]]; then
+    if [[ "$cur_version" == "$rsi" ]]; then
+      printf '[deprecation:ERROR] spec %s is DEPRECATED and the scheduled removal version (%s) has been reached (current %s) — overdue for INVALIDATION\n' \
+        "$spec_path" "$rsi" "$cur_version"
+      return 0
+    fi
+    # If cur_version > rsi (rsi sorts before cur_version when ascending)
+    local first_sort
+    first_sort=$(printf '%s\n%s\n' "$cur_version" "$rsi" | sort -V | head -1)
+    if [[ "$first_sort" == "$rsi" ]]; then
+      printf '[deprecation:ERROR] spec %s is DEPRECATED and the scheduled removal version (%s) has been passed (current %s) — overdue for INVALIDATION\n' \
+        "$spec_path" "$rsi" "$cur_version"
+      return 0
+    fi
+  fi
+
+  # Check displaced_by target state — Tier 2 if alternative isn't APPROVED
+  local manifest="$project_root/.spec/registry/manifest.json"
+  local displaced_state="UNKNOWN"
+  if [[ -n "$displaced_first" && -f "$manifest" ]]; then
+    local dby_file
+    dby_file=$(spec_file_for_id "$manifest" "$displaced_first")
+    if [[ -n "$dby_file" && -f "$dby_file" ]]; then
+      displaced_state=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$dby_file" \
+        | jq -r '.state // ""' 2>/dev/null || echo "UNKNOWN")
+    fi
+  fi
+
+  if [[ "$displaced_state" != "APPROVED" ]]; then
+    printf '[deprecation:WARNING] spec %s is DEPRECATED but its displaced_by target (%s) is %s — alternative is not state:APPROVED; scheduling looks off\n' \
+      "$spec_path" "$displaced_first" "$displaced_state"
+    return 0
+  fi
+
+  # Approaching-removal heuristic — Tier 2 when current VERSION's
+  # minor is one below rsi's minor (rough "within a minor bump").
+  if [[ -n "$cur_version" && -n "$rsi" ]]; then
+    local cur_major cur_minor rsi_major rsi_minor
+    cur_major=$(printf '%s' "$cur_version" | cut -d. -f1)
+    cur_minor=$(printf '%s' "$cur_version" | cut -d. -f2)
+    rsi_major=$(printf '%s' "$rsi" | cut -d. -f1)
+    rsi_minor=$(printf '%s' "$rsi" | cut -d. -f2)
+    if [[ "$cur_major" == "$rsi_major" ]]; then
+      local minor_gap=$(( rsi_minor - cur_minor ))
+      if (( minor_gap <= 1 )) && (( minor_gap >= 0 )); then
+        printf '[deprecation:WARNING] spec %s is DEPRECATED and approaching removal in %s (current %s) — migrate to %s before %s\n' \
+          "$spec_path" "$rsi" "$cur_version" "$displaced_first" "$rsi"
+        return 0
+      fi
+    fi
+  fi
+
+  # Default — Tier 1 ADVISORY (deprecated, alternative ready, removal not imminent)
+  printf '[deprecation:ADVISORY] spec %s is DEPRECATED (superseded by %s; scheduled removal in %s; current %s)\n' \
+    "$spec_path" "${displaced_first:-<none>}" "${rsi:-<unset>}" "${cur_version:-<unset>}"
 }
 
 # ── Check if an ADR artifact exists and is in required status ────────────────

--- a/tests/scenario-deprecated-resolver.sh
+++ b/tests/scenario-deprecated-resolver.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Scenario: work_check_spec_dep emits tiered deprecation messages
+#
+# Validates that the resolver helper correctly:
+# - Emits [deprecation:ADVISORY] when removal version is far away
+# - Emits [deprecation:WARNING] when displaced_by target is not APPROVED
+# - Emits [deprecation:WARNING] when removal version is within one minor bump
+# - Emits [deprecation:ERROR] when current VERSION >= removal_scheduled_in
+# - Returns 0 (SATISFIED) for all DEPRECATED cases — dep doesn't fail
+# - Emits nothing when the spec is APPROVED + ACTIVE (no deprecation)
+# - Falls back gracefully when VERSION file is missing
+#
+# Run from repo root: bash tests/scenario-deprecated-resolver.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-deprecated-resolver"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE"
+}
+trap cleanup EXIT
+mkdir -p "$TEST_BASE"
+
+echo ""
+echo "── Scenario: tiered deprecation messages from resolver ──────────"
+echo ""
+
+# Helper to invoke work_check_spec_dep in a subshell that sources work-lib.sh
+run_check() {
+    local pdir="$1"
+    local spec_id="$2"
+    local required_state="${3:-APPROVED}"
+    (
+        cd "$pdir"
+        # shellcheck disable=SC1091
+        source "$REPO_ROOT/scripts/work-lib.sh"
+        work_check_spec_dep "$pdir" "$spec_id" "$required_state"
+    )
+}
+
+# Project skeleton: VERSION + manifest with the two specs (deprecated + successor)
+setup_project() {
+    local pdir="$1"
+    local version="$2"
+    local removal_in="$3"
+    local successor_state="$4"   # APPROVED | DRAFT
+    local successor_status="$5"  # ACTIVE | DEPRECATED
+
+    rm -rf "$pdir"
+    mkdir -p "$pdir/.spec/domains/example" "$pdir/.spec/registry"
+    echo "$version" > "$pdir/VERSION"
+
+    # Successor spec
+    cat > "$pdir/.spec/domains/example/successor.md" <<EOF
+---
+{
+  "id": "example.successor",
+  "version": 1,
+  "status": "$successor_status",
+  "state": "$successor_state",
+  "domains": ["example"]
+}
+---
+
+# example.successor — Replacement
+
+## Requirements
+R1. Successor does the thing.
+
+---
+
+## Design Narrative
+Body.
+EOF
+
+    # The deprecated spec
+    cat > "$pdir/.spec/domains/example/legacy.md" <<EOF
+---
+{
+  "id": "example.legacy",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded by example.successor",
+  "removal_scheduled_in": "$removal_in",
+  "deprecation_date": "2026-05-17"
+}
+---
+
+# example.legacy — Old way
+
+## Requirements
+R1. Legacy does the thing.
+
+---
+
+## Design Narrative
+Body.
+EOF
+
+    cat > "$pdir/.spec/registry/manifest.json" <<EOF
+{
+  "version": 1,
+  "specs": {
+    "example.successor": {
+      "id": "example.successor",
+      "path": ".spec/domains/example/successor.md",
+      "state": "$successor_state",
+      "status": "$successor_status"
+    },
+    "example.legacy": {
+      "id": "example.legacy",
+      "path": ".spec/domains/example/legacy.md",
+      "state": "APPROVED",
+      "status": "DEPRECATED"
+    }
+  }
+}
+EOF
+}
+
+# ── Test 1: ADVISORY when removal is far away (0.10.0 → 1.0.0) ────────────
+P1="$TEST_BASE/p1"
+setup_project "$P1" "0.10.0" "1.0.0" "APPROVED" "ACTIVE"
+rc=0
+out=$(run_check "$P1" "example.legacy" APPROVED 2>&1) || rc=$?
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '\[deprecation:ADVISORY\]'; then
+    pass "Tier 1 ADVISORY when removal far away"
+else
+    fail "Tier 1 ADVISORY when removal far away" "rc=$rc; out=$out"
+fi
+
+# ── Test 2: WARNING when current minor is 1 below removal (0.21.0 → 0.22.0) ────
+P2="$TEST_BASE/p2"
+setup_project "$P2" "0.21.0" "0.22.0" "APPROVED" "ACTIVE"
+rc=0
+out=$(run_check "$P2" "example.legacy" APPROVED 2>&1) || rc=$?
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '\[deprecation:WARNING\]'; then
+    pass "Tier 2 WARNING when removal within one minor"
+else
+    fail "Tier 2 WARNING when removal within one minor" "rc=$rc; out=$out"
+fi
+
+# ── Test 3: WARNING when displaced_by target is DRAFT (0.10.0 → 1.0.0) ─────
+P3="$TEST_BASE/p3"
+setup_project "$P3" "0.10.0" "1.0.0" "DRAFT" "DRAFT"
+rc=0
+out=$(run_check "$P3" "example.legacy" APPROVED 2>&1) || rc=$?
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '\[deprecation:WARNING\].*not state:APPROVED'; then
+    pass "Tier 2 WARNING when displaced_by target not APPROVED"
+else
+    fail "Tier 2 WARNING when displaced_by target not APPROVED" "rc=$rc; out=$out"
+fi
+
+# ── Test 4: ERROR when current VERSION equals removal version (0.22.0 == 0.22.0) ─
+P4="$TEST_BASE/p4"
+setup_project "$P4" "0.22.0" "0.22.0" "APPROVED" "ACTIVE"
+rc=0
+out=$(run_check "$P4" "example.legacy" APPROVED 2>&1) || rc=$?
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '\[deprecation:ERROR\].*has been reached'; then
+    pass "Tier 3 ERROR when current VERSION equals removal"
+else
+    fail "Tier 3 ERROR when current VERSION equals removal" "rc=$rc; out=$out"
+fi
+
+# ── Test 5: ERROR when current VERSION exceeds removal (0.23.0 > 0.22.0) ────
+P5="$TEST_BASE/p5"
+setup_project "$P5" "0.23.0" "0.22.0" "APPROVED" "ACTIVE"
+rc=0
+out=$(run_check "$P5" "example.legacy" APPROVED 2>&1) || rc=$?
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '\[deprecation:ERROR\].*has been passed'; then
+    pass "Tier 3 ERROR when current VERSION exceeds removal"
+else
+    fail "Tier 3 ERROR when current VERSION exceeds removal" "rc=$rc; out=$out"
+fi
+
+# ── Test 6: SILENT when checking the successor itself (not DEPRECATED) ──────
+P6="$TEST_BASE/p6"
+setup_project "$P6" "0.10.0" "1.0.0" "APPROVED" "ACTIVE"
+rc=0
+out=$(run_check "$P6" "example.successor" APPROVED 2>&1) || rc=$?
+if [[ $rc -eq 0 ]] && ! echo "$out" | grep -q '\[deprecation:'; then
+    pass "no message when spec is APPROVED + ACTIVE"
+else
+    fail "no message when spec is APPROVED + ACTIVE" "rc=$rc; out=$out"
+fi
+
+# ── Test 7: dep stays SATISFIED (rc=0) for all DEPRECATED cases ─────────────
+# Already verified in tests 1-5 (rc check is part of each PASS), but explicit:
+P7="$TEST_BASE/p7"
+setup_project "$P7" "0.21.0" "0.22.0" "APPROVED" "ACTIVE"
+rc=0
+run_check "$P7" "example.legacy" APPROVED >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "DEPRECATED spec still SATISFIES dep (rc=0)"
+else
+    fail "DEPRECATED spec still SATISFIES dep (rc=0)" "rc=$rc"
+fi
+
+# ── Test 8: graceful fallback when VERSION file is missing ──────────────────
+P8="$TEST_BASE/p8"
+setup_project "$P8" "0.10.0" "1.0.0" "APPROVED" "ACTIVE"
+rm "$P8/VERSION"
+rc=0
+out=$(run_check "$P8" "example.legacy" APPROVED 2>&1) || rc=$?
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '\[deprecation:'; then
+    pass "graceful fallback when VERSION file missing (still emits a tier)"
+else
+    fail "graceful fallback when VERSION file missing (still emits a tier)" "rc=$rc; out=$out"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "── Scenario summary ───────────────────────────────────────────"
+echo "  Passed: $passed / $total"
+if [[ $failed -gt 0 ]]; then
+    echo "  Failed: $failed"
+    exit 1
+fi
+echo ""
+exit 0

--- a/tests/scenario-deprecated-status-validate.sh
+++ b/tests/scenario-deprecated-status-validate.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+# Scenario: spec-validate.sh enforces the DEPRECATED-status contract
+#
+# Validates that scripts/spec-validate.sh correctly:
+# - Refuses status:DEPRECATED without displaced_by
+# - Refuses status:DEPRECATED without displacement_reason
+# - Refuses status:DEPRECATED without removal_scheduled_in
+# - Refuses status:DEPRECATED with malformed removal_scheduled_in
+# - Refuses status:DEPRECATED with removal_scheduled_in <= current VERSION
+# - Refuses status:DEPRECATED without deprecation_date
+# - Refuses status:DEPRECATED with malformed deprecation_date
+# - Refuses status:DEPRECATED on a state:DRAFT spec
+# - Refuses status:DEPRECATED when displaced_by target is state:DRAFT
+# - Refuses status:DEPRECATED when displaced_by target is itself status:DEPRECATED
+# - Accepts a properly-formed status:DEPRECATED spec
+# - Allows status:DEPRECATED on state:INVALIDATED (terminal phase, no required fields)
+#
+# Run from repo root: bash tests/scenario-deprecated-status-validate.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+TEST_BASE="/tmp/vallorcine/scenario-deprecated-status-validate"
+VALIDATOR="$REPO_ROOT/scripts/spec-validate.sh"
+
+passed=0
+failed=0
+total=0
+
+pass() {
+    ((passed++)) || true
+    ((total++)) || true
+    echo "  PASS  $1"
+}
+
+fail() {
+    ((failed++)) || true
+    ((total++)) || true
+    echo "  FAIL  $1"
+    [[ -n "${2:-}" ]] && echo "        $2"
+}
+
+cleanup() {
+    rm -rf "$TEST_BASE"
+}
+trap cleanup EXIT
+mkdir -p "$TEST_BASE"
+
+echo ""
+echo "── Scenario: status:DEPRECATED validator contract ──────────────"
+echo ""
+
+# Set up a minimal project skeleton
+setup_project() {
+    local pdir="$1"
+    rm -rf "$pdir"
+    mkdir -p "$pdir/.spec/domains/example" "$pdir/.spec/registry"
+    echo "0.21.0" > "$pdir/VERSION"
+
+    # The displacing spec (alternative — must be APPROVED + not DEPRECATED)
+    cat > "$pdir/.spec/domains/example/successor.md" <<'EOF'
+---
+{
+  "id": "example.successor",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "APPROVED",
+  "domains": ["example"]
+}
+---
+
+# example.successor — The replacement
+
+## Requirements
+R1. The successor MUST do the thing.
+
+---
+
+## Design Narrative
+This is the replacement spec.
+EOF
+
+    # Build a minimal registry that resolves IDs to files
+    cat > "$pdir/.spec/registry/manifest.json" <<EOF
+{
+  "version": 1,
+  "specs": {
+    "example.successor": {
+      "id": "example.successor",
+      "path": ".spec/domains/example/successor.md",
+      "state": "APPROVED",
+      "status": "ACTIVE"
+    }
+  }
+}
+EOF
+}
+
+# Write a spec under test inside the project
+write_spec() {
+    local pdir="$1"
+    local frontmatter="$2"
+    cat > "$pdir/.spec/domains/example/under_test.md" <<EOF
+---
+$frontmatter
+---
+
+# example.under-test — Title
+
+## Requirements
+R1. The thing must happen.
+
+---
+
+## Design Narrative
+Body content.
+EOF
+}
+
+run_validate() {
+    local pdir="$1"
+    local file="$pdir/.spec/domains/example/under_test.md"
+    (cd "$pdir" && bash "$VALIDATOR" "$file" 2>&1)
+}
+
+PROJECT="$TEST_BASE/project"
+
+# ── Test 1: missing displaced_by → fail ─────────────────────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "0.22.0",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "requires non-empty displaced_by"; then
+    pass "missing displaced_by is flagged"
+else
+    fail "missing displaced_by is flagged" "$out"
+fi
+
+# ── Test 2: missing displacement_reason → fail ─────────────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "removal_scheduled_in": "0.22.0",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "requires displacement_reason"; then
+    pass "missing displacement_reason is flagged"
+else
+    fail "missing displacement_reason is flagged" "$out"
+fi
+
+# ── Test 3: missing removal_scheduled_in → fail ─────────────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "requires removal_scheduled_in"; then
+    pass "missing removal_scheduled_in is flagged"
+else
+    fail "missing removal_scheduled_in is flagged" "$out"
+fi
+
+# ── Test 4: malformed removal_scheduled_in → fail ───────────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "soon",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "not a well-formed semver"; then
+    pass "malformed removal_scheduled_in is flagged"
+else
+    fail "malformed removal_scheduled_in is flagged" "$out"
+fi
+
+# ── Test 5: removal_scheduled_in below current VERSION → fail ───────────
+setup_project "$PROJECT"  # VERSION = 0.21.0
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "0.10.0",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "below current VERSION"; then
+    pass "removal_scheduled_in below current VERSION is flagged"
+else
+    fail "removal_scheduled_in below current VERSION is flagged" "$out"
+fi
+
+# ── Test 6: removal_scheduled_in equals current VERSION → fail ──────────
+setup_project "$PROJECT"  # VERSION = 0.21.0
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "0.21.0",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "equals current VERSION"; then
+    pass "removal_scheduled_in equals current VERSION is flagged"
+else
+    fail "removal_scheduled_in equals current VERSION is flagged" "$out"
+fi
+
+# ── Test 7: missing deprecation_date → fail ─────────────────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "0.22.0"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "requires deprecation_date"; then
+    pass "missing deprecation_date is flagged"
+else
+    fail "missing deprecation_date is flagged" "$out"
+fi
+
+# ── Test 8: malformed deprecation_date → fail ───────────────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "0.22.0",
+  "deprecation_date": "May 17 2026"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "not a valid ISO date"; then
+    pass "malformed deprecation_date is flagged"
+else
+    fail "malformed deprecation_date is flagged" "$out"
+fi
+
+# ── Test 9: status:DEPRECATED on state:DRAFT → fail ─────────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "DRAFT",
+  "domains": ["example"]
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "DEPRECATED on a state:DRAFT spec is not allowed"; then
+    pass "status:DEPRECATED on state:DRAFT is refused"
+else
+    fail "status:DEPRECATED on state:DRAFT is refused" "$out"
+fi
+
+# ── Test 10: displaced_by target is state:DRAFT → fail ──────────────────
+setup_project "$PROJECT"
+# Mutate the successor to be DRAFT
+sed -i.bak 's/"state": "APPROVED"/"state": "DRAFT"/' "$PROJECT/.spec/domains/example/successor.md"
+sed -i.bak 's/"state": "APPROVED"/"state": "DRAFT"/' "$PROJECT/.spec/registry/manifest.json"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "0.22.0",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "must be state:APPROVED to displace"; then
+    pass "displaced_by target state:DRAFT is flagged"
+else
+    fail "displaced_by target state:DRAFT is flagged" "$out"
+fi
+
+# ── Test 11: displaced_by target itself status:DEPRECATED → fail ────────
+setup_project "$PROJECT"
+sed -i.bak 's/"status": "ACTIVE"/"status": "DEPRECATED"/' "$PROJECT/.spec/domains/example/successor.md"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded",
+  "removal_scheduled_in": "0.22.0",
+  "deprecation_date": "2026-05-17"
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "chain deprecations create confusion"; then
+    pass "displaced_by target status:DEPRECATED is flagged"
+else
+    fail "displaced_by target status:DEPRECATED is flagged" "$out"
+fi
+
+# ── Test 12: properly-formed status:DEPRECATED → pass ───────────────────
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "APPROVED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "superseded by example.successor",
+  "removal_scheduled_in": "0.22.0",
+  "deprecation_date": "2026-05-17"
+}'
+rc=0
+out=$(run_validate "$PROJECT" 2>&1) || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "well-formed status:DEPRECATED spec validates clean"
+else
+    fail "well-formed status:DEPRECATED spec validates clean" "rc=$rc; out=$out"
+fi
+
+# ── Test 13: status:DEPRECATED + state:INVALIDATED (terminal) → pass ────
+# In the terminal phase, the required fields are not re-checked (they
+# were enforced earlier). Spec just needs to be otherwise valid.
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "INVALIDATED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "retired after migration"
+}'
+rc=0
+out=$(run_validate "$PROJECT" 2>&1) || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "status:DEPRECATED + state:INVALIDATED (terminal) validates clean"
+else
+    fail "status:DEPRECATED + state:INVALIDATED (terminal) validates clean" "rc=$rc; out=$out"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "── Scenario summary ────────────────────────────────────────────"
+echo "  Passed: $passed / $total"
+if [[ $failed -gt 0 ]]; then
+    echo "  Failed: $failed"
+    exit 1
+fi
+echo ""
+exit 0

--- a/tests/scenario-deprecated-status-validate.sh
+++ b/tests/scenario-deprecated-status-validate.sh
@@ -363,9 +363,9 @@ else
     fail "well-formed status:DEPRECATED spec validates clean" "rc=$rc; out=$out"
 fi
 
-# ── Test 13: status:DEPRECATED + state:INVALIDATED (terminal) → pass ────
-# In the terminal phase, the required fields are not re-checked (they
-# were enforced earlier). Spec just needs to be otherwise valid.
+# ── Test 13: state:INVALIDATED + displaced_by WITHOUT audit-trail → fail
+# (audit-trail-before-deletion contract: reproducer + KB article required
+#  when invalidating a spec that had a successor)
 setup_project "$PROJECT"
 write_spec "$PROJECT" '{
   "id": "example.under-test",
@@ -376,12 +376,156 @@ write_spec "$PROJECT" '{
   "displaced_by": ["example.successor"],
   "displacement_reason": "retired after migration"
 }'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "reproducer frontmatter"; then
+    pass "INVALIDATED+displaced_by without reproducer is flagged"
+else
+    fail "INVALIDATED+displaced_by without reproducer is flagged" "$out"
+fi
+if echo "$out" | grep -q "missing KB archaeology article"; then
+    pass "INVALIDATED+displaced_by without KB article is flagged"
+else
+    fail "INVALIDATED+displaced_by without KB article is flagged" "$out"
+fi
+
+# ── Test 14: state:INVALIDATED + displaced_by WITH audit-trail → pass
+setup_project "$PROJECT"
+# Create the reproducer file + KB article
+mkdir -p "$PROJECT/src/legacy"
+echo "// reproducer for legacy v5 format" > "$PROJECT/src/legacy/V5Synthesizer.java"
+mkdir -p "$PROJECT/.kb/_legacy"
+cat > "$PROJECT/.kb/_legacy/example.under-test.md" <<'EOF'
+---
+{
+  "type": "legacy-archaeology",
+  "spec_ref": "example.under-test",
+  "removed_in": "0.22.0",
+  "removed_at": "2026-05-17"
+}
+---
+
+# Legacy: example.under-test
+
+## What it was
+A test artifact.
+
+## Why it existed
+For testing the audit trail.
+
+## Why it was removed
+Superseded by example.successor.
+
+## How to reproduce
+Use src/legacy/V5Synthesizer.java.
+EOF
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "INVALIDATED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "retired after migration",
+  "reproducer": {
+    "type": "synthesizer",
+    "path": "src/legacy/V5Synthesizer.java",
+    "description": "v5 byte-stream synthesizer for forensic tests"
+  }
+}'
 rc=0
 out=$(run_validate "$PROJECT" 2>&1) || rc=$?
 if [[ $rc -eq 0 ]]; then
-    pass "status:DEPRECATED + state:INVALIDATED (terminal) validates clean"
+    pass "INVALIDATED+displaced_by with full audit-trail validates clean"
 else
-    fail "status:DEPRECATED + state:INVALIDATED (terminal) validates clean" "rc=$rc; out=$out"
+    fail "INVALIDATED+displaced_by with full audit-trail validates clean" "rc=$rc; out=$out"
+fi
+
+# ── Test 15: state:INVALIDATED WITHOUT displaced_by → no audit-trail required
+# (direct retirement of an unused contract)
+setup_project "$PROJECT"
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "ACTIVE",
+  "state": "INVALIDATED",
+  "domains": ["example"]
+}'
+rc=0
+out=$(run_validate "$PROJECT" 2>&1) || rc=$?
+if [[ $rc -eq 0 ]]; then
+    pass "INVALIDATED without displaced_by (direct retire) bypasses audit-trail gate"
+else
+    fail "INVALIDATED without displaced_by (direct retire) bypasses audit-trail gate" "rc=$rc; out=$out"
+fi
+
+# ── Test 16: reproducer path doesn't exist → fail
+setup_project "$PROJECT"
+mkdir -p "$PROJECT/.kb/_legacy"
+cat > "$PROJECT/.kb/_legacy/example.under-test.md" <<'EOF'
+---
+{
+  "type": "legacy-archaeology",
+  "spec_ref": "example.under-test",
+  "removed_in": "0.22.0",
+  "removed_at": "2026-05-17"
+}
+---
+
+# Legacy
+Body.
+EOF
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "INVALIDATED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "retired",
+  "reproducer": {
+    "type": "synthesizer",
+    "path": "src/legacy/DoesNotExist.java"
+  }
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "reproducer path does not exist"; then
+    pass "missing reproducer file is flagged"
+else
+    fail "missing reproducer file is flagged" "$out"
+fi
+
+# ── Test 17: KB article has wrong spec_ref → fail
+setup_project "$PROJECT"
+mkdir -p "$PROJECT/src/legacy" "$PROJECT/.kb/_legacy"
+echo "// reproducer" > "$PROJECT/src/legacy/V5.java"
+cat > "$PROJECT/.kb/_legacy/example.under-test.md" <<'EOF'
+---
+{
+  "type": "legacy-archaeology",
+  "spec_ref": "different.spec",
+  "removed_in": "0.22.0",
+  "removed_at": "2026-05-17"
+}
+---
+
+# Legacy
+Body.
+EOF
+write_spec "$PROJECT" '{
+  "id": "example.under-test",
+  "version": 1,
+  "status": "DEPRECATED",
+  "state": "INVALIDATED",
+  "domains": ["example"],
+  "displaced_by": ["example.successor"],
+  "displacement_reason": "retired",
+  "reproducer": {"type": "synthesizer", "path": "src/legacy/V5.java"}
+}'
+out=$(run_validate "$PROJECT" || true)
+if echo "$out" | grep -q "spec_ref.*does not match"; then
+    pass "KB article wrong spec_ref is flagged"
+else
+    fail "KB article wrong spec_ref is flagged" "$out"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the DEPRECATED-state design (approved at PR #106 rev 2; refined to rev 3 during scoping) — pre-release projects can now use `status: DEPRECATED` as a substitute for the classical SemVer deprecation cycle without losing audit-trail discipline.

**Key refinement found during scoping:** vallorcine already has a two-field model (`state` for verification, `status` for lifecycle), and `DEPRECATED` is already a value in the `status` enum. The natural fit is to legitimize the `(state=APPROVED, status=DEPRECATED)` combination — not to introduce a parallel state value. The mental state machine `DRAFT → APPROVED → DEPRECATED → INVALIDATED` is now expressed via the `(state, status)` pair.

## What changed

### Validator extensions (`scripts/spec-validate.sh`)
- **Check 7f** — `status: DEPRECATED` requires non-empty `displaced_by` (each target must be `state: APPROVED` and not itself `status: DEPRECATED`), `displacement_reason`, `removal_scheduled_in` (well-formed semver, > current VERSION), `deprecation_date` (ISO).
- **Check 7g** — `status: DEPRECATED` on a `state: DRAFT` spec is refused.
- **Check 7h** — audit-trail-before-deletion gate: `state: INVALIDATED` + non-empty `displaced_by` requires `displacement_reason` + `reproducer` frontmatter (with path that exists) + KB archaeology article at `.kb/_legacy/<spec-id>.md`.
- **Check 7i** — loose code-marker check: emits WARNING when `@spec`-annotated source files don't contain a `deprecat*` substring. Catches Java/Rust/Python/Go/TS conventions cheaply.

### Resolver tier escalation (`scripts/work-lib.sh`)
`work_check_spec_dep` now emits four-tier deprecation messages on stderr when a resolved spec has `status: DEPRECATED`:
- **Tier 0 SILENT** — `APPROVED + ACTIVE/STABLE` (no deprecation)
- **Tier 1 ADVISORY** — `DEPRECATED`, removal far away
- **Tier 2 WARNING** — within 1 minor of removal OR `displaced_by` not APPROVED
- **Tier 3 ERROR** — current VERSION >= removal_scheduled_in (overdue)

All tiers leave the dep **SATISFIED** (rc=0). The resolver never blocks in-flight work on deprecation alone — warnings raise awareness.

### Kit-level rule (`rules/deprecation-discipline.md`)
Always-loaded. Covers the (state, status) model, required fields, resolver tiers, audit-trail-before-deletion contract, code-marker convention, allowed/disallowed transitions, workflow steps, and the no-rescind rationale.

### Tests
- `tests/scenario-deprecated-status-validate.sh` — 18 validator checks (all four new checks + edge cases)
- `tests/scenario-deprecated-resolver.sh` — 8 resolver tier checks
- All existing tests still pass (74 + 41 + 18 + 24 + 18 + 8 = **183 checks green**)

## Out of scope for v0.23.0

- **Helper commands `/spec-deprecate` and `/spec-invalidate`** — queued for v0.23.1. The validator already enforces the discipline mechanically; helpers are friction-reducers, not safety mechanisms. Shipping the load-bearing part first lets jlsm adopt; helpers follow.
- **Per-language strict code-marker patterns** — the v1 loose `deprecat*` substring check catches the 5 common languages cheaply. Per-language patterns with `.feature/project-config.md` declarations are a future enhancement when real cases emerge.
- **`.kb/_legacy/` path override** — v1 uses the default path; project-config override queued.

## Test plan

- [x] `bash tests/scenario-deprecated-status-validate.sh` — 18/18 pass
- [x] `bash tests/scenario-deprecated-resolver.sh` — 8/8 pass
- [x] `bash tests/test-install.sh` — 74/74 pass (no regressions)
- [x] `bash tests/test-completeness-contract.sh` — 41/41 pass (no regressions)
- [x] `bash tests/scenario-validate-subagent-return.sh` — 18/18 pass (no regressions)
- [x] `bash tests/test-central-invariant-gate.sh` — 24/24 pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)