### PR TITLE
feat: closure proof + test-replacement + structured-return contracts (v0.24.0)

### DIFF
--- a/agents/code-writer-agent.md
+++ b/agents/code-writer-agent.md
@@ -23,7 +23,17 @@ You do not optimise. You do not refactor. Minimum correct implementation only.
 - Never modify test files — tests are the specification
 - If a test is impossible given work plan constraints: escalate (do not work around)
   Update status.md substage → escalated-to-test-writer before stopping
+- If you observe a test that codifies a BUG as the contract (the test passes
+  BECAUSE the buggy behavior is what it asserts — common after a Breaker round),
+  escalate to Test Writer per `rules/completeness-contract.md` §7. Do NOT work
+  around the bug to make the broken test pass. Do NOT preserve the bug. The
+  Test Writer deletes-and-replaces; Code Writer flags-and-stops.
 - Append to cycle-log.md and update status.md after completing
+- Before marking a construct COMPLETE: demonstrate the test catches the
+  failure mode it's meant to catch via revert-test-restore — revert your
+  fix locally, run the test, paste the failure into cycle-log.md, restore.
+  Per `rules/completeness-contract.md` §1. "Test passes" alone is not
+  closure; many vacuous tests pass even when the fix is absent.
 
 ## Fix-forward rule
 When fixing a bug (from aTDD, escalation, or test failure), check your code for

--- a/agents/refactor-agent.md
+++ b/agents/refactor-agent.md
@@ -23,11 +23,25 @@ counterproductive.
 - Run the full test suite before touching anything — if tests are failing, stop
 - Run tests after every change — never leave tests failing
 - Never change observable behaviour — internals only
-- Never modify test files
+- Never modify test files for normal refactoring (the existing rule)
+- **Exception per `rules/completeness-contract.md` §7:** if you encounter a
+  test that asserts the *pre-refactor internal structure* rather than
+  *observable behavior* (e.g., "method X calls method Y exactly once" when
+  the post-refactor design splits Y across two methods), DELETE the
+  structure-locking test and write a behavioral test that asserts the
+  observable outcome. Log the deletion + replacement test name in
+  cycle-log.md. This is not a violation of "never modify tests" — it's the
+  contract's bug-codifying-test removal rule applied to the refactor case
+  (where the bug is the structural over-specification).
 - Update status.md substage as you move through the review checklist (crash safety)
 - Cycle 3: warn. Cycle 5: hard stop, request explicit approval. Cycle 6+: requires approval.
 - When missing tests found: update status.md substage → escalated-missing-tests,
   append to cycle-log.md, report to Test Writer, stop immediately
+- **Closure proof for behavioral refactors:** if a refactor changes observable
+  behavior even slightly, demonstrate via revert-test-restore per
+  `rules/completeness-contract.md` §1 (revert the refactor, run tests, paste
+  failure into cycle-log.md, restore). Pure structural / rename / formatting
+  refactors with zero behavioral delta are exempt — no test could have failed.
 
 ## Production safety checks
 During the security review (2g), also verify:

--- a/prompts/audit/prove-fix.md
+++ b/prompts/audit/prove-fix.md
@@ -411,6 +411,46 @@ FIX_IMPOSSIBLE with:
 - **Cannot read Suspect's analysis reasoning** — the finding description
   and source code are sufficient.
 
+## Strong-test guidance (avoid wrong-property traps)
+
+Per `rules/completeness-contract.md` §1, a test must assert the property
+the FIX enforces — not a weaker proxy. Common wrong-property traps:
+
+- **Round-trip through API trap.** A test that writes and reads back via
+  the public API passes even if your fix is absent, because the read path
+  inverts whatever the write path did. If the finding is "encryption
+  advertised but absent," the test must search the raw file bytes for the
+  sentinel and assert ABSENCE — not round-trip and assert equality.
+- **Mocked-dependency trap.** A test that mocks the dependency you fixed
+  passes against the mock, not the production behavior. Route through the
+  live dependency or use a reflective tripwire to assert the production
+  path constructs the fixed class.
+- **Equivalence-with-legacy trap.** A test that asserts the new path
+  produces the same output as the legacy path passes vacuously if both
+  paths route through the same legacy code. Add a reflective assertion
+  that the production code path actually instantiates the new class.
+
+If the finding description mentions one of these patterns, your Phase 1
+test MUST address that specific trap. Generic "strong-property test"
+guidance is not enough — the trap must be named and avoided.
+
+## Closure proof (Phase 2 completion)
+
+Before marking CONFIRMED_AND_FIXED, demonstrate the test catches the
+failure mode it's meant to catch (per `rules/completeness-contract.md` §1):
+
+1. Confirm the fix is in the diff (`git diff` shows the change).
+2. Run the new test → it passes.
+3. Temporarily revert the fix (`git stash` or local edit).
+4. Re-run the test → it MUST fail. Paste the failure output into your
+   return's "Closure proof" section.
+5. Restore the fix (`git stash pop` or revert the local edit).
+6. Re-run the test → it passes again.
+
+If step 4 doesn't fail, your test is vacuous. Strengthen the assertion
+before claiming CONFIRMED_AND_FIXED. "Looks right" is not closure;
+revert-test-restore IS closure.
+
 ## Output
 
 Write the output file to the path the orchestrator specified:
@@ -432,7 +472,17 @@ Write the output file to the path the orchestrator specified:
 ### Phase 1: Verify (skipped if Phase 0 = ALREADY_FIXED)
 - **Test method:** <method name> (or "removed" if impossible, or "skipped" if Phase 0)
 - **Test class:** <path to test class>
+- **Wrong-property trap addressed:** <named trap from "Strong-test guidance" section, or "n/a" if finding is not vulnerable to a known trap>
 - **Result:** <CONFIRMED | IMPOSSIBLE | SKIPPED>
+
+### Closure proof (CONFIRMED_AND_FIXED only)
+- **Reverted fix command:** <e.g., `git stash` or specific line revert>
+- **Test failure output without fix:** <one-line failure or "test passed without fix — INVALID, vacuous test">
+- **Restored fix command:** <e.g., `git stash pop`>
+- **Test pass output with fix:** <one-line confirmation>
+
+If the test passed without the fix, the result is NOT CONFIRMED_AND_FIXED.
+Strengthen the test and re-attempt the proof.
 - **Detail:** <what happened — test fails because X>
 
 ### Phase 2: Fix (if Phase 1 confirmed)

--- a/rules/completeness-contract.md
+++ b/rules/completeness-contract.md
@@ -36,16 +36,34 @@ When you genuinely cannot complete assigned scope, escalate via AskUserQuestion
 with this shape:
 
 ```
-I cannot do X because <concrete reason>.
+What is wired:
+  <specific file:line citations of the state that IS working>
 
-Proof you can validate:
-  <file:line evidence, failing command output, missing type, broken dep, etc.>
+What is NOT wired:
+  <specific file:line citations of the gap — what's missing or broken>
 
-To proceed, you need to:
-  <specific user action — confirm scope, fix upstream, approve workaround>
+Why escalating rather than fixing:
+  <the concrete blocker — the cost of picking blindly, the design ambiguity,
+   the dependency that doesn't exist yet, the policy decision required>
+
+Options (with cons, not just pros):
+  1. <option A> — <what's good> — <what's bad / what it costs>
+  2. <option B> — <what's good> — <what's bad / what it costs>
+  3. <option C if any>
+
+What I am NOT doing without approval:
+  <the specific change you'd make if you had carte blanche>
+
+What I AM doing:
+  <the bounded work you're committing to in the meantime, if any>
 ```
 
 Then **wait** for the user's decision. Do not mark COMPLETE.
+
+The "What I am NOT doing" and "What I AM doing" lines are load-bearing —
+they prevent the silent-deferral failure mode where the agent says
+"escalating" but actually ships partial work and labels the rest as
+follow-up.
 
 The proof must be user-checkable:
 
@@ -62,19 +80,34 @@ have authority for judgment calls about scope.
 
 ## Specific applications
 
-The authority rule implies six concrete contracts. Each catches a failure
+The authority rule implies eight concrete contracts. Each catches a failure
 mode the kit has seen repeatedly:
 
 ### 1. Verification contract
 
-Before claiming work COMPLETE, articulate the test that would FAIL if you
-took the path of least resistance — vacuous equivalence, mocked path,
-isolated codec, fallthrough to legacy code. If your tests do not cover
-that scenario, your tests are insufficient.
-
 A test passing is not evidence the strong property holds. Two paths
 producing identical output is a true assertion that proves nothing if
 both paths route through the same legacy code.
+
+Before claiming work COMPLETE, you must DEMONSTRATE (not just articulate)
+that your tests catch the failure mode they're meant to catch:
+
+1. **The fix is in the diff** — verifiable by `git diff`.
+2. **A test asserts the actual property** at byte level, via reflective
+   tripwire, via production-path assertion — not via round-trip behavior
+   that the read path inverts.
+3. **You SHOW why the test would fail without the fix.** Revert the fix
+   locally (e.g., `git stash`), rerun the test, paste the failure into
+   your return, then restore the fix (`git stash pop`).
+
+The third clause is load-bearing. Without it, weak tests pass trivially
+even when the fix is absent. With it, you have to either (a) write a
+test strong enough to fail without the fix, or (b) discover your test
+isn't strong enough and rewrite it.
+
+"Looks right" is not closure. "I added a test" is not closure. The only
+closure is "the test failed without the fix and passed with it, and
+here is the evidence."
 
 ### 2. Production-path contract
 
@@ -126,6 +159,43 @@ acceptance criteria item-by-item. For each AC item, point to the
 specific code, test, or doc that satisfies it. If you cannot point to
 something for an AC item, you have not completed the work — escalate
 per the channel above or finish.
+
+### 7. Test-replacement contract
+
+If a test codifies a bug as the contract (the test passes BECAUSE the
+buggy behavior is what it asserts), DELETE the test and write a new
+one that asserts the FIXED behavior. Do not preserve "adversarial"
+tests that lock in broken behavior, do not work around them, do not
+add a new test alongside.
+
+Subagents default to additive change — adding tests, not deleting.
+That default ships bugs. Explicit permission to delete is required
+because the alternative (work around the bug-codifying test) is the
+path of least resistance.
+
+A test deletion in a return MUST be accompanied by the new test that
+replaces it, and the new test must satisfy the Verification contract
+(§1 — revert-test-restore proof).
+
+### 8. Structured-return contract
+
+Returns must contain verifiable artifacts, not paragraphs of intent.
+For each closed finding, the return must include:
+
+- The fix's file:line citation (so the orchestrator can re-read it)
+- The asserting test's name + file:line
+- The revert-test-restore evidence from §1
+- For deleted tests (§7): the deleted test's name + the replacement test's name
+
+For escalated findings, the return must use the escalation channel
+template (see below) — not a `TODO`, not a "follow-up note", not a
+"will address later" sentence.
+
+Paragraphs of intent ("I cleaned this up", "I made it more robust") are
+not artifacts. Without specific items requested, returns drift into
+prose. The orchestrator's validator catches some of this (trigger phrase
+detection); the structured-return contract catches the rest by requiring
+verifiable references.
 
 ## How dispatch uses this rule
 

--- a/skills/feature-implement/SKILL.md
+++ b/skills/feature-implement/SKILL.md
@@ -280,6 +280,34 @@ For each construct:
 
 If a test fails unexpectedly after implementation: see Escalation Protocol.
 
+**Closure proof (MANDATORY per `rules/completeness-contract.md` §1).**
+Before marking a construct's implementation COMPLETE (Step 2.7 status
+update), demonstrate the test catches the failure mode it's meant to
+catch. Specifically:
+
+1. The fix is in the diff (verifiable via `git diff`).
+2. A test asserts the actual property — not via round-trip behavior
+   that the read path inverts. At byte level / via reflective
+   tripwire / via production-path assertion through the public API.
+3. **Revert the fix locally, run the test, paste the failure output
+   into cycle-log.md, restore the fix.** This proves the test would
+   actually fail without your implementation. "Test passes" alone is
+   insufficient — many vacuous tests pass even when the fix is absent.
+
+If reverting is impractical (e.g., the fix is structural, deleting a
+class), satisfy the spirit by writing a test that exercises the
+production code path end-to-end through the public API and articulating
+in cycle-log.md the specific wrong-property trap your test avoids.
+
+**Test replacement (`rules/completeness-contract.md` §7).** If a test
+codifies a bug as the contract — it passes BECAUSE the buggy behavior
+is what it asserts — DELETE the test and write a new one asserting the
+fixed behavior. Do not preserve the bug-codifying test, do not work
+around it, do not add the new test alongside. Subagent default is
+additive change; the explicit permission to delete is in the contract.
+Test deletions logged in cycle-log.md alongside the replacement test
+name.
+
 **Implementation principles:**
 - Minimum correct implementation — no gold-plating
 - Follow project-config.md conventions exactly
@@ -473,10 +501,22 @@ Write `.feature/<slug>/implement-summary.md` (or append cycle section):
 
 ### Notes
 - <any escalations, workarounds, or design choices made during implementation>
+
+### Closure proof (per construct)
+| Construct | Test (file:line) | Revert-test-restore outcome |
+|-----------|------------------|------------------------------|
+| <name>    | <path:line>      | "test failed at <assertion>" / "n/a — structural" |
+
+### Test replacements (if any)
+| Deleted test | Why bug-codifying | Replacement test (file:line) |
+|--------------|---------------------|-------------------------------|
+| <name>       | <one-line reason>   | <name@path:line>             |
 ```
 
 This summary is consumed by `/feature-refactor` — it avoids reloading all
-implementation and test files from scratch.
+implementation and test files from scratch. The closure-proof and
+test-replacement tables make `rules/completeness-contract.md` §1 and §7
+auditable per-construct rather than per-cycle.
 
 If work units are defined:
 - Mark the active unit as `complete` in the Work Units table in status.md

--- a/skills/feature-refactor/SKILL.md
+++ b/skills/feature-refactor/SKILL.md
@@ -186,6 +186,25 @@ Run /feature-implement to restore a passing state first."
 
 Update status.md substage as each item begins so a crash is resumable.
 
+**Refactor is a high-over-claim surface** — "I cleaned this up" with no
+behavioral test is the canonical refactor false-COMPLETE. Two contract
+rules apply with extra weight:
+
+- **Verification (`rules/completeness-contract.md` §1).** If a refactor
+  changes observable behavior even slightly, demonstrate the new
+  behavior via revert-test-restore: revert the refactor, run the test
+  suite, paste the failure into cycle-log.md, restore. Pure rename /
+  formatting / structural refactors with no behavioral delta are
+  exempt from the revert proof (no behavior changed → no test could
+  have failed).
+
+- **Test replacement (`rules/completeness-contract.md` §7).** If you
+  see a structure-locking test that asserts the *pre-refactor internal structure*
+  rather than the *observable behavior*, DELETE it and write a behavioral
+  test in its place. Do not preserve tests that lock in the pre-refactor
+  shape — they'll false-fail on the next refactor and obscure real
+  regressions. Log deletions + replacements in cycle-log.md.
+
 ### 2a — Coding standards
 `status.md substage → "refactor: coding-standards"`
 `Display: ── Coding standards ───────────────────────`

--- a/tests/test-completeness-contract.sh
+++ b/tests/test-completeness-contract.sh
@@ -85,15 +85,29 @@ else
     fail "rules/completeness-contract.md exists" "file not found"
 fi
 
-# ── Test 4: rule file contains the six contracts ──────────────────────
+# ── Test 4: rule file contains the eight contracts (v0.24.0 added §7, §8) ──
 if [[ -f "$rule_path" ]]; then
-    for contract in "Verification contract" "Production-path contract" "Measurement contract" "Annotation contract" "Quality-bar contract" "Scope-reconciliation contract"; do
+    for contract in "Verification contract" "Production-path contract" "Measurement contract" "Annotation contract" "Quality-bar contract" "Scope-reconciliation contract" "Test-replacement contract" "Structured-return contract"; do
         if grep -q "$contract" "$rule_path"; then
             pass "rule file contains '$contract'"
         else
             fail "rule file contains '$contract'" "missing"
         fi
     done
+
+    # v0.24.0 — Verification contract requires revert-test-restore closure proof
+    if grep -q "revert-test-restore\|Revert the fix locally" "$rule_path"; then
+        pass "Verification contract requires revert-test-restore closure proof"
+    else
+        fail "Verification contract requires revert-test-restore closure proof" "missing"
+    fi
+
+    # v0.24.0 — Escalation channel has "What I am NOT doing" + "What I AM doing"
+    if grep -q "What I am NOT doing" "$rule_path" && grep -q "What I AM doing" "$rule_path"; then
+        pass "Escalation channel template has NOT-doing/AM-doing clauses"
+    else
+        fail "Escalation channel template has NOT-doing/AM-doing clauses" "missing"
+    fi
 fi
 
 # ── Test 5: rule listed in MANIFEST ───────────────────────────────────
@@ -181,6 +195,89 @@ if [[ -f "$sv_skill" ]]; then
         pass "spec-verify has RETIRE/REMOVE enforcement guidance"
     else
         fail "spec-verify has RETIRE/REMOVE enforcement guidance" "not found"
+    fi
+fi
+
+# ── Test 11 (v0.24.0): feature-implement Step 2 enforces closure proof ────
+fi_skill="$REPO_ROOT/skills/feature-implement/SKILL.md"
+if [[ -f "$fi_skill" ]]; then
+    if grep -q "Closure proof (MANDATORY" "$fi_skill"; then
+        pass "feature-implement Step 2 has Closure proof MANDATORY section"
+    else
+        fail "feature-implement Step 2 has Closure proof MANDATORY section" "missing"
+    fi
+    if grep -q "Revert the fix locally" "$fi_skill"; then
+        pass "feature-implement requires revert-test-restore demonstration"
+    else
+        fail "feature-implement requires revert-test-restore demonstration" "missing"
+    fi
+    if grep -q "Test replacement" "$fi_skill"; then
+        pass "feature-implement references Test replacement contract §7"
+    else
+        fail "feature-implement references Test replacement contract §7" "missing"
+    fi
+fi
+
+# ── Test 12 (v0.24.0): feature-refactor §1/§7 enforcement ─────────────
+fr_skill="$REPO_ROOT/skills/feature-refactor/SKILL.md"
+if [[ -f "$fr_skill" ]]; then
+    if grep -q "high-over-claim surface" "$fr_skill"; then
+        pass "feature-refactor names itself as high-over-claim surface"
+    else
+        fail "feature-refactor names itself as high-over-claim surface" "missing"
+    fi
+    if grep -q "revert-test-restore" "$fr_skill"; then
+        pass "feature-refactor references revert-test-restore for behavioral refactors"
+    else
+        fail "feature-refactor references revert-test-restore for behavioral refactors" "missing"
+    fi
+    if grep -q "structure-locking test\|pre-refactor internal structure" "$fr_skill"; then
+        pass "feature-refactor permits §7 deletion of structure-locking tests"
+    else
+        fail "feature-refactor permits §7 deletion of structure-locking tests" "missing"
+    fi
+fi
+
+# ── Test 13 (v0.24.0): code-writer-agent + refactor-agent reference §1/§7 ──
+cw_agent="$REPO_ROOT/agents/code-writer-agent.md"
+if [[ -f "$cw_agent" ]]; then
+    if grep -q "revert-test-restore" "$cw_agent"; then
+        pass "code-writer-agent enforces revert-test-restore"
+    else
+        fail "code-writer-agent enforces revert-test-restore" "missing"
+    fi
+    if grep -q "completeness-contract.md.*§7\|§7\b" "$cw_agent"; then
+        pass "code-writer-agent flags-and-stops on bug-codifying tests (§7)"
+    else
+        fail "code-writer-agent flags-and-stops on bug-codifying tests (§7)" "missing"
+    fi
+fi
+ra_agent="$REPO_ROOT/agents/refactor-agent.md"
+if [[ -f "$ra_agent" ]]; then
+    if grep -q "structure-locking\|pre-refactor internal structure" "$ra_agent"; then
+        pass "refactor-agent permits §7 deletion of structure-locking tests"
+    else
+        fail "refactor-agent permits §7 deletion of structure-locking tests" "missing"
+    fi
+fi
+
+# ── Test 14 (v0.24.0): audit prove-fix has strong-test guidance + closure proof ──
+pf_prompt="$REPO_ROOT/prompts/audit/prove-fix.md"
+if [[ -f "$pf_prompt" ]]; then
+    if grep -q "wrong-property trap" "$pf_prompt"; then
+        pass "prove-fix prompt has wrong-property trap guidance"
+    else
+        fail "prove-fix prompt has wrong-property trap guidance" "missing"
+    fi
+    if grep -q "Round-trip through API trap" "$pf_prompt"; then
+        pass "prove-fix prompt names the round-trip-API trap"
+    else
+        fail "prove-fix prompt names the round-trip-API trap" "missing"
+    fi
+    if grep -q "Closure proof (Phase 2 completion)" "$pf_prompt"; then
+        pass "prove-fix prompt requires Closure proof for Phase 2"
+    else
+        fail "prove-fix prompt requires Closure proof for Phase 2" "missing"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Lifts 4 high-value subagent dispatch patterns from jlsm's post-PR-127 prompt-engineering findings (3 subagents over-claimed COMPLETE while leaving CRITICAL bugs unfixed; the 4th dispatched with these patterns produced an honest report). The patterns target 3 failure modes the v0.21.0 contract didn't catch:

1. **"Tests pass" used as closure even when the test is vacuous** — Pattern 2 fix: revert-test-restore as the closure proof
2. **Bug-codifying tests preserved instead of replaced** (additive change default) — Pattern 5 fix: explicit DELETE permission
3. **Returns as paragraphs-of-intent instead of verifiable artifacts** — Pattern 7 fix: structured return with file:line citations

Plus Pattern 3 sharpened: escalation channel template gains "What I am NOT doing without approval" / "What I AM doing" clauses to kill the silent-deferral failure mode.

## What changed

### Contract (`rules/completeness-contract.md`)

- **§1 Verification — sharpened.** Was "articulate the test that would FAIL"; now requires DEMONSTRATED closure via revert-test-restore (revert fix, run test, paste failure into return, restore fix). The third clause is load-bearing — without it weak tests pass trivially.
- **§7 Test-replacement (NEW).** Explicit permission to DELETE bug-codifying tests. Deletions must be accompanied by the replacement test (which satisfies §1).
- **§8 Structured-return (NEW).** Returns must contain verifiable artifacts (file:line, test names, revert-test-restore output), not paragraphs of intent.
- **Escalation channel template sharpened** with "What I am NOT doing without approval" + "What I AM doing".

### Skill / agent / prompt updates

- `skills/feature-implement` Step 2: closure-proof MANDATORY block; cycle summary gains Closure-proof + Test-replacement tables.
- `skills/feature-refactor` Step 2 preamble: refactor named as "high over-claim surface"; §1 enforced for behavioral refactors; §7 permits deletion of structure-locking tests.
- `agents/code-writer-agent`: revert-test-restore required; flags-and-stops on bug-codifying tests (Code Writer flags, Test Writer deletes — preserves existing "never modify tests" rule for Code Writer's normal cycle).
- `agents/refactor-agent`: explicit §7 exception for structure-locking tests; closure proof for behavioral refactors.
- `prompts/audit/prove-fix`: Strong-test guidance names 3 wrong-property traps (round-trip-API / mocked-dependency / equivalence-with-legacy). New Closure proof Phase 2 section requires revert-test-restore.

## Patterns NOT lifted (with reasoning)

- **Pattern 1 (sequence position "you are the 4th")** — requires orchestrator plumbing to track failed dispatch counts; deferred. Also edges into manipulative framing.
- **Pattern 4 (per-finding wrong-property guidance)** — can't generalize into static prompts (per-finding knowledge required). Lifted as principle into audit prove-fix only.
- **Pattern 6 (per-finding escalation permission)** — per-finding orchestrator decision; documented in contract as principle, not mechanically encoded.
- **Pattern 8 (embed user memory verbatim)** — partially solved (kit `rules/*.md` are always-loaded for subagents); project-local memory covered by `designs/memory-to-kb-migration.md`.

## Test plan

- [x] `bash tests/test-completeness-contract.sh` — 57/57 pass (was 41; +16 new)
- [x] `bash tests/test-install.sh` — 74/74 pass (no regressions)
- [x] `bash tests/scenario-validate-subagent-return.sh` — 18/18 pass (no regressions)
- [x] `bash tests/test-central-invariant-gate.sh` — 24/24 pass (no regressions)
- [x] `bash tests/scenario-deprecated-status-validate.sh` — 22/22 pass (no regressions)
- [x] `bash tests/scenario-deprecated-resolver.sh` — 12/12 pass (no regressions)
- [x] Full kit: 207 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)